### PR TITLE
headerssync: Add headers cache

### DIFF
--- a/src/common/system.cpp
+++ b/src/common/system.cpp
@@ -11,11 +11,21 @@
 #include <util/string.h>
 #include <util/time.h>
 
-#ifndef WIN32
-#include <sys/stat.h>
-#else
+#ifdef WIN32
 #include <compat/compat.h>
 #include <codecvt>
+#include <windows.h>
+#include <psapi.h>
+#else
+#include <sys/stat.h>
+#if defined(__linux__)
+#include <sys/sysinfo.h>
+#elif defined(__APPLE__)
+#include <mach/mach.h>
+#include <mach/mach_vm.h>
+#elif defined(HAVE_SYSCTL)
+#include <sys/sysctl.h>
+#endif
 #endif
 
 #ifdef HAVE_MALLOPT_ARENA_MAX
@@ -109,4 +119,53 @@ int GetNumCores()
 int64_t GetStartupTime()
 {
     return nStartupTime;
+}
+
+std::optional<size_t> GetFreeRAM()
+{
+#if defined(__linux__)
+    struct sysinfo info;
+    if (sysinfo(&info) != EXIT_SUCCESS) {
+        return std::nullopt;
+    }
+
+    return info.freeram;
+#elif defined(__APPLE__)
+    mach_port_t host_port = mach_host_self();
+    mach_msg_type_number_t count = HOST_VM_INFO64_COUNT;
+    vm_statistics64_data_t vm;
+
+    vm_size_t page_size = 0;
+    if (host_page_size(host_port, &page_size) != KERN_SUCCESS) {
+        return std::nullopt;
+    }
+
+    if (host_statistics64(host_port, HOST_VM_INFO, (host_info64_t)&vm, &count) != KERN_SUCCESS) {
+        return std::nullopt;
+    }
+
+    return vm.free_count * page_size;
+#elif defined(WIN32)
+    PERFORMANCE_INFORMATION info;
+    if (!GetPerformanceInfo(&info, sizeof(info))) {
+        return std::nullopt;
+    }
+
+    return info.PhysicalAvailable * info.PageSize;
+#elif defined(HAVE_SYSCTL)
+#   if defined(CTL_VM)
+    const int mib[] = { CTL_VM, VM_STAT };
+    vm_stat vm;
+    size_t size = sizeof(vm);
+    if (sysctl(mib, sizeof(mib) / sizeof(*mib), &vm, &size, nullptr, 0) != EXIT_SUCCESS) {
+        return std::nullopt;
+    }
+
+    return (vm.v_free_count + vm.v_cache_count) * vm.v_page_size;
+#   else
+#       error "sysctl but CTL_VM not implemented for platform"
+#   endif
+#else
+#   error "Unimplemented platform"
+#endif
 }

--- a/src/common/system.h
+++ b/src/common/system.h
@@ -9,6 +9,7 @@
 #include <bitcoin-build-config.h> // IWYU pragma: keep
 
 #include <cstdint>
+#include <optional>
 #include <string>
 
 // Application startup time (used for uptime calculation)
@@ -28,5 +29,7 @@ void runCommand(const std::string& strCommand);
  * @note This does count virtual cores, such as those provided by HyperThreading.
  */
 int GetNumCores();
+
+std::optional<size_t> GetFreeRAM();
 
 #endif // BITCOIN_COMMON_SYSTEM_H

--- a/src/headerssync.cpp
+++ b/src/headerssync.cpp
@@ -83,10 +83,12 @@ HeadersSyncState::ProcessingResult HeadersSyncState::ProcessNextHeaders(const
         // threshold (at which point m_download_state is updated to REDOWNLOAD).
         ret.success = ValidateAndStoreHeadersCommitments(received_headers);
         if (ret.success) {
-            if (full_headers_message || m_download_state == State::REDOWNLOAD) {
-                // A full headers message means the peer may have more to give us;
-                // also if we just switched to REDOWNLOAD then we need to re-request
+            if (m_download_state == State::REDOWNLOAD) {
+                // If we just switched to REDOWNLOAD then we need to re-request
                 // headers from the beginning.
+                ret.request_more = true;
+            } else if (full_headers_message) {
+                // A full headers message means the peer may have more to give us.
                 ret.request_more = true;
             } else {
                 Assume(m_download_state == State::PRESYNC);

--- a/src/headerssync.cpp
+++ b/src/headerssync.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 The Bitcoin Core developers
+// Copyright (c) 2022-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -29,9 +29,9 @@ HeadersSyncState::HeadersSyncState(NodeId id, const Consensus::Params& consensus
     m_id(id), m_consensus_params(consensus_params),
     m_chain_start(chain_start),
     m_minimum_required_work(minimum_required_work),
-    m_current_chain_work(chain_start->nChainWork),
-    m_last_header_received(m_chain_start->GetBlockHeader()),
-    m_current_height(chain_start->nHeight)
+    m_presync_chain_work(chain_start->nChainWork),
+    m_presync_last_header_received(m_chain_start->GetBlockHeader()),
+    m_presync_height(chain_start->nHeight)
 {
     // Estimate the number of blocks that could possibly exist on the peer's
     // chain *right now* using 6 blocks/second (fastest blockrate given the MTP
@@ -43,7 +43,7 @@ HeadersSyncState::HeadersSyncState(NodeId id, const Consensus::Params& consensus
     // could try again, if necessary, to sync a longer chain).
     m_max_commitments = 6*(Ticks<std::chrono::seconds>(NodeClock::now() - NodeSeconds{std::chrono::seconds{chain_start->GetMedianTimePast()}}) + MAX_FUTURE_BLOCK_TIME) / HEADER_COMMITMENT_PERIOD;
 
-    LogDebug(BCLog::NET, "Initial headers sync started with peer=%d: height=%i, max_commitments=%i, min_work=%s\n", m_id, m_current_height, m_max_commitments, m_minimum_required_work.ToString());
+    LogDebug(BCLog::NET, "Initial headers sync started with peer=%d: height=%i, max_commitments=%i, min_work=%s\n", m_id, m_presync_height, m_max_commitments, m_minimum_required_work.ToString());
 }
 
 /** Free any memory in use, and mark this object as no longer usable. This is
@@ -53,12 +53,12 @@ void HeadersSyncState::Finalize()
 {
     Assume(m_download_state != State::FINAL);
     ClearShrink(m_header_commitments);
-    m_last_header_received.SetNull();
+    m_presync_last_header_received.SetNull();
     ClearShrink(m_redownloaded_headers);
     m_redownload_buffer_last_hash.SetNull();
     m_redownload_buffer_first_prev_hash.SetNull();
     m_process_all_remaining_headers = false;
-    m_current_height = 0;
+    m_presync_height = 0;
 
     m_download_state = State::FINAL;
 }
@@ -93,7 +93,7 @@ HeadersSyncState::ProcessingResult HeadersSyncState::ProcessNextHeaders(const
                 // If we're in PRESYNC and we get a non-full headers
                 // message, then the peer's chain has ended and definitely doesn't
                 // have enough work, so we can stop our sync.
-                LogDebug(BCLog::NET, "Initial headers sync aborted with peer=%d: incomplete headers message at height=%i (presync phase)\n", m_id, m_current_height);
+                LogDebug(BCLog::NET, "Initial headers sync aborted with peer=%d: incomplete headers message at height=%i (presync phase)\n", m_id, m_presync_height);
             }
         }
     } else if (m_download_state == State::REDOWNLOAD) {
@@ -146,12 +146,12 @@ bool HeadersSyncState::ValidateAndStoreHeadersCommitments(const std::vector<CBlo
     Assume(m_download_state == State::PRESYNC);
     if (m_download_state != State::PRESYNC) return false;
 
-    if (headers[0].hashPrevBlock != m_last_header_received.GetHash()) {
+    if (headers[0].hashPrevBlock != m_presync_last_header_received.GetHash()) {
         // Somehow our peer gave us a header that doesn't connect.
         // This might be benign -- perhaps our peer reorged away from the chain
         // they were on. Give up on this sync for now (likely we will start a
         // new sync with a new starting point).
-        LogDebug(BCLog::NET, "Initial headers sync aborted with peer=%d: non-continuous headers at height=%i (presync phase)\n", m_id, m_current_height);
+        LogDebug(BCLog::NET, "Initial headers sync aborted with peer=%d: non-continuous headers at height=%i (presync phase)\n", m_id, m_presync_height);
         return false;
     }
 
@@ -163,14 +163,14 @@ bool HeadersSyncState::ValidateAndStoreHeadersCommitments(const std::vector<CBlo
         }
     }
 
-    if (m_current_chain_work >= m_minimum_required_work) {
+    if (m_presync_chain_work >= m_minimum_required_work) {
         m_redownloaded_headers.clear();
         m_redownload_buffer_last_height = m_chain_start->nHeight;
         m_redownload_buffer_first_prev_hash = m_chain_start->GetBlockHash();
         m_redownload_buffer_last_hash = m_chain_start->GetBlockHash();
         m_redownload_chain_work = m_chain_start->nChainWork;
         m_download_state = State::REDOWNLOAD;
-        LogDebug(BCLog::NET, "Initial headers sync transition with peer=%d: reached sufficient work at height=%i, redownloading from height=%i\n", m_id, m_current_height, m_redownload_buffer_last_height);
+        LogDebug(BCLog::NET, "Initial headers sync transition with peer=%d: reached sufficient work at height=%i, redownloading from height=%i\n", m_id, m_presync_height, m_redownload_buffer_last_height);
     }
     return true;
 }
@@ -180,7 +180,7 @@ bool HeadersSyncState::ValidateAndProcessSingleHeader(const CBlockHeader& curren
     Assume(m_download_state == State::PRESYNC);
     if (m_download_state != State::PRESYNC) return false;
 
-    int next_height = m_current_height + 1;
+    int next_height = m_presync_height + 1;
 
     // Verify that the difficulty isn't growing too fast; an adversary with
     // limited hashing capability has a greater chance of producing a high
@@ -188,7 +188,7 @@ bool HeadersSyncState::ValidateAndProcessSingleHeader(const CBlockHeader& curren
     // so don't let anyone give a chain that would violate the difficulty
     // adjustment maximum.
     if (!PermittedDifficultyTransition(m_consensus_params, next_height,
-                m_last_header_received.nBits, current.nBits)) {
+                m_presync_last_header_received.nBits, current.nBits)) {
         LogDebug(BCLog::NET, "Initial headers sync aborted with peer=%d: invalid difficulty transition at height=%i (presync phase)\n", m_id, next_height);
         return false;
     }
@@ -206,9 +206,9 @@ bool HeadersSyncState::ValidateAndProcessSingleHeader(const CBlockHeader& curren
         }
     }
 
-    m_current_chain_work += GetBlockProof(CBlockIndex(current));
-    m_last_header_received = current;
-    m_current_height = next_height;
+    m_presync_chain_work += GetBlockProof(CBlockIndex(current));
+    m_presync_last_header_received = current;
+    m_presync_height = next_height;
 
     return true;
 }
@@ -304,7 +304,7 @@ CBlockLocator HeadersSyncState::NextHeadersRequestLocator() const
 
     if (m_download_state == State::PRESYNC) {
         // During pre-synchronization, we continue from the last header received.
-        locator.push_back(m_last_header_received.GetHash());
+        locator.push_back(m_presync_last_header_received.GetHash());
     }
 
     if (m_download_state == State::REDOWNLOAD) {

--- a/src/headerssync.cpp
+++ b/src/headerssync.cpp
@@ -59,7 +59,8 @@ HeadersSyncState::HeadersSyncState(NodeId id, const Consensus::Params& consensus
     // exceeds this bound, because it's not possible for a consensus-valid
     // chain to be longer than this (at the current time -- in the future we
     // could try again, if necessary, to sync a longer chain).
-    m_max_commitments = 6*(Ticks<std::chrono::seconds>(NodeClock::now() - NodeSeconds{std::chrono::seconds{chain_start->GetMedianTimePast()}}) + MAX_FUTURE_BLOCK_TIME) / HEADER_COMMITMENT_PERIOD;
+    // Subtract cached headers as we don't redownload and verify commitments for them.
+    m_max_commitments = std::max<int64_t>(0, (6*(Ticks<std::chrono::seconds>(NodeClock::now() - NodeSeconds{std::chrono::seconds{chain_start->GetMedianTimePast()}}) + MAX_FUTURE_BLOCK_TIME)-m_headers_cache_max) / HEADER_COMMITMENT_PERIOD);
 
     // Pre-allocate a possibly large chunk of memory.
     m_headers_cache.reserve(m_headers_cache_max);
@@ -149,7 +150,7 @@ HeadersSyncState::ProcessingResult HeadersSyncState::ProcessNextHeaders(const
         // we'll return a batch of headers to the caller for processing.
         ret.success = true;
         for (const auto& hdr : received_headers) {
-            if (!ValidateAndStoreRedownloadedHeader(hdr)) {
+            if (!ValidateAndStoreRedownloadedHeader(hdr, /*from_cache=*/false)) {
                 // Something went wrong -- the peer gave us an unexpected chain.
                 // We could consider looking at the reason for failure and
                 // punishing the peer, but for now just give up on sync.
@@ -224,7 +225,7 @@ bool HeadersSyncState::ValidateAndStoreHeadersCommitments(const std::vector<CBlo
             uint256 prev_hash = m_chain_start->GetBlockHash();
             for (const auto& compressed_header : m_headers_cache) {
                 const CBlockHeader header = compressed_header.GetFullHeader(prev_hash);
-                if (!ValidateAndStoreRedownloadedHeader(header)) {
+                if (!ValidateAndStoreRedownloadedHeader(header, /*from_cache=*/true)) {
                     return false;
                 }
                 prev_hash = header.GetHash();
@@ -261,7 +262,10 @@ bool HeadersSyncState::ValidateAndProcessSingleHeader(const CBlockHeader& curren
         return false;
     }
 
-    if (next_height % HEADER_COMMITMENT_PERIOD == m_commit_offset) {
+    if (m_headers_cache.size() < m_headers_cache_max) {
+        // We do not redownload cached entries so we skip storing commitments for them.
+        m_headers_cache.emplace_back(current);
+    } else if (next_height % HEADER_COMMITMENT_PERIOD == m_commit_offset) {
         // Add a commitment.
         m_header_commitments.push_back(m_hasher(current.GetHash()) & 1);
         if (m_header_commitments.size() > m_max_commitments) {
@@ -278,14 +282,10 @@ bool HeadersSyncState::ValidateAndProcessSingleHeader(const CBlockHeader& curren
     m_presync_last_header_received = current;
     m_presync_height = next_height;
 
-    if (m_headers_cache.size() < m_headers_cache_max) {
-        m_headers_cache.emplace_back(current);
-    }
-
     return true;
 }
 
-bool HeadersSyncState::ValidateAndStoreRedownloadedHeader(const CBlockHeader& header)
+bool HeadersSyncState::ValidateAndStoreRedownloadedHeader(const CBlockHeader& header, bool from_cache)
 {
     Assume(m_download_state == State::REDOWNLOAD);
     if (m_download_state != State::REDOWNLOAD) return false;
@@ -307,8 +307,8 @@ bool HeadersSyncState::ValidateAndStoreRedownloadedHeader(const CBlockHeader& he
         previous_nBits = m_chain_start->nBits;
     }
 
-    if (!PermittedDifficultyTransition(m_consensus_params, next_height,
-                previous_nBits, header.nBits)) {
+    if (!from_cache && !PermittedDifficultyTransition(m_consensus_params, next_height,
+                                                      previous_nBits, header.nBits)) {
         LogDebug(BCLog::NET, "Initial headers sync aborted with peer=%d: invalid difficulty transition at height=%i (redownload phase)\n", m_id, next_height);
         return false;
     }
@@ -326,7 +326,7 @@ bool HeadersSyncState::ValidateAndStoreRedownloadedHeader(const CBlockHeader& he
     // it's possible our peer has extended its chain between our first sync and
     // our second, and we don't want to return failure after we've seen our
     // target blockhash just because we ran out of commitments.
-    if (!m_process_all_remaining_headers && next_height % HEADER_COMMITMENT_PERIOD == m_commit_offset) {
+    if (!m_process_all_remaining_headers && !from_cache && next_height % HEADER_COMMITMENT_PERIOD == m_commit_offset) {
         if (m_header_commitments.size() == 0) {
             LogDebug(BCLog::NET, "Initial headers sync aborted with peer=%d: commitment overrun at height=%i (redownload phase)\n", m_id, next_height);
             // Somehow our peer managed to feed us a different chain and

--- a/src/headerssync.cpp
+++ b/src/headerssync.cpp
@@ -3,11 +3,15 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <headerssync.h>
+
+#include <common/system.h>
 #include <logging.h>
 #include <pow.h>
 #include <util/check.h>
 #include <util/time.h>
 #include <util/vector.h>
+
+#include <algorithm>
 
 // The two constants below are computed using the simulation script in
 // contrib/devtools/headerssync-params.py.
@@ -24,14 +28,28 @@ constexpr size_t REDOWNLOAD_BUFFER_SIZE{14827}; // 14827/624 = ~23.8 commitments
 static_assert(sizeof(CompressedHeader) == 48);
 
 HeadersSyncState::HeadersSyncState(NodeId id, const Consensus::Params& consensus_params,
-        const CBlockIndex* chain_start, const arith_uint256& minimum_required_work) :
+        const CBlockIndex* chain_start, const arith_uint256& minimum_required_work,
+        const std::optional<size_t> cache_size) :
     m_commit_offset(FastRandomContext().randrange<unsigned>(HEADER_COMMITMENT_PERIOD)),
     m_id(id), m_consensus_params(consensus_params),
     m_chain_start(chain_start),
     m_minimum_required_work(minimum_required_work),
     m_presync_chain_work(chain_start->nChainWork),
     m_presync_last_header_received(m_chain_start->GetBlockHeader()),
-    m_presync_height(chain_start->nHeight)
+    m_presync_height(chain_start->nHeight),
+    m_headers_cache_max(cache_size ? *cache_size : std::min<size_t>(
+        // 1.1 - Account for 10% more blocks than expected.
+        1.1f * ((NodeClock::now() - NodeSeconds{std::chrono::seconds{chain_start->GetMedianTimePast()}}) / 10min),
+        std::max(
+            // Lower limit
+            REDOWNLOAD_BUFFER_SIZE,
+            // Upper limit
+            std::min<size_t>(
+                // Don't cache more than 30 years of ~10-minute blocks for now
+                6 * 24 * 365 * 30,
+                // We try to make sure not to use more than 10% of
+                // available RAM for the headers cache.
+                (GetFreeRAM().value_or(0) / 10) / sizeof(decltype(m_headers_cache)::value_type)))))
 {
     // Estimate the number of blocks that could possibly exist on the peer's
     // chain *right now* using 6 blocks/second (fastest blockrate given the MTP
@@ -43,7 +61,10 @@ HeadersSyncState::HeadersSyncState(NodeId id, const Consensus::Params& consensus
     // could try again, if necessary, to sync a longer chain).
     m_max_commitments = 6*(Ticks<std::chrono::seconds>(NodeClock::now() - NodeSeconds{std::chrono::seconds{chain_start->GetMedianTimePast()}}) + MAX_FUTURE_BLOCK_TIME) / HEADER_COMMITMENT_PERIOD;
 
-    LogDebug(BCLog::NET, "Initial headers sync started with peer=%d: height=%i, max_commitments=%i, min_work=%s\n", m_id, m_presync_height, m_max_commitments, m_minimum_required_work.ToString());
+    // Pre-allocate a possibly large chunk of memory.
+    m_headers_cache.reserve(m_headers_cache_max);
+
+    LogDebug(BCLog::NET, "Initial headers sync started with peer=%d: height=%i, max_commitments=%i, min_work=%s, cache=%d headers (%.1f MiB)", m_id, m_presync_height, m_max_commitments, m_minimum_required_work.ToString(), m_headers_cache_max, (m_headers_cache_max * sizeof(decltype(m_headers_cache)::value_type)) / (1024.0f * 1024.0f));
 }
 
 /** Free any memory in use, and mark this object as no longer usable. This is
@@ -54,6 +75,7 @@ void HeadersSyncState::Finalize()
     Assume(m_download_state != State::FINAL);
     ClearShrink(m_header_commitments);
     m_presync_last_header_received.SetNull();
+    std::vector<CompressedHeader>{}.swap(m_headers_cache);
     ClearShrink(m_redownloaded_headers);
     m_redownload_buffer_last_hash.SetNull();
     m_redownload_buffer_first_prev_hash.SetNull();
@@ -84,9 +106,31 @@ HeadersSyncState::ProcessingResult HeadersSyncState::ProcessNextHeaders(const
         ret.success = ValidateAndStoreHeadersCommitments(received_headers);
         if (ret.success) {
             if (m_download_state == State::REDOWNLOAD) {
-                // If we just switched to REDOWNLOAD then we need to re-request
-                // headers from the beginning.
-                ret.request_more = true;
+                if (m_presync_last_header_received.GetHash() == m_redownload_buffer_last_hash) {
+                    // If we already had a big enough m_headers_cache that it
+                    // was sufficient to reach m_minimum_required_work and
+                    // therefore we already filled the redownload buffer, then
+                    // we don't need to request more headers.
+                    // This will make us switch state again to FINAL at the end
+                    // of this function.
+                    Assume(m_presync_height <= static_cast<int64_t>(m_headers_cache_max));
+                    Assume(m_presync_chain_work >= m_minimum_required_work);
+                    ret.request_more = false;
+
+                    // Having already reached sufficient work implies we *need
+                    // to* return all remaining headers in
+                    // PopHeadersReadyForAcceptance() below before switching to
+                    // FINAL at the end of this function which will clear all
+                    // buffers.
+                    Assume(m_process_all_remaining_headers);
+                } else {
+                    // If we just switched to REDOWNLOAD and m_headers_cache was
+                    // insufficient to store all headers, we need to re-request
+                    // headers.
+                    ret.request_more = true;
+                }
+
+                ret.pow_validated_headers = PopHeadersReadyForAcceptance();
             } else if (full_headers_message) {
                 // A full headers message means the peer may have more to give us.
                 ret.request_more = true;
@@ -171,7 +215,29 @@ bool HeadersSyncState::ValidateAndStoreHeadersCommitments(const std::vector<CBlo
         m_redownload_buffer_first_prev_hash = m_chain_start->GetBlockHash();
         m_redownload_buffer_last_hash = m_chain_start->GetBlockHash();
         m_redownload_chain_work = m_chain_start->nChainWork;
+
+        // Need to switch state before reading from m_headers_cache since we are
+        // calling ValidateAndStoreRedownloadedHeader() which requires it.
         m_download_state = State::REDOWNLOAD;
+
+        if (!m_headers_cache.empty()) {
+            uint256 prev_hash = m_chain_start->GetBlockHash();
+            for (const auto& compressed_header : m_headers_cache) {
+                const CBlockHeader header = compressed_header.GetFullHeader(prev_hash);
+                if (!ValidateAndStoreRedownloadedHeader(header)) {
+                    return false;
+                }
+                prev_hash = header.GetHash();
+            }
+
+            // We could add logic here to see if m_headers_cache.back() exists
+            // within the headers parameter to this method, and call
+            // ValidateAndStoreRedownloadedHeader() on any that didn't fit in
+            // the cache. Avoided to rein in complexity.
+            LogDebug(BCLog::NET, "Populated %d headers from cache.", m_headers_cache.size());
+            m_headers_cache.clear();
+        }
+
         LogDebug(BCLog::NET, "Initial headers sync transition with peer=%d: reached sufficient work at height=%i, redownloading from height=%i\n", m_id, m_presync_height, m_redownload_buffer_last_height);
     }
     return true;
@@ -211,6 +277,10 @@ bool HeadersSyncState::ValidateAndProcessSingleHeader(const CBlockHeader& curren
     m_presync_chain_work += GetBlockProof(CBlockIndex(current));
     m_presync_last_header_received = current;
     m_presync_height = next_height;
+
+    if (m_headers_cache.size() < m_headers_cache_max) {
+        m_headers_cache.emplace_back(current);
+    }
 
     return true;
 }

--- a/src/headerssync.h
+++ b/src/headerssync.h
@@ -207,7 +207,7 @@ private:
 
     /** In REDOWNLOAD, check a header's commitment (if applicable) and add to
      * buffer for later processing */
-    bool ValidateAndStoreRedownloadedHeader(const CBlockHeader& header);
+    bool ValidateAndStoreRedownloadedHeader(const CBlockHeader& header, bool from_cache);
 
     /** Return a set of headers that satisfy our proof-of-work threshold */
     std::vector<CBlockHeader> PopHeadersReadyForAcceptance();

--- a/src/headerssync.h
+++ b/src/headerssync.h
@@ -15,6 +15,7 @@
 #include <util/hasher.h>
 
 #include <deque>
+#include <optional>
 #include <vector>
 
 // A compressed CBlockHeader, which leaves out the prevhash
@@ -40,7 +41,8 @@ struct CompressedHeader {
         nNonce = header.nNonce;
     }
 
-    CBlockHeader GetFullHeader(const uint256& hash_prev_block) {
+    CBlockHeader GetFullHeader(const uint256& hash_prev_block) const
+    {
         CBlockHeader ret;
         ret.nVersion = nVersion;
         ret.hashPrevBlock = hash_prev_block;
@@ -134,9 +136,12 @@ public:
      * consensus_params: parameters needed for difficulty adjustment validation
      * chain_start: best known fork point that the peer's headers branch from
      * minimum_required_work: amount of chain work required to accept the chain
+     * cache_size: Number of headers to cache in order to avoid re-downloading.
+     *             If unset it be configured depending on available RAM.
      */
     HeadersSyncState(NodeId id, const Consensus::Params& consensus_params,
-            const CBlockIndex* chain_start, const arith_uint256& minimum_required_work);
+            const CBlockIndex* chain_start, const arith_uint256& minimum_required_work,
+            std::optional<size_t> cache_size);
 
     /** Result data structure for ProcessNextHeaders. */
     struct ProcessingResult {
@@ -241,6 +246,11 @@ private:
 
     /** Height of m_presync_last_header_received */
     int64_t m_presync_height{0};
+
+    /** During phase 1 (PRESYNC), we cache received headers so we don't have to
+     *  re-download all of them in phase 2 (REDOWNLOAD). */
+    std::vector<CompressedHeader> m_headers_cache;
+    const size_t m_headers_cache_max;
 
     /** During phase 2 (REDOWNLOAD), we buffer redownloaded headers in memory
      *  until enough commitments have been verified; those are stored in

--- a/src/headerssync.h
+++ b/src/headerssync.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 The Bitcoin Core developers
+// Copyright (c) 2022-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -119,13 +119,13 @@ public:
     State GetState() const { return m_download_state; }
 
     /** Return the height reached during the PRESYNC phase */
-    int64_t GetPresyncHeight() const { return m_current_height; }
+    int64_t GetPresyncHeight() const { return m_presync_height; }
 
     /** Return the block timestamp of the last header received during the PRESYNC phase. */
-    uint32_t GetPresyncTime() const { return m_last_header_received.nTime; }
+    uint32_t GetPresyncTime() const { return m_presync_last_header_received.nTime; }
 
     /** Return the amount of work in the chain received during the PRESYNC phase. */
-    arith_uint256 GetPresyncWork() const { return m_current_chain_work; }
+    arith_uint256 GetPresyncWork() const { return m_presync_chain_work; }
 
     /** Construct a HeadersSyncState object representing a headers sync via this
      *  download-twice mechanism).
@@ -221,7 +221,7 @@ private:
     const arith_uint256 m_minimum_required_work;
 
     /** Work that we've seen so far on the peer's chain */
-    arith_uint256 m_current_chain_work;
+    arith_uint256 m_presync_chain_work;
 
     /** m_hasher is a salted hasher for making our 1-bit commitments to headers we've seen. */
     const SaltedTxidHasher m_hasher;
@@ -237,10 +237,10 @@ private:
     uint64_t m_max_commitments{0};
 
     /** Store the latest header received while in PRESYNC (initialized to m_chain_start) */
-    CBlockHeader m_last_header_received;
+    CBlockHeader m_presync_last_header_received;
 
-    /** Height of m_last_header_received */
-    int64_t m_current_height{0};
+    /** Height of m_presync_last_header_received */
+    int64_t m_presync_height{0};
 
     /** During phase 2 (REDOWNLOAD), we buffer redownloaded headers in memory
      *  until enough commitments have been verified; those are stored in

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3,6 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <limits>
 #include <net_processing.h>
 
 #include <addrman.h>
@@ -2649,7 +2650,7 @@ bool PeerManagerImpl::TryLowWorkHeadersSync(Peer& peer, CNode& pfrom, const CBlo
             // advancing to the first unknown header would be a small effect.
             LOCK(peer.m_headers_sync_mutex);
             peer.m_headers_sync.reset(new HeadersSyncState(peer.m_id, m_chainparams.GetConsensus(),
-                chain_start_header, minimum_chain_work));
+                chain_start_header, minimum_chain_work, /*cache_size=*/std::nullopt));
 
             // Now a HeadersSyncState object for tracking this synchronization
             // is created, process the headers using it as normal. Failures are

--- a/src/test/fuzz/headerssync.cpp
+++ b/src/test/fuzz/headerssync.cpp
@@ -50,13 +50,11 @@ FUZZ_TARGET(headers_sync_state, .init = initialize_headers_sync_state_fuzz)
 {
     SeedRandomStateForTest(SeedRand::ZEROS);
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
-    auto mock_time{ConsumeTime(fuzzed_data_provider)};
 
     CBlockHeader genesis_header{Params().GenesisBlock()};
     CBlockIndex start_index(genesis_header);
 
-    if (mock_time < start_index.GetMedianTimePast()) return;
-    SetMockTime(mock_time);
+    SetMockTime(ConsumeTime(fuzzed_data_provider, /*min=*/start_index.GetMedianTimePast()));
 
     const uint256 genesis_hash = genesis_header.GetHash();
     start_index.phashBlock = &genesis_hash;

--- a/src/test/fuzz/headerssync.cpp
+++ b/src/test/fuzz/headerssync.cpp
@@ -39,8 +39,8 @@ void MakeHeadersContinuous(
 class FuzzedHeadersSyncState : public HeadersSyncState
 {
 public:
-    FuzzedHeadersSyncState(const unsigned commit_offset, const CBlockIndex* chain_start, const arith_uint256& minimum_required_work)
-        : HeadersSyncState(/*id=*/0, Params().GetConsensus(), chain_start, minimum_required_work)
+    FuzzedHeadersSyncState(const unsigned commit_offset, const CBlockIndex* chain_start, const arith_uint256& minimum_required_work, size_t cache_size)
+        : HeadersSyncState(/*id=*/0, Params().GetConsensus(), chain_start, minimum_required_work, cache_size)
     {
         const_cast<unsigned&>(m_commit_offset) = commit_offset;
     }
@@ -63,7 +63,8 @@ FUZZ_TARGET(headers_sync_state, .init = initialize_headers_sync_state_fuzz)
     FuzzedHeadersSyncState headers_sync(
         /*commit_offset=*/fuzzed_data_provider.ConsumeIntegralInRange<unsigned>(1, 1024),
         /*chain_start=*/&start_index,
-        /*minimum_required_work=*/min_work);
+        /*minimum_required_work=*/min_work,
+        /*cache_size=*/fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 5'000'000));
 
     // Store headers for potential redownload phase.
     std::vector<CBlockHeader> all_headers;

--- a/src/test/headers_sync_chainwork_tests.cpp
+++ b/src/test/headers_sync_chainwork_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 The Bitcoin Core developers
+// Copyright (c) 2022-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -63,14 +63,18 @@ BOOST_FIXTURE_TEST_SUITE(headers_sync_chainwork_tests, HeadersGeneratorSetup)
 //    updates to the REDOWNLOAD phase successfully.
 // 2. Then we deliver the second set of headers and verify that they fail
 //    processing (presumably due to commitments not matching).
-// 3. Finally, we verify that repeating with the first set of headers in both
-//    phases is successful.
+static void SneakyRedownload(const std::vector<CBlockHeader>& first_chain, const std::vector<CBlockHeader>& second_chain, const CBlockIndex* chain_start, const arith_uint256& chain_work);
+// 3. Verify that repeating with the first set of headers in both phases is
+//    successful.
+static void HappyPath(const std::vector<CBlockHeader>& first_chain, const CBlockIndex* chain_start, const arith_uint256& chain_work);
+// 4. Finally, repeat the second set of headers in both phases to demonstrate
+//    behavior when the chain a peer provides has too little work.
+static void TooLittleWork(const std::vector<CBlockHeader>& second_chain, const CBlockIndex* chain_start, const arith_uint256& chain_work);
+
 BOOST_AUTO_TEST_CASE(headers_sync_state)
 {
     std::vector<CBlockHeader> first_chain;
     std::vector<CBlockHeader> second_chain;
-
-    std::unique_ptr<HeadersSyncState> hss;
 
     const int target_blocks = 15000;
     arith_uint256 chain_work = target_blocks*2;
@@ -86,56 +90,67 @@ BOOST_AUTO_TEST_CASE(headers_sync_state)
             ArithToUint256(1), Params().GenesisBlock().nBits);
 
     const CBlockIndex* chain_start = WITH_LOCK(::cs_main, return m_node.chainman->m_blockman.LookupBlockIndex(Params().GenesisBlock().GetHash()));
+
+    SneakyRedownload(first_chain, second_chain, chain_start, chain_work);
+    HappyPath(first_chain, chain_start, chain_work);
+    TooLittleWork(second_chain, chain_start, chain_work);
+}
+
+static void SneakyRedownload(const std::vector<CBlockHeader>& first_chain, const std::vector<CBlockHeader>& second_chain, const CBlockIndex* chain_start, const arith_uint256& chain_work)
+{
     std::vector<CBlockHeader> headers_batch;
 
     // Feed the first chain to HeadersSyncState, by delivering 1 header
     // initially and then the rest.
     headers_batch.insert(headers_batch.end(), std::next(first_chain.begin()), first_chain.end());
 
-    hss.reset(new HeadersSyncState(0, Params().GetConsensus(), chain_start, chain_work));
-    (void)hss->ProcessNextHeaders({first_chain.front()}, true);
+    HeadersSyncState hss{0, Params().GetConsensus(), chain_start, chain_work};
+    (void)hss.ProcessNextHeaders({first_chain.front()}, true);
     // Pretend the first header is still "full", so we don't abort.
-    auto result = hss->ProcessNextHeaders(headers_batch, true);
+    auto result = hss.ProcessNextHeaders(headers_batch, true);
 
     // This chain should look valid, and we should have met the proof-of-work
     // requirement.
     BOOST_CHECK(result.success);
     BOOST_CHECK(result.request_more);
-    BOOST_CHECK(hss->GetState() == HeadersSyncState::State::REDOWNLOAD);
+    BOOST_CHECK(hss.GetState() == HeadersSyncState::State::REDOWNLOAD);
 
     // Try to sneakily feed back the second chain.
-    result = hss->ProcessNextHeaders(second_chain, true);
+    result = hss.ProcessNextHeaders(second_chain, true);
     BOOST_CHECK(!result.success); // foiled!
-    BOOST_CHECK(hss->GetState() == HeadersSyncState::State::FINAL);
+    BOOST_CHECK(hss.GetState() == HeadersSyncState::State::FINAL);
+}
 
-    // Now try again, this time feeding the first chain twice.
-    hss.reset(new HeadersSyncState(0, Params().GetConsensus(), chain_start, chain_work));
-    (void)hss->ProcessNextHeaders(first_chain, true);
-    BOOST_CHECK(hss->GetState() == HeadersSyncState::State::REDOWNLOAD);
+static void HappyPath(const std::vector<CBlockHeader>& first_chain, const CBlockIndex* chain_start, const arith_uint256& chain_work)
+{
+    HeadersSyncState hss{0, Params().GetConsensus(), chain_start, chain_work};
+    (void)hss.ProcessNextHeaders(first_chain, true);
+    BOOST_CHECK(hss.GetState() == HeadersSyncState::State::REDOWNLOAD);
 
-    result = hss->ProcessNextHeaders(first_chain, true);
+    auto result = hss.ProcessNextHeaders(first_chain, true);
     BOOST_CHECK(result.success);
     BOOST_CHECK(!result.request_more);
     // All headers should be ready for acceptance:
     BOOST_CHECK(result.pow_validated_headers.size() == first_chain.size());
     // Nothing left for the sync logic to do:
-    BOOST_CHECK(hss->GetState() == HeadersSyncState::State::FINAL);
+    BOOST_CHECK(hss.GetState() == HeadersSyncState::State::FINAL);
+}
 
-    // Finally, verify that just trying to process the second chain would not
-    // succeed (too little work)
-    hss.reset(new HeadersSyncState(0, Params().GetConsensus(), chain_start, chain_work));
-    BOOST_CHECK(hss->GetState() == HeadersSyncState::State::PRESYNC);
+static void TooLittleWork(const std::vector<CBlockHeader>& second_chain, const CBlockIndex* chain_start, const arith_uint256& chain_work)
+{
+    HeadersSyncState hss{0, Params().GetConsensus(), chain_start, chain_work};
+    BOOST_CHECK(hss.GetState() == HeadersSyncState::State::PRESYNC);
      // Pretend just the first message is "full", so we don't abort.
-    (void)hss->ProcessNextHeaders({second_chain.front()}, true);
-    BOOST_CHECK(hss->GetState() == HeadersSyncState::State::PRESYNC);
+    (void)hss.ProcessNextHeaders({second_chain.front()}, true);
+    BOOST_CHECK(hss.GetState() == HeadersSyncState::State::PRESYNC);
 
-    headers_batch.clear();
+    std::vector<CBlockHeader> headers_batch;
     headers_batch.insert(headers_batch.end(), std::next(second_chain.begin(), 1), second_chain.end());
     // Tell the sync logic that the headers message was not full, implying no
     // more headers can be requested. For a low-work-chain, this should causes
     // the sync to end with no headers for acceptance.
-    result = hss->ProcessNextHeaders(headers_batch, false);
-    BOOST_CHECK(hss->GetState() == HeadersSyncState::State::FINAL);
+    auto result = hss.ProcessNextHeaders(headers_batch, false);
+    BOOST_CHECK(hss.GetState() == HeadersSyncState::State::FINAL);
     BOOST_CHECK(result.pow_validated_headers.empty());
     BOOST_CHECK(!result.request_more);
     // Nevertheless, no validation errors should have been detected with the

--- a/src/test/headers_sync_chainwork_tests.cpp
+++ b/src/test/headers_sync_chainwork_tests.cpp
@@ -104,7 +104,7 @@ static void SneakyRedownload(const std::vector<CBlockHeader>& first_chain, const
     // initially and then the rest.
     headers_batch.insert(headers_batch.end(), std::next(first_chain.begin()), first_chain.end());
 
-    HeadersSyncState hss{0, Params().GetConsensus(), chain_start, CHAIN_WORK};
+    HeadersSyncState hss{0, Params().GetConsensus(), chain_start, CHAIN_WORK, /*cache_size=*/1};
     auto result = hss.ProcessNextHeaders({first_chain.front()}, true);
     BOOST_REQUIRE_EQUAL(hss.GetState(), HeadersSyncState::State::PRESYNC);
     BOOST_CHECK(result.success);
@@ -119,8 +119,8 @@ static void SneakyRedownload(const std::vector<CBlockHeader>& first_chain, const
     BOOST_REQUIRE_EQUAL(hss.GetState(), HeadersSyncState::State::REDOWNLOAD);
     BOOST_CHECK(result.success);
     BOOST_CHECK(result.request_more);
-    // We should have reset the locator to genesis.
-    BOOST_CHECK_EQUAL(hss.NextHeadersRequestLocator().vHave.front(), Params().GenesisBlock().GetHash());
+    // We should have reset the locator to the first header after genesis, since it was cached.
+    BOOST_CHECK_EQUAL(hss.NextHeadersRequestLocator().vHave.front(), first_chain.front().GetHash());
     BOOST_CHECK(result.pow_validated_headers.empty());
 
     // Try to sneakily feed back the second chain during REDOWNLOAD.
@@ -132,15 +132,17 @@ static void SneakyRedownload(const std::vector<CBlockHeader>& first_chain, const
 
 static void HappyPath(const std::vector<CBlockHeader>& first_chain, const CBlockIndex* chain_start)
 {
-    HeadersSyncState hss{0, Params().GetConsensus(), chain_start, CHAIN_WORK};
+    HeadersSyncState hss{0, Params().GetConsensus(), chain_start, CHAIN_WORK, /*cache_size=*/1};
     auto result = hss.ProcessNextHeaders(first_chain, true);
     BOOST_REQUIRE_EQUAL(hss.GetState(), HeadersSyncState::State::REDOWNLOAD);
     BOOST_CHECK(result.success);
     BOOST_CHECK(result.request_more);
-    // We should have reset the locator to genesis.
-    BOOST_CHECK_EQUAL(hss.NextHeadersRequestLocator().vHave.front(), Params().GenesisBlock().GetHash());
+    // We should have reset the locator to the first header after genesis, since it was cached.
+    BOOST_CHECK_EQUAL(hss.NextHeadersRequestLocator().vHave.front(), first_chain.front().GetHash());
 
-    result = hss.ProcessNextHeaders(first_chain, true);
+    std::vector<CBlockHeader> headers_batch;
+    headers_batch.insert(headers_batch.end(), std::next(first_chain.begin()), first_chain.end());
+    result = hss.ProcessNextHeaders(headers_batch, /*full_headers_message=*/true);
     // Nothing left for the sync logic to do:
     BOOST_REQUIRE_EQUAL(hss.GetState(), HeadersSyncState::State::FINAL);
     BOOST_CHECK(result.success);
@@ -151,7 +153,7 @@ static void HappyPath(const std::vector<CBlockHeader>& first_chain, const CBlock
 
 static void TooLittleWork(const std::vector<CBlockHeader>& second_chain, const CBlockIndex* chain_start)
 {
-    HeadersSyncState hss{0, Params().GetConsensus(), chain_start, CHAIN_WORK};
+    HeadersSyncState hss{0, Params().GetConsensus(), chain_start, CHAIN_WORK, /*cache_size=*/TARGET_BLOCKS};
     BOOST_REQUIRE_EQUAL(hss.GetState(), HeadersSyncState::State::PRESYNC);
     // Pretend just the first message is "full", so we don't abort.
     auto result = hss.ProcessNextHeaders({second_chain.front()}, true);

--- a/src/test/headers_sync_chainwork_tests.cpp
+++ b/src/test/headers_sync_chainwork_tests.cpp
@@ -13,6 +13,9 @@
 
 #include <boost/test/unit_test.hpp>
 
+static constexpr int TARGET_BLOCKS{15000};
+static const arith_uint256 CHAIN_WORK{TARGET_BLOCKS*2};
+
 struct HeadersGeneratorSetup : public RegTestingSetup {
     /** Search for a nonce to meet (regtest) proof of work */
     void FindProofOfWork(CBlockHeader& starting_header);
@@ -63,40 +66,37 @@ BOOST_FIXTURE_TEST_SUITE(headers_sync_chainwork_tests, HeadersGeneratorSetup)
 //    updates to the REDOWNLOAD phase successfully.
 // 2. Then we deliver the second set of headers and verify that they fail
 //    processing (presumably due to commitments not matching).
-static void SneakyRedownload(const std::vector<CBlockHeader>& first_chain, const std::vector<CBlockHeader>& second_chain, const CBlockIndex* chain_start, const arith_uint256& chain_work);
+static void SneakyRedownload(const std::vector<CBlockHeader>& first_chain, const std::vector<CBlockHeader>& second_chain, const CBlockIndex* chain_start);
 // 3. Verify that repeating with the first set of headers in both phases is
 //    successful.
-static void HappyPath(const std::vector<CBlockHeader>& first_chain, const CBlockIndex* chain_start, const arith_uint256& chain_work);
+static void HappyPath(const std::vector<CBlockHeader>& first_chain, const CBlockIndex* chain_start);
 // 4. Finally, repeat the second set of headers in both phases to demonstrate
 //    behavior when the chain a peer provides has too little work.
-static void TooLittleWork(const std::vector<CBlockHeader>& second_chain, const CBlockIndex* chain_start, const arith_uint256& chain_work);
+static void TooLittleWork(const std::vector<CBlockHeader>& second_chain, const CBlockIndex* chain_start);
 
 BOOST_AUTO_TEST_CASE(headers_sync_state)
 {
     std::vector<CBlockHeader> first_chain;
     std::vector<CBlockHeader> second_chain;
 
-    const int target_blocks = 15000;
-    arith_uint256 chain_work = target_blocks*2;
+    const auto genesis{Params().GenesisBlock()};
 
     // Generate headers for two different chains (using differing merkle roots
     // to ensure the headers are different).
-    GenerateHeaders(first_chain, target_blocks-1, Params().GenesisBlock().GetHash(),
-            Params().GenesisBlock().nVersion, Params().GenesisBlock().nTime,
-            ArithToUint256(0), Params().GenesisBlock().nBits);
+    GenerateHeaders(first_chain, TARGET_BLOCKS-1, genesis.GetHash(),
+            genesis.nVersion, genesis.nTime, ArithToUint256(0), genesis.nBits);
 
-    GenerateHeaders(second_chain, target_blocks-2, Params().GenesisBlock().GetHash(),
-            Params().GenesisBlock().nVersion, Params().GenesisBlock().nTime,
-            ArithToUint256(1), Params().GenesisBlock().nBits);
+    GenerateHeaders(second_chain, TARGET_BLOCKS-2, genesis.GetHash(),
+            genesis.nVersion, genesis.nTime, ArithToUint256(1), genesis.nBits);
 
-    const CBlockIndex* chain_start = WITH_LOCK(::cs_main, return m_node.chainman->m_blockman.LookupBlockIndex(Params().GenesisBlock().GetHash()));
+    const CBlockIndex* chain_start = WITH_LOCK(::cs_main, return m_node.chainman->m_blockman.LookupBlockIndex(genesis.GetHash()));
 
-    SneakyRedownload(first_chain, second_chain, chain_start, chain_work);
-    HappyPath(first_chain, chain_start, chain_work);
-    TooLittleWork(second_chain, chain_start, chain_work);
+    SneakyRedownload(first_chain, second_chain, chain_start);
+    HappyPath(first_chain, chain_start);
+    TooLittleWork(second_chain, chain_start);
 }
 
-static void SneakyRedownload(const std::vector<CBlockHeader>& first_chain, const std::vector<CBlockHeader>& second_chain, const CBlockIndex* chain_start, const arith_uint256& chain_work)
+static void SneakyRedownload(const std::vector<CBlockHeader>& first_chain, const std::vector<CBlockHeader>& second_chain, const CBlockIndex* chain_start)
 {
     std::vector<CBlockHeader> headers_batch;
 
@@ -104,53 +104,68 @@ static void SneakyRedownload(const std::vector<CBlockHeader>& first_chain, const
     // initially and then the rest.
     headers_batch.insert(headers_batch.end(), std::next(first_chain.begin()), first_chain.end());
 
-    HeadersSyncState hss{0, Params().GetConsensus(), chain_start, chain_work};
-    (void)hss.ProcessNextHeaders({first_chain.front()}, true);
-    // Pretend the first header is still "full", so we don't abort.
-    auto result = hss.ProcessNextHeaders(headers_batch, true);
-
-    // This chain should look valid, and we should have met the proof-of-work
-    // requirement.
+    HeadersSyncState hss{0, Params().GetConsensus(), chain_start, CHAIN_WORK};
+    auto result = hss.ProcessNextHeaders({first_chain.front()}, true);
+    BOOST_REQUIRE_EQUAL(hss.GetState(), HeadersSyncState::State::PRESYNC);
     BOOST_CHECK(result.success);
     BOOST_CHECK(result.request_more);
-    BOOST_CHECK(hss.GetState() == HeadersSyncState::State::REDOWNLOAD);
+    BOOST_CHECK_EQUAL(hss.NextHeadersRequestLocator().vHave.front(), first_chain.front().GetHash());
+    BOOST_CHECK(result.pow_validated_headers.empty());
 
-    // Try to sneakily feed back the second chain.
+    // Pretend the first header is still "full", so we don't abort.
+    result = hss.ProcessNextHeaders(headers_batch, true);
+    // This chain should look valid, and we should have met the proof-of-work
+    // requirement during PRESYNC and transitioned to REDOWNLOAD.
+    BOOST_REQUIRE_EQUAL(hss.GetState(), HeadersSyncState::State::REDOWNLOAD);
+    BOOST_CHECK(result.success);
+    BOOST_CHECK(result.request_more);
+    // We should have reset the locator to genesis.
+    BOOST_CHECK_EQUAL(hss.NextHeadersRequestLocator().vHave.front(), Params().GenesisBlock().GetHash());
+    BOOST_CHECK(result.pow_validated_headers.empty());
+
+    // Try to sneakily feed back the second chain during REDOWNLOAD.
     result = hss.ProcessNextHeaders(second_chain, true);
+    BOOST_REQUIRE_EQUAL(hss.GetState(), HeadersSyncState::State::FINAL);
     BOOST_CHECK(!result.success); // foiled!
-    BOOST_CHECK(hss.GetState() == HeadersSyncState::State::FINAL);
+    BOOST_CHECK(result.pow_validated_headers.empty());
 }
 
-static void HappyPath(const std::vector<CBlockHeader>& first_chain, const CBlockIndex* chain_start, const arith_uint256& chain_work)
+static void HappyPath(const std::vector<CBlockHeader>& first_chain, const CBlockIndex* chain_start)
 {
-    HeadersSyncState hss{0, Params().GetConsensus(), chain_start, chain_work};
-    (void)hss.ProcessNextHeaders(first_chain, true);
-    BOOST_CHECK(hss.GetState() == HeadersSyncState::State::REDOWNLOAD);
-
+    HeadersSyncState hss{0, Params().GetConsensus(), chain_start, CHAIN_WORK};
     auto result = hss.ProcessNextHeaders(first_chain, true);
+    BOOST_REQUIRE_EQUAL(hss.GetState(), HeadersSyncState::State::REDOWNLOAD);
+    BOOST_CHECK(result.success);
+    BOOST_CHECK(result.request_more);
+    // We should have reset the locator to genesis.
+    BOOST_CHECK_EQUAL(hss.NextHeadersRequestLocator().vHave.front(), Params().GenesisBlock().GetHash());
+
+    result = hss.ProcessNextHeaders(first_chain, true);
+    // Nothing left for the sync logic to do:
+    BOOST_REQUIRE_EQUAL(hss.GetState(), HeadersSyncState::State::FINAL);
     BOOST_CHECK(result.success);
     BOOST_CHECK(!result.request_more);
     // All headers should be ready for acceptance:
-    BOOST_CHECK(result.pow_validated_headers.size() == first_chain.size());
-    // Nothing left for the sync logic to do:
-    BOOST_CHECK(hss.GetState() == HeadersSyncState::State::FINAL);
+    BOOST_CHECK_EQUAL(result.pow_validated_headers.size(), first_chain.size());
 }
 
-static void TooLittleWork(const std::vector<CBlockHeader>& second_chain, const CBlockIndex* chain_start, const arith_uint256& chain_work)
+static void TooLittleWork(const std::vector<CBlockHeader>& second_chain, const CBlockIndex* chain_start)
 {
-    HeadersSyncState hss{0, Params().GetConsensus(), chain_start, chain_work};
-    BOOST_CHECK(hss.GetState() == HeadersSyncState::State::PRESYNC);
-     // Pretend just the first message is "full", so we don't abort.
-    (void)hss.ProcessNextHeaders({second_chain.front()}, true);
-    BOOST_CHECK(hss.GetState() == HeadersSyncState::State::PRESYNC);
+    HeadersSyncState hss{0, Params().GetConsensus(), chain_start, CHAIN_WORK};
+    BOOST_REQUIRE_EQUAL(hss.GetState(), HeadersSyncState::State::PRESYNC);
+    // Pretend just the first message is "full", so we don't abort.
+    auto result = hss.ProcessNextHeaders({second_chain.front()}, true);
+    BOOST_REQUIRE_EQUAL(hss.GetState(), HeadersSyncState::State::PRESYNC);
+    BOOST_CHECK(result.success);
+    BOOST_CHECK(result.request_more);
 
     std::vector<CBlockHeader> headers_batch;
     headers_batch.insert(headers_batch.end(), std::next(second_chain.begin(), 1), second_chain.end());
     // Tell the sync logic that the headers message was not full, implying no
     // more headers can be requested. For a low-work-chain, this should causes
     // the sync to end with no headers for acceptance.
-    auto result = hss.ProcessNextHeaders(headers_batch, false);
-    BOOST_CHECK(hss.GetState() == HeadersSyncState::State::FINAL);
+    result = hss.ProcessNextHeaders(headers_batch, false);
+    BOOST_REQUIRE_EQUAL(hss.GetState(), HeadersSyncState::State::FINAL);
     BOOST_CHECK(result.pow_validated_headers.empty());
     BOOST_CHECK(!result.request_more);
     // Nevertheless, no validation errors should have been detected with the


### PR DESCRIPTION
While we do want to avoid OOM-attacks through [CVE-2024-52916](https://bitcoincore.org/en/2024/07/03/disclose-header-spam/), we can still serve the happy path by caching headers up to a reasonable chain height.

Cuts out time/bandwidth re-downloading same headers from same peer - good for both local and remote node, especially over slow/flaky connections. Even more helpful when the local node has flaky connection to all other nodes.

Queries the machine for free RAM and takes up to 10% of it for the cache. (Which is released after syncing ends).