### PR TITLE
SwiftSync

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -260,6 +260,7 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   rpc/txoutproof.cpp
   script/sigcache.cpp
   signet.cpp
+  swiftsync.cpp
   torcontrol.cpp
   txdb.cpp
   txgraph.cpp

--- a/src/bench/CMakeLists.txt
+++ b/src/bench/CMakeLists.txt
@@ -52,6 +52,7 @@ add_executable(bench_bitcoin
   strencodings.cpp
   txgraph.cpp
   txorphanage.cpp
+  swiftsyncbench.cpp
   util_time.cpp
   verify_script.cpp
 )

--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -25,7 +25,7 @@
 // a block off the wire, but before we can relay the block on to peers using
 // compact block relay.
 
-static void DeserializeBlockTest(benchmark::Bench& bench)
+static void DeserializeBlockBench(benchmark::Bench& bench)
 {
     DataStream stream(benchmark::data::block413567);
     std::byte a{0};
@@ -39,26 +39,18 @@ static void DeserializeBlockTest(benchmark::Bench& bench)
     });
 }
 
-static void DeserializeAndCheckBlockTest(benchmark::Bench& bench)
+static void CheckBlockBench(benchmark::Bench& bench)
 {
-    DataStream stream(benchmark::data::block413567);
-    std::byte a{0};
-    stream.write({&a, 1}); // Prevent compaction
-
-    ArgsManager bench_args;
-    const auto chainParams = CreateChainParams(bench_args, ChainType::MAIN);
-
+    CBlock block;
+    DataStream(benchmark::data::block413567) >> TX_WITH_WITNESS(block);
+    const auto chainParams = CreateChainParams(ArgsManager{}, ChainType::MAIN);
     bench.unit("block").run([&] {
-        CBlock block; // Note that CBlock caches its checked state, so we need to recreate it here
-        stream >> TX_WITH_WITNESS(block);
-        bool rewound = stream.Rewind(benchmark::data::block413567.size());
-        assert(rewound);
-
+        block.fChecked = block.m_checked_witness_commitment = block.m_checked_merkle_root = false; // Reset the cached state
         BlockValidationState validationState;
-        bool checked = CheckBlock(block, validationState, chainParams->GetConsensus());
-        assert(checked);
+        bool checked = CheckBlock(block, validationState, chainParams->GetConsensus(), /*fCheckPOW=*/true, /*fCheckMerkleRoot=*/true);
+        assert(checked && validationState.IsValid());
     });
 }
 
-BENCHMARK(DeserializeBlockTest, benchmark::PriorityLevel::HIGH);
-BENCHMARK(DeserializeAndCheckBlockTest, benchmark::PriorityLevel::HIGH);
+BENCHMARK(DeserializeBlockBench, benchmark::PriorityLevel::HIGH);
+BENCHMARK(CheckBlockBench, benchmark::PriorityLevel::HIGH);

--- a/src/bench/swiftsyncbench.cpp
+++ b/src/bench/swiftsyncbench.cpp
@@ -1,0 +1,30 @@
+// src/bench/swiftsync.cpp
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see COPYING.
+
+#include <bench/bench.h>
+#include <swiftsync.h>
+#include <util/fs.h>
+
+#include <cstddef>
+
+static void SwiftSyncLoadBench(benchmark::Bench& bench)
+{
+    // TODO generate a fake swiftsync file
+    // SwiftSyncHints hints;
+    // hints.Load(fs::PathToString("/Users/lorinc/Dev/swiftsync-888888.bin"));
+    // assert(hints.IsLoaded() && hints.GetTerminalBlockHeight() == 888'888);
+    //
+    // bench.batch(hints.GetTerminalBlockHeight()).unit("blocks").run([&] {
+    //     size_t utxos{0};
+    //     for (int h{0}; h <= hints.GetTerminalBlockHeight(); ++h) {
+    //         hints.SetCurrentBlockHeight(h);
+    //         while (hints.HasNextBit()) {
+    //             utxos += !hints.GetNextBit();
+    //         }
+    //     }
+    //     assert(utxos == 3'071'308'286);
+    // });
+}
+
+BENCHMARK(SwiftSyncLoadBench, benchmark::PriorityLevel::HIGH);

--- a/src/bench/swiftsyncbench.cpp
+++ b/src/bench/swiftsyncbench.cpp
@@ -12,7 +12,7 @@ static void SwiftSyncLoadBench(benchmark::Bench& bench)
 {
     // TODO generate a fake swiftsync file
     // SwiftSyncHints hints;
-    // hints.Load(fs::PathToString("/Users/lorinc/Dev/swiftsync-888888.bin"));
+    // hints.Load(fs::PathToString("/Users/lorinc/Dev/swiftsync-888888_new.bin"));
     // assert(hints.IsLoaded() && hints.GetTerminalBlockHeight() == 888'888);
     //
     // bench.batch(hints.GetTerminalBlockHeight()).unit("blocks").run([&] {

--- a/src/compressor.cpp
+++ b/src/compressor.cpp
@@ -16,36 +16,27 @@
  * form).
  */
 
-static bool IsToKeyID(const CScript& script, CKeyID &hash)
+static bool IsToKeyID(const CScript& script, CKeyID& hash)
 {
-    if (script.size() == 25 && script[0] == OP_DUP && script[1] == OP_HASH160
-                            && script[2] == 20 && script[23] == OP_EQUALVERIFY
-                            && script[24] == OP_CHECKSIG) {
-        memcpy(&hash, &script[3], 20);
-        return true;
-    }
-    return false;
+    if (!script.IsPayToPubKeyHash()) return false;
+    memcpy(&hash, &script[3], 20);
+    return true;
 }
 
-static bool IsToScriptID(const CScript& script, CScriptID &hash)
+static bool IsToScriptID(const CScript& script, CScriptID& hash)
 {
-    if (script.size() == 23 && script[0] == OP_HASH160 && script[1] == 20
-                            && script[22] == OP_EQUAL) {
-        memcpy(&hash, &script[2], 20);
-        return true;
-    }
-    return false;
+    if (!script.IsPayToScriptHash()) return false;
+    memcpy(&hash, &script[2], 20);
+    return true;
 }
 
-static bool IsToPubKey(const CScript& script, CPubKey &pubkey)
+static bool IsToPubKey(const CScript& script, CPubKey& pubkey)
 {
-    if (script.size() == 35 && script[0] == 33 && script[34] == OP_CHECKSIG
-                            && (script[1] == 0x02 || script[1] == 0x03)) {
+    if (script.IsCompressedPayToPubKey()) {
         pubkey.Set(&script[1], &script[34]);
         return true;
     }
-    if (script.size() == 67 && script[0] == 65 && script[66] == OP_CHECKSIG
-                            && script[1] == 0x04) {
+    if (script.IsUncompressedPayToPubKey()) {
         pubkey.Set(&script[1], &script[66]);
         return pubkey.IsFullyValid(); // if not fully valid, a case that would not be compressible
     }

--- a/src/consensus/tx_check.cpp
+++ b/src/consensus/tx_check.cpp
@@ -38,22 +38,36 @@ bool CheckTransaction(const CTransaction& tx, TxValidationState& state)
     // of a tx as spent, it does not check if the tx has duplicate inputs.
     // Failure to run this check will result in either a crash or an inflation bug, depending on the implementation of
     // the underlying coins database.
-    std::set<COutPoint> vInOutPoints;
-    for (const auto& txin : tx.vin) {
-        if (!vInOutPoints.insert(txin.prevout).second)
+    if (tx.vin.size() == 1) {
+        if (tx.IsCoinBase()) {
+            if (tx.vin[0].scriptSig.size() < 2 || tx.vin[0].scriptSig.size() > 100) {
+                return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-cb-length");
+            }
+        }
+    } else if (tx.vin.size() == 2) {
+        if (tx.vin[0].prevout == tx.vin[1].prevout) {
             return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-inputs-duplicate");
-    }
+        }
+        if (tx.vin[0].prevout.IsNull() || tx.vin[1].prevout.IsNull()) {
+            return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-prevout-null");
+        }
+    } else {
+        std::vector<COutPoint> sortedPrevouts;
+        sortedPrevouts.reserve(tx.vin.size());
+        for (const auto& txin : tx.vin) {
+            sortedPrevouts.push_back(txin.prevout);
+        }
+        std::sort(sortedPrevouts.begin(), sortedPrevouts.end());
+        if (std::ranges::adjacent_find(sortedPrevouts) != sortedPrevouts.end()) {
+            return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-inputs-duplicate");
+        }
 
-    if (tx.IsCoinBase())
-    {
-        if (tx.vin[0].scriptSig.size() < 2 || tx.vin[0].scriptSig.size() > 100)
-            return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-cb-length");
-    }
-    else
-    {
-        for (const auto& txin : tx.vin)
-            if (txin.prevout.IsNull())
+        for (const auto& in : sortedPrevouts) {
+            if (!in.hash.IsNull()) break; // invalid values can only be at the beginning
+            if (in.IsNull()) {
                 return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-prevout-null");
+            }
+        }
     }
 
     return true;

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -112,13 +112,11 @@ bool SequenceLocks(const CTransaction &tx, int flags, std::vector<int>& prevHeig
 unsigned int GetLegacySigOpCount(const CTransaction& tx)
 {
     unsigned int nSigOps = 0;
-    for (const auto& txin : tx.vin)
-    {
-        nSigOps += txin.scriptSig.GetSigOpCount(false);
+    for (const auto& txin : tx.vin) {
+        nSigOps += txin.scriptSig.GetLegacySigOpCount(/*fAccurate=*/false);
     }
-    for (const auto& txout : tx.vout)
-    {
-        nSigOps += txout.scriptPubKey.GetSigOpCount(false);
+    for (const auto& txout : tx.vout) {
+        nSigOps += txout.scriptPubKey.GetLegacySigOpCount(/*fAccurate=*/false);
     }
     return nSigOps;
 }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1768,8 +1768,14 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     }
 #endif
 
-    LogInfo("Loading SwiftSync hints bitmap...");
-    g_swiftsync_hints.Load("./booster.bin"); // TODO: add -swiftsyncfile parameter
+    if (args.IsArgSet("-swiftsyncfile")) {
+        fs::path path = fs::absolute(args.GetPathArg("-swiftsyncfile"));
+        if (!fs::exists(path)) {
+            return InitError(Untranslated("Provided SwiftSync file doesn't exist"));
+        }
+        LogInfo("Loading SwiftSync hints bitmap file...");
+        g_swiftsync_hints.Load(path.utf8string());
+    }
 
     // ********************************************************* Step 7: load block chain
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -479,6 +479,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
     argsman.AddArg("-alertnotify=<cmd>", "Execute command when an alert is raised (%s in cmd is replaced by message)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 #endif
     argsman.AddArg("-assumevalid=<hex>", strprintf("If this block is in the chain assume that it and its ancestors are valid and potentially skip their script verification (0 to verify all, default: %s, testnet3: %s, testnet4: %s, signet: %s)", defaultChainParams->GetConsensus().defaultAssumeValid.GetHex(), testnetChainParams->GetConsensus().defaultAssumeValid.GetHex(), testnet4ChainParams->GetConsensus().defaultAssumeValid.GetHex(), signetChainParams->GetConsensus().defaultAssumeValid.GetHex()), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-swiftsyncfile=<file>", "Specify hints file to use for SwiftSync.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-blocksdir=<dir>", "Specify directory to hold blocks subdirectory for *.dat files (default: <datadir>)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-blocksxor",
                    strprintf("Whether an XOR-key applies to blocksdir *.dat files. "

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -69,6 +69,7 @@
 #include <rpc/util.h>
 #include <scheduler.h>
 #include <script/sigcache.h>
+#include <swiftsync.h>
 #include <sync.h>
 #include <torcontrol.h>
 #include <txdb.h>
@@ -147,6 +148,8 @@ static constexpr bool DEFAULT_PROXYRANDOMIZE{true};
 static constexpr bool DEFAULT_REST_ENABLE{false};
 static constexpr bool DEFAULT_I2P_ACCEPT_INCOMING{true};
 static constexpr bool DEFAULT_STOPAFTERBLOCKIMPORT{false};
+
+extern SwiftSyncHints g_swiftsync_hints;
 
 #ifdef WIN32
 // Win32 LevelDB doesn't use filedescriptors, and the ones used for
@@ -1764,6 +1767,9 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         validation_signals.RegisterValidationInterface(g_zmq_notification_interface.get());
     }
 #endif
+
+    LogInfo("Loading SwiftSync hints bitmap...");
+    g_swiftsync_hints.Load("./booster.bin"); // TODO: add -swiftsyncfile parameter
 
     // ********************************************************* Step 7: load block chain
 

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -181,7 +181,7 @@ static bool CheckSigopsBIP54(const CTransaction& tx, const CCoinsViewCache& inpu
         // `fAccurate` means correctly accounting sigops for CHECKMULTISIGs(VERIFY) with 16 pubkeys
         // or fewer. This method of accounting was introduced by BIP16, and BIP54 reuses it.
         // The GetSigOpCount call on the previous scriptPubKey counts both bare and P2SH sigops.
-        sigops += txin.scriptSig.GetSigOpCount(/*fAccurate=*/true);
+        sigops += txin.scriptSig.GetLegacySigOpCount(/*fAccurate=*/true);
         sigops += prev_txo.scriptPubKey.GetSigOpCount(txin.scriptSig);
 
         if (sigops > MAX_TX_LEGACY_SIGOPS) {

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -239,7 +239,7 @@ bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
             if (stack.empty())
                 return false;
             CScript subscript(stack.back().begin(), stack.back().end());
-            if (subscript.GetSigOpCount(true) > MAX_P2SH_SIGOPS) {
+            if (subscript.GetLegacySigOpCount(true) > MAX_P2SH_SIGOPS) {
                 return false;
             }
         }

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -2123,7 +2123,7 @@ size_t static WitnessSigOps(int witversion, const std::vector<unsigned char>& wi
 
         if (witprogram.size() == WITNESS_V0_SCRIPTHASH_SIZE && witness.stack.size() > 0) {
             CScript subscript(witness.stack.back().begin(), witness.stack.back().end());
-            return subscript.GetSigOpCount(true);
+            return subscript.GetLegacySigOpCount(true);
         }
     }
 

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -8,6 +8,7 @@
 #include <crypto/common.h>
 #include <crypto/hex_base.h>
 #include <hash.h>
+#include <iostream>
 #include <uint256.h>
 #include <util/hash_type.h>
 
@@ -156,34 +157,153 @@ std::string GetOpName(opcodetype opcode)
     }
 }
 
-unsigned int CScript::GetSigOpCount(bool fAccurate) const
+static constexpr unsigned int DECODE_ERR{std::numeric_limits<unsigned int>::max()};
+
+static constexpr std::pair<unsigned int, unsigned int>
+DecodePushData(const opcodetype opcode,
+               const CScript::const_iterator& ptr,
+               const unsigned int remaining) noexcept
 {
-    unsigned int n = 0;
-    const_iterator pc = begin();
-    opcodetype lastOpcode = OP_INVALIDOPCODE;
-    while (pc < end())
-    {
-        opcodetype opcode;
-        if (!GetOp(pc, opcode))
-            break;
-        if (opcode == OP_CHECKSIG || opcode == OP_CHECKSIGVERIFY)
-            n++;
-        else if (opcode == OP_CHECKMULTISIG || opcode == OP_CHECKMULTISIGVERIFY)
-        {
-            if (fAccurate && lastOpcode >= OP_1 && lastOpcode <= OP_16)
-                n += DecodeOP_N(lastOpcode);
-            else
-                n += MAX_PUBKEYS_PER_MULTISIG;
-        }
-        lastOpcode = opcode;
+    unsigned int size_bytes;
+    switch (opcode) {
+    case OP_PUSHDATA1: size_bytes = 1; break;
+    case OP_PUSHDATA2: size_bytes = 2; break;
+    case OP_PUSHDATA4: size_bytes = 4; break;
+    default: size_bytes = 0; break;
     }
-    return n;
+    if (size_bytes > remaining) return {DECODE_ERR, DECODE_ERR};
+
+    unsigned int data_bytes;
+    switch (size_bytes) {
+    case 1: data_bytes = ptr[0]; break;
+    case 2: data_bytes = ReadLE16(&*ptr); break;
+    case 4: data_bytes = ReadLE32(&*ptr); break;
+    default: data_bytes = opcode; break;
+    }
+    if (data_bytes > remaining || size_bytes + data_bytes > remaining) return {size_bytes, DECODE_ERR};
+
+    return {size_bytes, data_bytes};
+}
+
+unsigned int CScript::GetLegacySigOpCount(bool fAccurate) const
+{
+    auto GetScriptOpOriginal{[&](const_iterator& pc, const_iterator end, opcodetype& opcodeRet, std::vector<unsigned char>* pvchRet) -> bool {
+        opcodeRet = OP_INVALIDOPCODE;
+        if (pvchRet)
+            pvchRet->clear();
+        if (pc >= end)
+            return false;
+
+        // Read instruction
+        if (end - pc < 1)
+            return false;
+        unsigned int opcode = *pc++;
+
+        // Immediate operand
+        if (opcode <= OP_PUSHDATA4) {
+            unsigned int nSize = 0;
+            if (opcode < OP_PUSHDATA1) {
+                nSize = opcode;
+            } else if (opcode == OP_PUSHDATA1) {
+                if (end - pc < 1)
+                    return false;
+                nSize = *pc++;
+            } else if (opcode == OP_PUSHDATA2) {
+                if (end - pc < 2)
+                    return false;
+                nSize = ReadLE16(&pc[0]);
+                pc += 2;
+            } else if (opcode == OP_PUSHDATA4) {
+                if (end - pc < 4)
+                    return false;
+                nSize = ReadLE32(&pc[0]);
+                pc += 4;
+            }
+            if (end - pc < 0 || (unsigned int)(end - pc) < nSize)
+                return false;
+            if (pvchRet)
+                pvchRet->assign(pc, pc + nSize);
+            pc += nSize;
+        }
+
+        opcodeRet = static_cast<opcodetype>(opcode);
+        return true;
+    }};
+    auto GetSigOpCountOriginal{[&]() -> unsigned int {
+        unsigned int n = 0;
+        const_iterator pc = begin();
+        opcodetype lastOpcode = OP_INVALIDOPCODE;
+        while (pc < end()) {
+            opcodetype opcode;
+            if (!GetScriptOpOriginal(pc, end(), opcode, nullptr))
+                break;
+            if (opcode == OP_CHECKSIG || opcode == OP_CHECKSIGVERIFY)
+                n++;
+            else if (opcode == OP_CHECKMULTISIG || opcode == OP_CHECKMULTISIGVERIFY) {
+                if (fAccurate && lastOpcode >= OP_1 && lastOpcode <= OP_16)
+                    n += DecodeOP_N(lastOpcode);
+                else
+                    n += MAX_PUBKEYS_PER_MULTISIG;
+            }
+            lastOpcode = opcode;
+        }
+        return n;
+    }};
+
+    auto GetSigOpCountNew{[&]() -> unsigned int {
+        switch (size()) {
+        case 0: return 0;
+        case 22: if (IsPayToWitnessPubKeyHash()) return 0; else break;
+        case 23: if (IsPayToScriptHash()) return 0; else break;
+        case 25: if (IsPayToPubKeyHash()) return 1; else break;
+        case 34: if (IsPayToTaproot() || IsPayToWitnessScriptHash()) return 0; else break;
+        case 35: if (IsCompressedPayToPubKey()) return 1; else break;
+        case 67: if (IsUncompressedPayToPubKey()) return 1; else break;
+        }
+
+        unsigned int n = 0;
+        const_iterator pc{begin()};
+        const_iterator const pend{end()};
+        opcodetype lastOpcode = OP_INVALIDOPCODE;
+        while (pc < pend) {
+            const auto opcode{static_cast<opcodetype>(*pc++)};
+            if (opcode <= OP_PUSHDATA4) {
+                auto [size_bytes, data_bytes]{DecodePushData(opcode, pc, pend - pc)};
+                if (data_bytes == DECODE_ERR) break;
+                pc += size_bytes + data_bytes;
+            } else if (opcode >= OP_CHECKSIG && opcode <= OP_CHECKMULTISIGVERIFY) {
+                if (opcode == OP_CHECKSIG || opcode == OP_CHECKSIGVERIFY) {
+                    ++n;
+                } else {
+                    assert(opcode == OP_CHECKMULTISIG || opcode == OP_CHECKMULTISIGVERIFY);
+                    if (fAccurate && (lastOpcode >= OP_1 && lastOpcode <= OP_16)) {
+                        n += DecodeOP_N(lastOpcode);
+                    } else {
+                        n += MAX_PUBKEYS_PER_MULTISIG;
+                    }
+                }
+            }
+            if (fAccurate) lastOpcode = opcode;
+        }
+        return n;
+    }};
+
+    const auto original_result{GetSigOpCountOriginal()};
+    const auto new_result{GetSigOpCountNew()};
+    if (original_result != new_result) {
+        // TODO
+        std::cout << "Warning: GetSigOpCount() results differ: " << original_result << " vs " << new_result << " " << HexStr({begin(), end()}) << std::endl;
+        std::cout.flush();
+        throw "fail!";
+    }
+    assert(original_result == new_result);
+    return new_result;
 }
 
 unsigned int CScript::GetSigOpCount(const CScript& scriptSig) const
 {
     if (!IsPayToScriptHash())
-        return GetSigOpCount(true);
+        return GetLegacySigOpCount(true);
 
     // This is a pay-to-script-hash scriptPubKey;
     // get the last item that the scriptSig
@@ -201,7 +321,7 @@ unsigned int CScript::GetSigOpCount(const CScript& scriptSig) const
 
     /// ... and return its opcount:
     CScript subscript(vData.begin(), vData.end());
-    return subscript.GetSigOpCount(true);
+    return subscript.GetLegacySigOpCount(true);
 }
 
 bool CScript::IsPayToAnchor() const
@@ -313,52 +433,22 @@ bool CScript::HasValidOps() const
 bool GetScriptOp(CScriptBase::const_iterator& pc, CScriptBase::const_iterator end, opcodetype& opcodeRet, std::vector<unsigned char>* pvchRet)
 {
     opcodeRet = OP_INVALIDOPCODE;
-    if (pvchRet)
-        pvchRet->clear();
-    if (pc >= end)
-        return false;
+    if (pvchRet) pvchRet->clear();
+    if (pc >= end) return false;
 
     // Read instruction
-    if (end - pc < 1)
-        return false;
-    unsigned int opcode = *pc++;
+    const auto opcode{static_cast<opcodetype>(*pc++)};
+    if (opcode <= OP_PUSHDATA4) {
+        auto [size_bytes, data_bytes]{DecodePushData(opcode, pc, end - pc)};
+        if (data_bytes == DECODE_ERR) return false;
 
-    // Immediate operand
-    if (opcode <= OP_PUSHDATA4)
-    {
-        unsigned int nSize = 0;
-        if (opcode < OP_PUSHDATA1)
-        {
-            nSize = opcode;
-        }
-        else if (opcode == OP_PUSHDATA1)
-        {
-            if (end - pc < 1)
-                return false;
-            nSize = *pc++;
-        }
-        else if (opcode == OP_PUSHDATA2)
-        {
-            if (end - pc < 2)
-                return false;
-            nSize = ReadLE16(&pc[0]);
-            pc += 2;
-        }
-        else if (opcode == OP_PUSHDATA4)
-        {
-            if (end - pc < 4)
-                return false;
-            nSize = ReadLE32(&pc[0]);
-            pc += 4;
-        }
-        if (end - pc < 0 || (unsigned int)(end - pc) < nSize)
-            return false;
-        if (pvchRet)
-            pvchRet->assign(pc, pc + nSize);
-        pc += nSize;
+        assert(size_bytes != DECODE_ERR);
+        pc += size_bytes;
+        if (pvchRet) pvchRet->assign(pc, pc + data_bytes);
+        pc += data_bytes;
     }
+    opcodeRet = opcode;
 
-    opcodeRet = static_cast<opcodetype>(opcode);
     return true;
 }
 

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -264,30 +264,6 @@ bool CScript::IsPayToAnchor(int version, const std::vector<unsigned char>& progr
         program[1] == 0x73;
 }
 
-bool CScript::IsPayToScriptHash() const
-{
-    // Extra-fast test for pay-to-script-hash CScripts:
-    return (this->size() == 23 &&
-            (*this)[0] == OP_HASH160 &&
-            (*this)[1] == 0x14 &&
-            (*this)[22] == OP_EQUAL);
-}
-
-bool CScript::IsPayToWitnessScriptHash() const
-{
-    // Extra-fast test for pay-to-witness-script-hash CScripts:
-    return (this->size() == 34 &&
-            (*this)[0] == OP_0 &&
-            (*this)[1] == 0x20);
-}
-
-bool CScript::IsPayToTaproot() const
-{
-    return (this->size() == 34 &&
-            (*this)[0] == OP_1 &&
-            (*this)[1] == 0x20);
-}
-
 // A witness program is any valid CScript that consists of a 1-byte push opcode
 // followed by a data push between 2 and 40 bytes.
 bool CScript::IsWitnessProgram(int& version, std::vector<unsigned char>& program) const

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -608,8 +608,6 @@ public:
 
     bool IsWitnessProgram(int& version, std::vector<unsigned char>& program) const;
 
-    bool IsPayToTaproot() const;
-
     /** Called by IsStandardTx and P2SH/BIP62 VerifyScript (which makes it consensus-critical). */
     bool IsPushOnly(const_iterator pc) const;
     bool IsPushOnly() const;

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -534,7 +534,7 @@ public:
      * counted more accurately, assuming they are of the form
      *  ... OP_N CHECKMULTISIG ...
      */
-    unsigned int GetSigOpCount(bool fAccurate) const;
+    unsigned int GetLegacySigOpCount(bool fAccurate) const;
 
     /**
      * Accurately count sigOps, including sigOps in
@@ -550,8 +550,62 @@ public:
      */
     static bool IsPayToAnchor(int version, const std::vector<unsigned char>& program);
 
-    bool IsPayToScriptHash() const;
-    bool IsPayToWitnessScriptHash() const;
+    bool IsPayToPubKeyHash() const noexcept
+    {
+        return size() == 25 &&
+               front() == OP_DUP &&
+               (*this)[1] == OP_HASH160 &&
+               (*this)[2] == 0x14 &&
+               (*this)[23] == OP_EQUALVERIFY &&
+               (*this)[24] == OP_CHECKSIG;
+    }
+
+    bool IsPayToScriptHash() const noexcept
+    {
+        // Extra-fast test for pay-to-script-hash CScripts:
+        return size() == 23 &&
+               front() == OP_HASH160 &&
+               (*this)[1] == 0x14 &&
+               (*this)[22] == OP_EQUAL;
+    }
+
+    bool IsPayToWitnessPubKeyHash() const noexcept
+    {
+        return size() == 22 &&
+               front() == OP_0 &&
+               (*this)[1] == 0x14;
+    }
+
+    bool IsPayToTaproot() const noexcept
+    {
+        return size() == 34 &&
+               front() == OP_1 &&
+               (*this)[1] == 0x20;
+    }
+
+    bool IsPayToWitnessScriptHash() const noexcept
+    {
+        return size() == 34 &&
+               front() == OP_0 &&
+               (*this)[1] == 0x20;
+    }
+
+    bool IsCompressedPayToPubKey() const noexcept
+    {
+        return size() == 35 &&
+               front() == 0x21 &&
+               ((*this)[1] == 0x02 || (*this)[1] == 0x03) &&
+               back() == OP_CHECKSIG;
+    }
+
+    bool IsUncompressedPayToPubKey() const noexcept
+    {
+        return size() == 67 &&
+               front() == 0x41 &&
+               (*this)[1] == 0x04 &&
+               back() == OP_CHECKSIG;
+    }
+
     bool IsWitnessProgram(int& version, std::vector<unsigned char>& program) const;
 
     bool IsPayToTaproot() const;

--- a/src/swiftsync.cpp
+++ b/src/swiftsync.cpp
@@ -1,0 +1,64 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <logging.h>
+#include <streams.h>
+#include <swiftsync.h>
+#include <util/fs.h>
+
+#include <exception>
+#include <string>
+
+void SwiftSyncHints::Load(const std::string& filename)
+{
+    FILE* file = fsbridge::fopen(fs::u8path(filename), "rb");
+    AutoFile hints_file(file);
+    int block_height = 0;
+
+    while (true) {
+        uint16_t num_bits;
+        hints_file >> num_bits;
+        if (num_bits == 0) break; // end-marker
+
+        std::vector<bool> bitmap;
+        uint8_t byte;
+        // read full bytes
+        for (int i = 0; i < num_bits / 8; i++) {
+            hints_file >> byte;
+            for (int bit = 0; bit < 8; bit++) {
+                bitmap.push_back((byte & (1 << bit)) != 0);
+            }
+        }
+        // read remaining bits, if there are any
+        int remaining_bits = num_bits % 8;
+        if (remaining_bits > 0) {
+            hints_file >> byte;
+            for (int bit = 0; bit < remaining_bits; bit++) {
+                bitmap.push_back((byte & (1 << bit)) != 0);
+            }
+        }
+        block_outputs_bitmap[block_height] = bitmap;
+        block_height++;
+        if (block_height % 20000 == 0) {
+            LogInfo("SwiftSync hints bitmap: loaded for %d blocks...\n", block_height);
+        }
+    }
+
+    is_loaded = true;
+}
+
+void SwiftSyncHints::SetCurrentBlockHeight(int block_height)
+{
+    // TODO: don't crash is hints for certain height are not available
+    assert(block_outputs_bitmap.contains(block_height));
+    current_bitmap = &block_outputs_bitmap[block_height];
+    next_bit_pos = 0;
+}
+
+bool SwiftSyncHints::GetNextBit()
+{
+    bool result = current_bitmap->at(next_bit_pos);
+    next_bit_pos++;
+    return result;
+}

--- a/src/swiftsync.cpp
+++ b/src/swiftsync.cpp
@@ -45,6 +45,7 @@ void SwiftSyncHints::Load(const std::string& filename)
         }
     }
 
+    terminal_block_height = block_height-1;
     is_loaded = true;
 }
 

--- a/src/swiftsync.h
+++ b/src/swiftsync.h
@@ -1,0 +1,27 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_SWIFTSYNC_H
+#define BITCOIN_SWIFTSYNC_H
+
+#include <map>
+#include <string>
+#include <vector>
+
+class SwiftSyncHints
+{
+public:
+    void Load(const std::string &filename);
+    bool IsLoaded() const { return is_loaded; }
+    void SetCurrentBlockHeight(int block_height);
+    bool GetNextBit();
+
+private:
+    bool is_loaded{false};
+    std::vector<bool> *current_bitmap;
+    int next_bit_pos;
+    std::map<int, std::vector<bool>> block_outputs_bitmap;
+};
+
+#endif

--- a/src/swiftsync.h
+++ b/src/swiftsync.h
@@ -14,11 +14,14 @@ class SwiftSyncHints
 public:
     void Load(const std::string &filename);
     bool IsLoaded() const { return is_loaded; }
+    int  GetTerminalBlockHeight() const { return terminal_block_height; }
     void SetCurrentBlockHeight(int block_height);
     bool GetNextBit();
+    int  GetNextBitPos() { return next_bit_pos; }
 
 private:
     bool is_loaded{false};
+    int terminal_block_height;
     std::vector<bool> *current_bitmap;
     int next_bit_pos;
     std::map<int, std::vector<bool>> block_outputs_bitmap;

--- a/src/swiftsync.h
+++ b/src/swiftsync.h
@@ -5,26 +5,36 @@
 #ifndef BITCOIN_SWIFTSYNC_H
 #define BITCOIN_SWIFTSYNC_H
 
-#include <map>
-#include <string>
 #include <vector>
+#include <string>
+#include <cstdint>
 
 class SwiftSyncHints
 {
 public:
-    void Load(const std::string &filename);
-    bool IsLoaded() const { return is_loaded; }
-    int  GetTerminalBlockHeight() const { return terminal_block_height; }
+    struct BlockHints
+    {
+        std::vector<uint8_t> spent;
+        uint16_t count;
+
+        explicit BlockHints(uint16_t c) : spent((c + 7) / 8), count(c) {}
+    };
+
+    void Load(const std::string& filename);
+    bool IsLoaded() const noexcept { return is_loaded; }
+    int GetTerminalBlockHeight() const noexcept { return terminal_height; }
+    int GetNextBitPos() const noexcept { return next_bit_pos; }
     void SetCurrentBlockHeight(int block_height);
+
+    bool HasNextBit() const noexcept { return next_bit_pos < current_bitset->count; }
     bool GetNextBit();
-    int  GetNextBitPos() { return next_bit_pos; }
 
 private:
     bool is_loaded{false};
-    int terminal_block_height;
-    std::vector<bool> *current_bitmap;
-    int next_bit_pos;
-    std::map<int, std::vector<bool>> block_outputs_bitmap;
+    int terminal_height{-1};
+    const BlockHints* current_bitset{nullptr};
+    int next_bit_pos{0};
+    std::vector<BlockHints> block_outputs_bitset;
 };
 
 #endif

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -101,6 +101,7 @@ add_executable(test_bitcoin
   sock_tests.cpp
   span_tests.cpp
   streams_tests.cpp
+  swiftsync_tests.cpp
   sync_tests.cpp
   system_ram_tests.cpp
   system_tests.cpp

--- a/src/test/fuzz/script.cpp
+++ b/src/test/fuzz/script.cpp
@@ -98,7 +98,10 @@ FUZZ_TARGET(script, .init = initialize_script)
     (void)script.IsPayToScriptHash();
     (void)script.IsPayToWitnessScriptHash();
     (void)script.IsPushOnly();
-    (void)script.GetSigOpCount(/* fAccurate= */ false);
+    (void)script.GetLegacySigOpCount(/*fAccurate=*/fuzzed_data_provider.ConsumeBool());
+
+    auto script_sig{ConsumeScript(fuzzed_data_provider)};
+    (void)script.GetSigOpCount(script_sig);
 
     {
         const std::vector<uint8_t> bytes = ConsumeRandomLengthByteVector(fuzzed_data_provider);

--- a/src/test/fuzz/script_ops.cpp
+++ b/src/test/fuzz/script_ops.cpp
@@ -43,8 +43,8 @@ FUZZ_TARGET(script_ops)
             });
     }
     const CScript& script = script_mut;
-    (void)script.GetSigOpCount(false);
-    (void)script.GetSigOpCount(true);
+    (void)script.GetLegacySigOpCount(/*fAccurate=*/false);
+    (void)script.GetLegacySigOpCount(/*fAccurate=*/true);
     (void)script.GetSigOpCount(script);
     (void)script.HasValidOps();
     (void)script.IsPayToScriptHash();

--- a/src/test/swiftsync_tests.cpp
+++ b/src/test/swiftsync_tests.cpp
@@ -1,0 +1,68 @@
+// Copyright (c) 2012-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <swiftsync.h>
+#include <streams.h>
+#include <test/util/random.h>
+#include <test/util/setup_common.h>
+#include <util/fs.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(swiftsync_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(bitmap_roundtrip)
+{
+    const fs::path path{m_args.GetDataDirBase() / "swiftsync_bitmap_test.dat"};
+    constexpr uint32_t NUM_BLOCKS{10};
+
+    std::vector<std::vector<bool>> original(NUM_BLOCKS);
+
+    // --- write file --------------------------------------------------------
+    {
+        AutoFile f{fsbridge::fopen(path, "wb")};
+
+        for (uint32_t h{0}; h < NUM_BLOCKS; ++h) {
+            const uint16_t bits = 1 + m_rng.randrange(200);
+            original[h].resize(bits);
+
+            f << bits;
+
+            for (uint16_t i = 0; i < bits; i += 8) {
+                uint8_t byte{0};
+                for (int j = 0; j < 8 && i + j < bits; ++j) {
+                    const bool val = m_rng.randbool();
+                    original[h][i + j] = val;
+                    if (val) byte |= 1 << j;
+                }
+                f << byte;
+            }
+        }
+
+        uint16_t end_marker = 0;
+        f << end_marker;
+    }
+
+    // --- read & verify -----------------------------------------------------
+    {
+        SwiftSyncHints hints;
+        hints.Load(fs::PathToString(path));
+
+        BOOST_CHECK(hints.IsLoaded());
+        BOOST_CHECK_EQUAL(hints.GetTerminalBlockHeight(), NUM_BLOCKS - 1);
+
+        for (uint32_t h{0}; h < NUM_BLOCKS; ++h) {
+            hints.SetCurrentBlockHeight(h);
+            for (size_t i = 0; i < original[h].size(); ++i) {
+                BOOST_CHECK_EQUAL(hints.GetNextBit(), original[h][i]);
+            }
+            // After the expected number of bits a further call MUST throw.
+            BOOST_CHECK_THROW(hints.GetNextBit(), std::out_of_range);
+        }
+    }
+
+    fs::remove(path);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -407,20 +407,110 @@ BOOST_AUTO_TEST_CASE(tx_oversized)
     }
 }
 
-BOOST_AUTO_TEST_CASE(basic_transaction_tests)
+static CMutableTransaction CreateTransaction()
 {
-    // Random real transaction (e2769b09e784f32f62ef849763d4f45b98e07ba658647343b915ff832b110436)
-    unsigned char ch[] = {0x01, 0x00, 0x00, 0x00, 0x01, 0x6b, 0xff, 0x7f, 0xcd, 0x4f, 0x85, 0x65, 0xef, 0x40, 0x6d, 0xd5, 0xd6, 0x3d, 0x4f, 0xf9, 0x4f, 0x31, 0x8f, 0xe8, 0x20, 0x27, 0xfd, 0x4d, 0xc4, 0x51, 0xb0, 0x44, 0x74, 0x01, 0x9f, 0x74, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x8c, 0x49, 0x30, 0x46, 0x02, 0x21, 0x00, 0xda, 0x0d, 0xc6, 0xae, 0xce, 0xfe, 0x1e, 0x06, 0xef, 0xdf, 0x05, 0x77, 0x37, 0x57, 0xde, 0xb1, 0x68, 0x82, 0x09, 0x30, 0xe3, 0xb0, 0xd0, 0x3f, 0x46, 0xf5, 0xfc, 0xf1, 0x50, 0xbf, 0x99, 0x0c, 0x02, 0x21, 0x00, 0xd2, 0x5b, 0x5c, 0x87, 0x04, 0x00, 0x76, 0xe4, 0xf2, 0x53, 0xf8, 0x26, 0x2e, 0x76, 0x3e, 0x2d, 0xd5, 0x1e, 0x7f, 0xf0, 0xbe, 0x15, 0x77, 0x27, 0xc4, 0xbc, 0x42, 0x80, 0x7f, 0x17, 0xbd, 0x39, 0x01, 0x41, 0x04, 0xe6, 0xc2, 0x6e, 0xf6, 0x7d, 0xc6, 0x10, 0xd2, 0xcd, 0x19, 0x24, 0x84, 0x78, 0x9a, 0x6c, 0xf9, 0xae, 0xa9, 0x93, 0x0b, 0x94, 0x4b, 0x7e, 0x2d, 0xb5, 0x34, 0x2b, 0x9d, 0x9e, 0x5b, 0x9f, 0xf7, 0x9a, 0xff, 0x9a, 0x2e, 0xe1, 0x97, 0x8d, 0xd7, 0xfd, 0x01, 0xdf, 0xc5, 0x22, 0xee, 0x02, 0x28, 0x3d, 0x3b, 0x06, 0xa9, 0xd0, 0x3a, 0xcf, 0x80, 0x96, 0x96, 0x8d, 0x7d, 0xbb, 0x0f, 0x91, 0x78, 0xff, 0xff, 0xff, 0xff, 0x02, 0x8b, 0xa7, 0x94, 0x0e, 0x00, 0x00, 0x00, 0x00, 0x19, 0x76, 0xa9, 0x14, 0xba, 0xde, 0xec, 0xfd, 0xef, 0x05, 0x07, 0x24, 0x7f, 0xc8, 0xf7, 0x42, 0x41, 0xd7, 0x3b, 0xc0, 0x39, 0x97, 0x2d, 0x7b, 0x88, 0xac, 0x40, 0x94, 0xa8, 0x02, 0x00, 0x00, 0x00, 0x00, 0x19, 0x76, 0xa9, 0x14, 0xc1, 0x09, 0x32, 0x48, 0x3f, 0xec, 0x93, 0xed, 0x51, 0xf5, 0xfe, 0x95, 0xe7, 0x25, 0x59, 0xf2, 0xcc, 0x70, 0x43, 0xf9, 0x88, 0xac, 0x00, 0x00, 0x00, 0x00, 0x00};
-    std::vector<unsigned char> vch(ch, ch + sizeof(ch) -1);
-    DataStream stream(vch);
+    // Serialized random real transaction (e2769b09e784f32f62ef849763d4f45b98e07ba658647343b915ff832b110436)
+    static constexpr auto ser_tx{"01000000016bff7fcd4f8565ef406dd5d63d4ff94f318fe82027fd4dc451b04474019f74b4000000008c493046022100da0dc6aecefe1e06efdf05773757deb168820930e3b0d03f46f5fcf150bf990c022100d25b5c87040076e4f253f8262e763e2dd51e7ff0be157727c4bc42807f17bd39014104e6c26ef67dc610d2cd192484789a6cf9aea9930b944b7e2db5342b9d9e5b9ff79aff9a2ee1978dd7fd01dfc522ee02283d3b06a9d03acf8096968d7dbb0f9178ffffffff028ba7940e000000001976a914badeecfdef0507247fc8f74241d73bc039972d7b88ac4094a802000000001976a914c10932483fec93ed51f5fe95e72559f2cc7043f988ac0000000000"_hex};
     CMutableTransaction tx;
-    stream >> TX_WITH_WITNESS(tx);
+    DataStream(ser_tx) >> TX_WITH_WITNESS(tx);
+    return tx;
+}
+
+BOOST_AUTO_TEST_CASE(transaction_duplicate_input_test)
+{
+    auto tx{CreateTransaction()};
+
     TxValidationState state;
     BOOST_CHECK_MESSAGE(CheckTransaction(CTransaction(tx), state) && state.IsValid(), "Simple deserialized transaction should be valid.");
 
-    // Check that duplicate txins fail
-    tx.vin.push_back(tx.vin[0]);
-    BOOST_CHECK_MESSAGE(!CheckTransaction(CTransaction(tx), state) || !state.IsValid(), "Transaction with duplicate txins should be invalid.");
+    // Add duplicate input
+    tx.vin.emplace_back(tx.vin[0]);
+    std::ranges::shuffle(tx.vin, m_rng);
+    BOOST_CHECK_MESSAGE(!CheckTransaction(CTransaction(tx), state) || !state.IsValid(), "Transaction with 2 duplicate txins should be invalid.");
+
+    // ... add a valid input for more complex check
+    tx.vin.emplace_back(COutPoint(Txid::FromUint256(uint256{1}), 1));
+    std::ranges::shuffle(tx.vin, m_rng);
+    BOOST_CHECK_MESSAGE(!CheckTransaction(CTransaction(tx), state) || !state.IsValid(), "Transaction with 3 inputs (2 valid, 1 duplicate) should be invalid.");
+}
+
+BOOST_AUTO_TEST_CASE(transaction_duplicate_detection_test)
+{
+    // Randomized testing against hash- and tree-based duplicate check
+    auto reference_duplicate_check_hash{[](const std::vector<CTxIn>& vin) {
+        std::unordered_set<COutPoint, SaltedOutpointHasher> vInOutPoints;
+        for (const auto& txin : vin) {
+            if (!vInOutPoints.insert(txin.prevout).second) {
+                return false;
+            }
+        }
+        return true;
+    }};
+    auto reference_duplicate_check_tree{[](const std::vector<CTxIn>& vin) {
+        std::set<COutPoint> vInOutPoints;
+        for (const auto& txin : vin) {
+            if (!vInOutPoints.insert(txin.prevout).second) {
+                return false;
+            }
+        }
+        return true;
+    }};
+
+    std::vector<Txid> hashes;
+    std::vector<uint32_t> ns;
+    for (int i = 0; i < 10; ++i) {
+        hashes.emplace_back(Txid::FromUint256(m_rng.rand256()));
+        ns.emplace_back(m_rng.rand32());
+    }
+    auto tx{CreateTransaction()};
+    TxValidationState state;
+    for (int i{0}; i < 100; ++i) {
+        if (m_rng.randbool()) {
+            tx.vin.clear();
+        }
+        for (int j{0}, num_inputs{1 + m_rng.randrange(5)}; j < num_inputs; ++j) {
+            if (COutPoint outpoint(hashes[m_rng.randrange(hashes.size())], ns[m_rng.randrange(ns.size())]); !outpoint.IsNull()) {
+                tx.vin.emplace_back(outpoint);
+            }
+        }
+        std::ranges::shuffle(tx.vin, m_rng);
+
+        bool actual{CheckTransaction(CTransaction(tx), state)};
+        BOOST_CHECK_EQUAL(actual, reference_duplicate_check_hash(tx.vin));
+        BOOST_CHECK_EQUAL(actual, reference_duplicate_check_tree(tx.vin));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(transaction_null_prevout_detection_test)
+{
+    // Randomized testing against linear null prevout check
+    auto reference_null_prevout_check_hash{[](const std::vector<CTxIn>& vin) {
+        for (const auto& txin : vin) {
+            if (txin.prevout.IsNull()) {
+                return false;
+            }
+        }
+        return true;
+    }};
+
+    auto tx{CreateTransaction()};
+    TxValidationState state;
+    for (int i{0}; i < 100; ++i) {
+        if (m_rng.randbool()) {
+            tx.vin.clear();
+        }
+        for (int j{0}, num_inputs{1 + m_rng.randrange(5)}; j < num_inputs; ++j) {
+            switch (m_rng.randrange(5)) {
+            case 0: tx.vin.emplace_back(COutPoint()); break;                                               // Null prevout
+            case 1: tx.vin.emplace_back(Txid::FromUint256(uint256::ZERO), m_rng.rand32()); break;          // Null hash, random index
+            case 2: tx.vin.emplace_back(Txid::FromUint256(m_rng.rand256()), COutPoint::NULL_INDEX); break; // Random hash, Null index
+            default: tx.vin.emplace_back(Txid::FromUint256(m_rng.rand256()), m_rng.rand32());              // Random prevout
+            }
+        }
+        std::ranges::shuffle(tx.vin, m_rng);
+
+        BOOST_CHECK_EQUAL(CheckTransaction(CTransaction(tx), state), reference_null_prevout_check_hash(tx.vin));
+    }
 }
 
 BOOST_AUTO_TEST_CASE(test_Get)

--- a/src/test/txvalidation_tests.cpp
+++ b/src/test/txvalidation_tests.cpp
@@ -481,7 +481,7 @@ BOOST_FIXTURE_TEST_CASE(version3_tests, RegTestingSetup)
 
         auto ancestors{pool.CalculateMemPoolAncestors(entry.FromTx(tx_many_sigops), m_limits)};
         // legacy uses fAccurate = false, and the maximum number of multisig keys is used
-        const int64_t total_sigops{static_cast<int64_t>(tx_many_sigops->vin.size()) * static_cast<int64_t>(script_multisig.GetSigOpCount(/*fAccurate=*/false))};
+        const int64_t total_sigops{static_cast<int64_t>(tx_many_sigops->vin.size()) * static_cast<int64_t>(script_multisig.GetLegacySigOpCount(/*fAccurate=*/false))};
         BOOST_CHECK_EQUAL(total_sigops, tx_many_sigops->vin.size() * MAX_PUBKEYS_PER_MULTISIG);
         const int64_t bip141_vsize{GetVirtualTransactionSize(*tx_many_sigops)};
         // Weight limit is not reached...

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -652,3 +652,8 @@ std::ostream& operator<<(std::ostream& os, const Txid& txid) {
 std::ostream& operator<<(std::ostream& os, const Wtxid& wtxid) {
     return os << wtxid.ToString();
 }
+
+std::ostream& operator<<(std::ostream& os, const COutPoint& outpoint)
+{
+    return os << outpoint.hash << ", " << outpoint.n;
+}

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -293,6 +293,7 @@ std::ostream& operator<<(std::ostream& os, const uint160& num);
 std::ostream& operator<<(std::ostream& os, const uint256& num);
 std::ostream& operator<<(std::ostream& os, const Txid& txid);
 std::ostream& operator<<(std::ostream& os, const Wtxid& wtxid);
+std::ostream& operator<<(std::ostream& os, const COutPoint& outpoint);
 // @}
 
 /**

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -17,6 +17,7 @@
 #include <consensus/tx_check.h>
 #include <consensus/tx_verify.h>
 #include <consensus/validation.h>
+#include <crypto/muhash.h>
 #include <cuckoocache.h>
 #include <flatfile.h>
 #include <hash.h>
@@ -44,6 +45,7 @@
 #include <script/script.h>
 #include <script/sigcache.h>
 #include <signet.h>
+#include <swiftsync.h>
 #include <tinyformat.h>
 #include <txdb.h>
 #include <txmempool.h>
@@ -112,6 +114,10 @@ const std::vector<std::string> CHECKLEVEL_DOC {
  *  noticeably interfere with the pruning mechanism.
  * */
 static constexpr int PRUNE_LOCK_BUFFER{10};
+
+static arith_uint256 g_swiftsync_aggregate_hash;
+static HashWriter g_swiftsync_salted_hash_writer;
+SwiftSyncHints g_swiftsync_hints;
 
 TRACEPOINT_SEMAPHORE(validation, block_connected);
 TRACEPOINT_SEMAPHORE(utxocache, flush);
@@ -2092,6 +2098,37 @@ void UpdateCoins(const CTransaction& tx, CCoinsViewCache& inputs, CTxUndo &txund
     AddCoins(inputs, tx, nHeight);
 }
 
+void UpdateCoinsSwiftSync(const CTransaction& tx, CCoinsViewCache& inputs, const CBlockIndex& block_index)
+{
+    bool tx_is_coinbase = tx.IsCoinBase();
+
+    // ignore txs that are overwritten later (duplicate txids)
+    if (IsBIP30Unspendable(block_index) && tx_is_coinbase) return;
+
+    // mark inputs spent (-> simply remove them from swiftsync aggregate hash)
+    if (!tx_is_coinbase) {
+        for (const CTxIn &txin : tx.vin) {
+            auto coin_hash = (HashWriter(g_swiftsync_salted_hash_writer) << txin.prevout).GetSHA256();
+            g_swiftsync_aggregate_hash -= UintToArith256(coin_hash);
+        }
+    }
+    // add outputs
+    const Txid& txid = tx.GetHash();
+    for (size_t i = 0; i < tx.vout.size(); ++i) {
+        // if we already know it gets spent up until the terminal swiftsync block: add it to swiftsync aggregate hash
+        if (!g_swiftsync_hints.GetNextBit()) {
+            if (!tx.vout[i].scriptPubKey.IsUnspendable()) {
+                auto coin_hash = (HashWriter(g_swiftsync_salted_hash_writer) << COutPoint(txid, i)).GetSHA256();
+                g_swiftsync_aggregate_hash += UintToArith256(coin_hash);
+            }
+        // if we know it ends up in the terminal swiftsync block UTXO set: add it as usual
+        } else {
+            bool overwrite = tx_is_coinbase;
+            inputs.AddCoin(COutPoint(txid, i), Coin(tx.vout[i], block_index.nHeight, tx_is_coinbase), overwrite);
+        }
+    }
+}
+
 std::optional<std::pair<ScriptError, std::string>> CScriptCheck::operator()() {
     const CScript &scriptSig = ptxTo->vin[nIn].scriptSig;
     const CScriptWitness *witness = &ptxTo->vin[nIn].scriptWitness;
@@ -2418,6 +2455,11 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     // Special case for the genesis block, skipping connection of its transactions
     // (its coinbase is unspendable)
     if (block_hash == params.GetConsensus().hashGenesisBlock) {
+        g_swiftsync_aggregate_hash = arith_uint256{0};
+        std::array<std::byte, 32> swiftsync_salt;
+        FastRandomContext{}.fillrand(swiftsync_salt);
+        g_swiftsync_salted_hash_writer.write(swiftsync_salt);
+
         if (!fJustCheck)
             view.SetBestBlock(pindex->GetBlockHash());
         return true;
@@ -2584,6 +2626,11 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     CAmount nFees = 0;
     int nInputs = 0;
     int64_t nSigOpsCost = 0;
+    bool use_swiftsync = g_swiftsync_hints.IsLoaded() &&
+        pindex->nHeight <= g_swiftsync_hints.GetTerminalBlockHeight();
+    if (use_swiftsync) {
+        g_swiftsync_hints.SetCurrentBlockHeight(pindex->nHeight);
+    }
     blockundo.vtxundo.reserve(block.vtx.size() - 1);
     for (unsigned int i = 0; i < block.vtx.size(); i++)
     {
@@ -2592,7 +2639,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
 
         nInputs += tx.vin.size();
 
-        if (!tx.IsCoinBase())
+        if (!tx.IsCoinBase() && !use_swiftsync)
         {
             CAmount txfee = 0;
             TxValidationState tx_state;
@@ -2625,17 +2672,19 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
             }
         }
 
-        // GetTransactionSigOpCost counts 3 types of sigops:
-        // * legacy (always)
-        // * p2sh (when P2SH enabled in flags and excludes coinbase)
-        // * witness (when witness enabled in flags and excludes coinbase)
-        nSigOpsCost += GetTransactionSigOpCost(tx, view, flags);
-        if (nSigOpsCost > MAX_BLOCK_SIGOPS_COST) {
-            state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-blk-sigops", "too many sigops");
-            break;
+        if (!use_swiftsync) {
+            // GetTransactionSigOpCost counts 3 types of sigops:
+            // * legacy (always)
+            // * p2sh (when P2SH enabled in flags and excludes coinbase)
+            // * witness (when witness enabled in flags and excludes coinbase)
+            nSigOpsCost += GetTransactionSigOpCost(tx, view, flags);
+            if (nSigOpsCost > MAX_BLOCK_SIGOPS_COST) {
+                state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-blk-sigops", "too many sigops");
+                break;
+            }
         }
 
-        if (!tx.IsCoinBase() && fScriptChecks)
+        if (!tx.IsCoinBase() && fScriptChecks && !use_swiftsync)
         {
             bool fCacheResults = fJustCheck; /* Don't cache results if we're actually connecting blocks (still consult the cache, though) */
             bool tx_ok;
@@ -2661,8 +2710,24 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
         if (i > 0) {
             blockundo.vtxundo.emplace_back();
         }
-        UpdateCoins(tx, view, i == 0 ? undoDummy : blockundo.vtxundo.back(), pindex->nHeight);
+        if (!use_swiftsync) {
+            UpdateCoins(tx, view, i == 0 ? undoDummy : blockundo.vtxundo.back(), pindex->nHeight);
+        } else {
+            UpdateCoinsSwiftSync(tx, view, *pindex);
+        }
     }
+
+    if (pindex->nHeight == g_swiftsync_hints.GetTerminalBlockHeight()) {
+        if (g_swiftsync_aggregate_hash == 0) {
+            LogInfo("*** SwiftSync: aggregate hash check at terminal block height %d succeeded. ***\n", pindex->nHeight);
+        } else {
+            // TODO: find a proper way to signal this error; strictly speaking it's not a
+            // block validation error, most likely the given hints data file was invalid
+            state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "swiftsync-aggregate-hash-not-zero-at-terminal-block",
+                          "fails the aggregate hash check (should be zero at terminal block!)");
+        }
+    }
+
     const auto time_3{SteadyClock::now()};
     m_chainman.time_connect += time_3 - time_2;
     LogDebug(BCLog::BENCH, "      - Connect %u transactions: %.2fms (%.3fms/tx, %.3fms/txin) [%.2fs (%.2fms/blk)]\n", (unsigned)block.vtx.size(),
@@ -2671,10 +2736,12 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
              Ticks<SecondsDouble>(m_chainman.time_connect),
              Ticks<MillisecondsDouble>(m_chainman.time_connect) / m_chainman.num_blocks_total);
 
-    CAmount blockReward = nFees + GetBlockSubsidy(pindex->nHeight, params.GetConsensus());
-    if (block.vtx[0]->GetValueOut() > blockReward && state.IsValid()) {
-        state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-cb-amount",
-                      strprintf("coinbase pays too much (actual=%d vs limit=%d)", block.vtx[0]->GetValueOut(), blockReward));
+    if (!use_swiftsync) {
+        CAmount blockReward = nFees + GetBlockSubsidy(pindex->nHeight, params.GetConsensus());
+        if (block.vtx[0]->GetValueOut() > blockReward && state.IsValid()) {
+            state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-cb-amount",
+                          strprintf("coinbase pays too much (actual=%d vs limit=%d)", block.vtx[0]->GetValueOut(), blockReward));
+        }
     }
     if (control) {
         auto parallel_result = control->Complete();
@@ -2698,7 +2765,8 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
         return true;
     }
 
-    if (!m_blockman.WriteBlockUndo(blockundo, state, *pindex)) {
+    // TODO: potential showstopper: we can't write undo data when we use SwiftSync :(
+    if (!use_swiftsync && !m_blockman.WriteBlockUndo(blockundo, state, *pindex)) {
         return false;
     }
 


### PR DESCRIPTION
WIP prototype, don't use it, just hacked it together quickly to see what we can do, it's nowhere near ready for production use.

---

See https://delvingbitcoin.org/t/swiftsync-speeding-up-ibd-with-pre-generated-hints-poc for detailed discussions.
Hints file can be generated with https://github.com/theStack/swiftsync-hints-gen

---

### Measurements

<details>
<summary>sha256 vs no validation - max dbcache - swiftsync is 30% slower</summary>

```
COMMITS="7d5b69265c099dbde57a1fe77642d01111dda7eb ac22f2e8a30716de52123fe7f041bf94a05fde3a"; \
STOP_HEIGHT=888888; DBCACHE=45000; \
CC=gcc; CXX=g++; \
BASE_DIR="/mnt/my_storage"; DATA_DIR="$BASE_DIR/BitcoinData"; LOG_DIR="$BASE_DIR/logs"; \
(echo ""; for c in $COMMITS; do git fetch origin $c -q && git log -1 --pretty=format:'%h %s' $c || exit 1; done; echo "") && \
hyperfine \
  --sort 'command' \
  --runs 1 \
  --export-json "$BASE_DIR/rdx-${COMMITS// /-}-$STOP_HEIGHT-$DBCACHE-$CC.json" \
  --parameter-list COMMIT ${COMMITS// /,} \
  --prepare "killall bitcoind; rm -f $DATA_DIR/debug.log; git checkout {COMMIT}; git clean -fxd; git reset --hard; \
    cmake -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_WALLET=OFF && cmake --build build -j$(nproc) --target bitcoind && \
    ./build/bin/bitcoind -datadir=$DATA_DIR -stopatheight=$STOP_HEIGHT -dbcache=5000 -printtoconsole=0; sleep 100" \
  --cleanup "cp $DATA_DIR/debug.log $LOG_DIR/debug-{COMMIT}-$(date +%s).log" \
  "COMPILER=$CC ./build/bin/bitcoind -datadir=$DATA_DIR -stopatheight=$STOP_HEIGHT -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 -dbcache=$DBCACHE -swiftsyncfile=../ibd-booster-888888.bin"

7d5b69265c init: use the -swiftsyncfile option
ac22f2e8a3 EXPERIMENT: completely skip spent coin hashing

Benchmark 1: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=888888 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 -dbcache=45000 -swiftsyncfile=../ibd-booster-888888.bin (COMMIT = 7d5b69265c099dbde57a1fe77642d01111dda7eb)
  Time (abs ≡):        10130.540 s               [User: 11125.272 s, System: 494.581 s]
 
Benchmark 2: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=888888 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 -dbcache=45000 -swiftsyncfile=../ibd-booster-888888.bin (COMMIT = ac22f2e8a30716de52123fe7f041bf94a05fde3a)
  Time (abs ≡):        7649.627 s               [User: 8652.434 s, System: 495.903 s]
 
Relative speed comparison
        1.32          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=888888 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 -dbcache=45000 -swiftsyncfile=../ibd-booster-888888.bin (COMMIT = 7d5b69265c099dbde57a1fe77642d01111dda7eb)
        1.00          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=888888 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 -dbcache=45000 -swiftsyncfile=../ibd-booster-888888.bin (COMMIT = ac22f2e8a30716de52123fe7f041bf94a05fde3a)
```

</details>

<details>
<summary>xor + 64 bit siphash vs xor + 64 bit siphash + #32043 - max dbcache - swiftsync is 10% slower (latter is 7% faster than original no sync)</summary>

```
92810b8a9f Use XOR + SipHashUint256Extra
f45ada38b2 Use g_swiftsync_aggregate_hasher + rest of IBD optimizations

Benchmark 1: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=888888 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 -dbcache=45000 -swiftsyncfile=../swiftsync-888888_new.bin (COMMIT = 92810b8a9f94be189e0b902349fdb49804945aba)
  Time (abs ≡):        7830.761 s               [User: 8819.513 s, System: 496.865 s]
 
Benchmark 2: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=888888 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 -dbcache=45000 -swiftsyncfile=../swiftsync-888888_new.bin (COMMIT = f45ada38b2caa8a707d1d6acdf5c552d1cafb192)
  Time (abs ≡):        7108.036 s               [User: 8180.358 s, System: 585.332 s]
```

</details>


The xor + siphash is so fast that it's barely visible in the flames anymore:

![image](https://github.com/user-attachments/assets/cf9bec8b-2508-4154-81cc-4cc6c843fdb2)


With this version I just did a `reindex-chainstate` with xor&siphash swiftsync in 29 minutes until 888888 on my laptop... with profiling enabled.

The next bottleneck is block reading & deserialization:
<img width="1365" alt="image" src="https://github.com/user-attachments/assets/af376169-9df1-48f0-9e08-0d4da5afba93" />

Mostly transaction deserialization, apparently:
<img width="1365" alt="image" src="https://github.com/user-attachments/assets/20830db2-1d5b-46a0-b247-e10e1d122f33" />

And a few other ones that we might speed up by parallelizing them:
<img width="437" alt="image" src="https://github.com/user-attachments/assets/9893315b-f94b-4753-b04e-115094d3f54a" />

------


<details>
<summary>xor + 64 bit siphash + #32043 + default dbcache - 347% faster</summary>

```
COMMITS="6ff1ba00c452486fae8204ca6bdf53460c8f13d0"; \
STOP_HEIGHT=888888; DBCACHE=450; \
CC=gcc; CXX=g++; \
BASE_DIR="/mnt/my_storage"; DATA_DIR="$BASE_DIR/BitcoinData"; LOG_DIR="$BASE_DIR/logs"; \
(echo ""; for c in $COMMITS; do git fetch origin $c -q && git log -1 --pretty=format:'%h %s' $c || exit 1; done; echo "") && \
hyperfine \
  --sort 'command' \
  --runs 2 \
  --export-json "$BASE_DIR/rdx-${COMMITS// /-}-$STOP_HEIGHT-$DBCACHE-$CC.json" \
  --parameter-list COMMIT ${COMMITS// /,} \
  --prepare "killall bitcoind; rm -f $DATA_DIR/debug.log; git checkout {COMMIT}; git clean -fxd; git reset --hard; \
    cmake -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_WALLET=OFF && cmake --build build -j$(nproc) --target bitcoind && \
    ./build/bin/bitcoind -datadir=$DATA_DIR -stopatheight=$STOP_HEIGHT -dbcache=5000 -printtoconsole=0; sleep 100" \
  --cleanup "cp $DATA_DIR/debug.log $LOG_DIR/debug-{COMMIT}-$(date +%s).log" \
  "COMPILER=$CC ./build/bin/bitcoind -datadir=$DATA_DIR -stopatheight=$STOP_HEIGHT -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 -dbcache=$DBCACHE -swiftsyncfile=../swiftsync-888888_new.bin"

6f5f6c822e init: add -swiftsyncfile option
6ff1ba00c4 Disable bip30 checks during use_swiftsync

Benchmark 1: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=888888 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 -dbcache=450 -swiftsyncfile=../ibd-booster-888888.bin (COMMIT = 6f5f6c822ec6de7c785672728025bae0b603a60e)
  Time (mean ± σ):     20065.545 s ± 118.648 s    [User: 35517.056 s, System: 2622.277 s]
  Range (min … max):   19981.647 s … 20149.442 s    2 runs

Benchmark 2: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=888888 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 -dbcache=450 -swiftsyncfile=../swiftsync-888888_new.bin (COMMIT = 6ff1ba00c452486fae8204ca6bdf53460c8f13d0)
  Time (mean ± σ):     5773.543 s ±  1.689 s    [User: 7226.366 s, System: 481.885 s]
  Range (min … max):   5772.348 s … 5774.738 s    2 runs

```

</details>