### PR TITLE
blocks: reduce header hash calculations

### DIFF
--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -55,7 +55,7 @@ static void DeserializeAndCheckBlockTest(benchmark::Bench& bench)
         assert(rewound);
 
         BlockValidationState validationState;
-        bool checked = CheckBlock(block, validationState, chainParams->GetConsensus());
+        bool checked = CheckBlock(block, block.GetHash(), validationState, chainParams->GetConsensus());
         assert(checked);
     });
 }

--- a/src/bench/duplicate_inputs.cpp
+++ b/src/bench/duplicate_inputs.cpp
@@ -68,10 +68,10 @@ static void DuplicateInputs(benchmark::Bench& bench)
     block.vtx.push_back(MakeTransactionRef(std::move(naughtyTx)));
 
     block.hashMerkleRoot = BlockMerkleRoot(block);
-
+    const auto block_hash{block.GetHash()};
     bench.run([&] {
         BlockValidationState cvstate{};
-        assert(!CheckBlock(block, cvstate, chainparams.GetConsensus(), false, false));
+        assert(!CheckBlock(block, block_hash, cvstate, chainparams.GetConsensus(), false, false));
         assert(cvstate.GetRejectReason() == "bad-txns-inputs-duplicate");
     });
 }

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -184,11 +184,10 @@ bool PartiallyDownloadedBlock::IsTxAvailable(size_t index) const
     return txn_available[index] != nullptr;
 }
 
-ReadStatus PartiallyDownloadedBlock::FillBlock(CBlock& block, const std::vector<CTransactionRef>& vtx_missing, bool segwit_active)
+ReadStatus PartiallyDownloadedBlock::FillBlock(CBlock& block, const uint256& hash, const std::vector<CTransactionRef>& vtx_missing, bool segwit_active)
 {
     if (header.IsNull()) return READ_STATUS_INVALID;
 
-    uint256 hash = header.GetHash();
     block = header;
     block.vtx.resize(txn_available.size());
 

--- a/src/blockencodings.h
+++ b/src/blockencodings.h
@@ -148,7 +148,7 @@ public:
     ReadStatus InitData(const CBlockHeaderAndShortTxIDs& cmpctblock, const std::vector<std::pair<Wtxid, CTransactionRef>>& extra_txn);
     bool IsTxAvailable(size_t index) const;
     // segwit_active enforces witness mutation checks just before reporting a healthy status
-    ReadStatus FillBlock(CBlock& block, const std::vector<CTransactionRef>& vtx_missing, bool segwit_active);
+    ReadStatus FillBlock(CBlock& block, const uint256& hash, const std::vector<CTransactionRef>& vtx_missing, bool segwit_active);
 };
 
 #endif // BITCOIN_BLOCKENCODINGS_H

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -984,7 +984,7 @@ btck_ChainstateManager* btck_chainstate_manager_create(
 
         for (Chainstate* chainstate : WITH_LOCK(chainman->GetMutex(), return chainman->GetAll())) {
             BlockValidationState state;
-            if (!chainstate->ActivateBestChain(state, nullptr)) {
+            if (!chainstate->ActivateBestChain(state)) {
                 LogError("Failed to connect best block: %s", state.ToString());
                 return nullptr;
             }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3283,7 +3283,6 @@ void PeerManagerImpl::ProcessGetCFCheckPt(CNode& node, Peer& peer, DataStream& v
 
 void PeerManagerImpl::ProcessBlock(CNode& node, const std::shared_ptr<const CBlock>& block, const uint256& block_hash, bool force_processing, bool min_pow_checked)
 {
-    Assert(block->GetHash() == block_hash);
     bool new_block{false};
     m_chainman.ProcessNewBlock(block, force_processing, min_pow_checked, &new_block);
     if (new_block) {
@@ -4559,7 +4558,6 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
             // we have a chain with at least the minimum chain work), and we ignore
             // compact blocks with less work than our tip, it is safe to treat
             // reconstructed compact blocks as having been requested.
-            Assert(blockhash == pblock->GetHash());
             ProcessBlock(pfrom, pblock, blockhash, /*force_processing=*/true, /*min_pow_checked=*/true);
             LOCK(cs_main); // hold cs_main for CBlockIndex::IsValid()
             if (pindex->IsValid(BLOCK_VALID_TRANSACTIONS)) {

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -1274,7 +1274,7 @@ void ImportBlocks(ChainstateManager& chainman, std::span<const fs::path> import_
     // the relevant pointers before the ABC call.
     for (Chainstate* chainstate : WITH_LOCK(::cs_main, return chainman.GetAll())) {
         BlockValidationState state;
-        if (!chainstate->ActivateBestChain(state, nullptr)) {
+        if (!chainstate->ActivateBestChain(state)) {
             chainman.GetNotifications().fatalError(strprintf(_("Failed to connect best block (%s)."), state.ToString()));
             return;
         }

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -1028,7 +1028,7 @@ bool BlockManager::ReadBlock(CBlock& block, const FlatFilePos& pos, const std::o
     }
 
     // Signet only: check block solution
-    if (GetConsensus().signet_blocks && !CheckSignetBlockSolution(block, GetConsensus())) {
+    if (GetConsensus().signet_blocks && !CheckSignetBlockSolution(block, block_hash, GetConsensus())) {
         LogError("Errors in block solution at %s while reading block", pos.ToString());
         return false;
     }

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -975,7 +975,7 @@ public:
     bool checkBlock(const CBlock& block, const node::BlockCheckOptions& options, std::string& reason, std::string& debug) override
     {
         LOCK(chainman().GetMutex());
-        BlockValidationState state{TestBlockValidity(chainman().ActiveChainstate(), block, /*check_pow=*/options.check_pow, /*=check_merkle_root=*/options.check_merkle_root)};
+        BlockValidationState state{TestBlockValidity(chainman().ActiveChainstate(), block, block.GetHash(), /*check_pow=*/options.check_pow, /*=check_merkle_root=*/options.check_merkle_root)};
         reason = state.GetRejectReason();
         debug = state.GetDebugMessage();
         return state.IsValid();

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -180,7 +180,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock()
     pblock->nNonce         = 0;
 
     if (m_options.test_block_validity) {
-        if (BlockValidationState state{TestBlockValidity(m_chainstate, *pblock, /*check_pow=*/false, /*check_merkle_root=*/false)}; !state.IsValid()) {
+        if (BlockValidationState state{TestBlockValidity(m_chainstate, *pblock, pblock->GetHash(), /*check_pow=*/false, /*check_merkle_root=*/false)}; !state.IsValid()) {
             throw std::runtime_error(strprintf("TestBlockValidity failed: %s", state.ToString()));
         }
     }

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -388,7 +388,7 @@ static RPCHelpMan generateblock()
         block.vtx.insert(block.vtx.end(), txs.begin(), txs.end());
         RegenerateCommitments(block, chainman);
 
-        if (BlockValidationState state{TestBlockValidity(chainman.ActiveChainstate(), block, /*check_pow=*/false, /*check_merkle_root=*/false)}; !state.IsValid()) {
+        if (BlockValidationState state{TestBlockValidity(chainman.ActiveChainstate(), block, block.GetHash(), /*check_pow=*/false, /*check_merkle_root=*/false)}; !state.IsValid()) {
             throw JSONRPCError(RPC_VERIFY_ERROR, strprintf("TestBlockValidity failed: %s", state.ToString()));
         }
     }
@@ -747,7 +747,7 @@ static RPCHelpMan getblocktemplate()
                 return "duplicate-inconclusive";
             }
 
-            return BIP22ValidationResult(TestBlockValidity(chainman.ActiveChainstate(), block, /*check_pow=*/false, /*check_merkle_root=*/true)); // TODO
+            return BIP22ValidationResult(TestBlockValidity(chainman.ActiveChainstate(), block, hash, /*check_pow=*/false, /*check_merkle_root=*/true)); // TODO
         }
 
         const UniValue& aClientRules = oparam.find_value("rules");

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -747,7 +747,7 @@ static RPCHelpMan getblocktemplate()
                 return "duplicate-inconclusive";
             }
 
-            return BIP22ValidationResult(TestBlockValidity(chainman.ActiveChainstate(), block, /*check_pow=*/false, /*check_merkle_root=*/true));
+            return BIP22ValidationResult(TestBlockValidity(chainman.ActiveChainstate(), block, /*check_pow=*/false, /*check_merkle_root=*/true)); // TODO
         }
 
         const UniValue& aClientRules = oparam.find_value("rules");

--- a/src/signet.cpp
+++ b/src/signet.cpp
@@ -124,6 +124,7 @@ std::optional<SignetTxs> SignetTxs::Create(const CBlock& block, const CScript& c
 // Signet block solution checker
 bool CheckSignetBlockSolution(const CBlock& block, const uint256& block_hash, const Consensus::Params& consensusParams)
 {
+    Assert(block_hash == block.GetHash());
     if (block_hash == consensusParams.hashGenesisBlock) {
         // genesis block solution is always valid
         return true;

--- a/src/signet.cpp
+++ b/src/signet.cpp
@@ -122,9 +122,9 @@ std::optional<SignetTxs> SignetTxs::Create(const CBlock& block, const CScript& c
 }
 
 // Signet block solution checker
-bool CheckSignetBlockSolution(const CBlock& block, const Consensus::Params& consensusParams)
+bool CheckSignetBlockSolution(const CBlock& block, const uint256& block_hash, const Consensus::Params& consensusParams)
 {
-    if (block.GetHash() == consensusParams.hashGenesisBlock) {
+    if (block_hash == consensusParams.hashGenesisBlock) {
         // genesis block solution is always valid
         return true;
     }

--- a/src/signet.cpp
+++ b/src/signet.cpp
@@ -124,7 +124,6 @@ std::optional<SignetTxs> SignetTxs::Create(const CBlock& block, const CScript& c
 // Signet block solution checker
 bool CheckSignetBlockSolution(const CBlock& block, const uint256& block_hash, const Consensus::Params& consensusParams)
 {
-    Assert(block_hash == block.GetHash());
     if (block_hash == consensusParams.hashGenesisBlock) {
         // genesis block solution is always valid
         return true;

--- a/src/signet.h
+++ b/src/signet.h
@@ -14,7 +14,7 @@
 /**
  * Extract signature and check whether a block has a valid solution
  */
-bool CheckSignetBlockSolution(const CBlock& block, const Consensus::Params& consensusParams);
+bool CheckSignetBlockSolution(const CBlock& block, const uint256& block_hash, const Consensus::Params& consensusParams);
 
 /**
  * Generate the signet tx corresponding to the given block

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -95,21 +95,21 @@ BOOST_AUTO_TEST_CASE(SimpleRoundTripTest)
         CBlock block2;
         {
             PartiallyDownloadedBlock tmp = partialBlock;
-            BOOST_CHECK(partialBlock.FillBlock(block2, {}, /*segwit_active=*/true) == READ_STATUS_INVALID); // No transactions
+            BOOST_CHECK(partialBlock.FillBlock(block2, block2.GetHash(), {}, /*segwit_active=*/true) == READ_STATUS_INVALID); // No transactions
             partialBlock = tmp;
         }
 
         // Wrong transaction
         {
             PartiallyDownloadedBlock tmp = partialBlock;
-            partialBlock.FillBlock(block2, {block.vtx[2]}, /*segwit_active=*/true); // Current implementation doesn't check txn here, but don't require that
+            partialBlock.FillBlock(block2, block2.GetHash(), {block.vtx[2]}, /*segwit_active=*/true); // Current implementation doesn't check txn here, but don't require that
             partialBlock = tmp;
         }
         bool mutated;
         BOOST_CHECK(block.hashMerkleRoot != BlockMerkleRoot(block2, &mutated));
 
         CBlock block3;
-        BOOST_CHECK(partialBlock.FillBlock(block3, {block.vtx[1]}, /*segwit_active=*/true) == READ_STATUS_OK);
+        BOOST_CHECK(partialBlock.FillBlock(block3, block3.GetHash(), {block.vtx[1]}, /*segwit_active=*/true) == READ_STATUS_OK);
         BOOST_CHECK_EQUAL(block.GetHash().ToString(), block3.GetHash().ToString());
         BOOST_CHECK_EQUAL(block.hashMerkleRoot.ToString(), BlockMerkleRoot(block3, &mutated).ToString());
         BOOST_CHECK(!mutated);
@@ -182,14 +182,14 @@ BOOST_AUTO_TEST_CASE(NonCoinbasePreforwardRTTest)
         CBlock block2;
         {
             PartiallyDownloadedBlock tmp = partialBlock;
-            BOOST_CHECK(partialBlock.FillBlock(block2, {}, /*segwit_active=*/true) == READ_STATUS_INVALID); // No transactions
+            BOOST_CHECK(partialBlock.FillBlock(block2, block2.GetHash(), {}, /*segwit_active=*/true) == READ_STATUS_INVALID); // No transactions
             partialBlock = tmp;
         }
 
         // Wrong transaction
         {
             PartiallyDownloadedBlock tmp = partialBlock;
-            partialBlock.FillBlock(block2, {block.vtx[1]}, /*segwit_active=*/true); // Current implementation doesn't check txn here, but don't require that
+            partialBlock.FillBlock(block2, block2.GetHash(), {block.vtx[1]}, /*segwit_active=*/true); // Current implementation doesn't check txn here, but don't require that
             partialBlock = tmp;
         }
         BOOST_CHECK_EQUAL(pool.get(block.vtx[2]->GetHash()).use_count(), SHARED_TX_OFFSET + 2); // +2 because of partialBlock and block2
@@ -198,7 +198,7 @@ BOOST_AUTO_TEST_CASE(NonCoinbasePreforwardRTTest)
 
         CBlock block3;
         PartiallyDownloadedBlock partialBlockCopy = partialBlock;
-        BOOST_CHECK(partialBlock.FillBlock(block3, {block.vtx[0]}, /*segwit_active=*/true) == READ_STATUS_OK);
+        BOOST_CHECK(partialBlock.FillBlock(block3, block3.GetHash(), {block.vtx[0]}, /*segwit_active=*/true) == READ_STATUS_OK);
         BOOST_CHECK_EQUAL(block.GetHash().ToString(), block3.GetHash().ToString());
         BOOST_CHECK_EQUAL(block.hashMerkleRoot.ToString(), BlockMerkleRoot(block3, &mutated).ToString());
         BOOST_CHECK(!mutated);
@@ -252,7 +252,7 @@ BOOST_AUTO_TEST_CASE(SufficientPreforwardRTTest)
 
         CBlock block2;
         PartiallyDownloadedBlock partialBlockCopy = partialBlock;
-        BOOST_CHECK(partialBlock.FillBlock(block2, {}, /*segwit_active=*/true) == READ_STATUS_OK);
+        BOOST_CHECK(partialBlock.FillBlock(block2, block2.GetHash(), {}, /*segwit_active=*/true) == READ_STATUS_OK);
         BOOST_CHECK_EQUAL(block.GetHash().ToString(), block2.GetHash().ToString());
         bool mutated;
         BOOST_CHECK_EQUAL(block.hashMerkleRoot.ToString(), BlockMerkleRoot(block2, &mutated).ToString());
@@ -300,7 +300,7 @@ BOOST_AUTO_TEST_CASE(EmptyBlockRoundTripTest)
 
         CBlock block2;
         std::vector<CTransactionRef> vtx_missing;
-        BOOST_CHECK(partialBlock.FillBlock(block2, vtx_missing, /*segwit_active=*/true) == READ_STATUS_OK);
+        BOOST_CHECK(partialBlock.FillBlock(block2, block2.GetHash(), vtx_missing, /*segwit_active=*/true) == READ_STATUS_OK);
         BOOST_CHECK_EQUAL(block.GetHash().ToString(), block2.GetHash().ToString());
         BOOST_CHECK_EQUAL(block.hashMerkleRoot.ToString(), BlockMerkleRoot(block2, &mutated).ToString());
         BOOST_CHECK(!mutated);

--- a/src/test/coinstatsindex_tests.cpp
+++ b/src/test/coinstatsindex_tests.cpp
@@ -93,7 +93,7 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_unclean_shutdown, TestChain100Setup)
 
             LOCK(cs_main);
             BlockValidationState state;
-            BOOST_CHECK(CheckBlock(block, state, params.GetConsensus()));
+            BOOST_CHECK(CheckBlock(block, block.GetHash(), state, params.GetConsensus()));
             BOOST_CHECK(m_node.chainman->AcceptBlock(new_block, state, &new_block_index, true, nullptr, nullptr, true));
             CCoinsViewCache view(&chainstate.CoinsTip());
             BOOST_CHECK(chainstate.ConnectBlock(block, state, new_block_index, view));

--- a/src/test/coinstatsindex_tests.cpp
+++ b/src/test/coinstatsindex_tests.cpp
@@ -94,7 +94,7 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_unclean_shutdown, TestChain100Setup)
             LOCK(cs_main);
             BlockValidationState state;
             BOOST_CHECK(CheckBlock(block, block.GetHash(), state, params.GetConsensus()));
-            BOOST_CHECK(m_node.chainman->AcceptBlock(new_block, state, &new_block_index, true, nullptr, nullptr, true));
+            BOOST_CHECK(m_node.chainman->AcceptBlock(new_block, new_block->GetHash(), state, &new_block_index, true, nullptr, nullptr, true));
             CCoinsViewCache view(&chainstate.CoinsTip());
             BOOST_CHECK(chainstate.ConnectBlock(block, state, new_block_index, view));
         }

--- a/src/test/fuzz/block.cpp
+++ b/src/test/fuzz/block.cpp
@@ -32,18 +32,19 @@ FUZZ_TARGET(block, .init = initialize_block)
         return;
     }
     const Consensus::Params& consensus_params = Params().GetConsensus();
+    const uint256 block_hash = block.GetHash();
     BlockValidationState validation_state_pow_and_merkle;
-    const bool valid_incl_pow_and_merkle = CheckBlock(block, validation_state_pow_and_merkle, consensus_params, /* fCheckPOW= */ true, /* fCheckMerkleRoot= */ true);
+    const bool valid_incl_pow_and_merkle = CheckBlock(block, block_hash, validation_state_pow_and_merkle, consensus_params, /* fCheckPOW= */ true, /* fCheckMerkleRoot= */ true);
     assert(validation_state_pow_and_merkle.IsValid() || validation_state_pow_and_merkle.IsInvalid() || validation_state_pow_and_merkle.IsError());
     (void)validation_state_pow_and_merkle.Error("");
     BlockValidationState validation_state_pow;
-    const bool valid_incl_pow = CheckBlock(block, validation_state_pow, consensus_params, /* fCheckPOW= */ true, /* fCheckMerkleRoot= */ false);
+    const bool valid_incl_pow = CheckBlock(block, block_hash, validation_state_pow, consensus_params, /* fCheckPOW= */ true, /* fCheckMerkleRoot= */ false);
     assert(validation_state_pow.IsValid() || validation_state_pow.IsInvalid() || validation_state_pow.IsError());
     BlockValidationState validation_state_merkle;
-    const bool valid_incl_merkle = CheckBlock(block, validation_state_merkle, consensus_params, /* fCheckPOW= */ false, /* fCheckMerkleRoot= */ true);
+    const bool valid_incl_merkle = CheckBlock(block, block_hash, validation_state_merkle, consensus_params, /* fCheckPOW= */ false, /* fCheckMerkleRoot= */ true);
     assert(validation_state_merkle.IsValid() || validation_state_merkle.IsInvalid() || validation_state_merkle.IsError());
     BlockValidationState validation_state_none;
-    const bool valid_incl_none = CheckBlock(block, validation_state_none, consensus_params, /* fCheckPOW= */ false, /* fCheckMerkleRoot= */ false);
+    const bool valid_incl_none = CheckBlock(block, block_hash, validation_state_none, consensus_params, /* fCheckPOW= */ false, /* fCheckMerkleRoot= */ false);
     assert(validation_state_none.IsValid() || validation_state_none.IsInvalid() || validation_state_none.IsError());
     if (valid_incl_pow_and_merkle) {
         assert(valid_incl_pow && valid_incl_merkle && valid_incl_none);

--- a/src/test/fuzz/partially_downloaded_block.cpp
+++ b/src/test/fuzz/partially_downloaded_block.cpp
@@ -118,7 +118,7 @@ FUZZ_TARGET(partially_downloaded_block, .init = initialize_pdb)
     pdb.m_check_block_mutated_mock = FuzzedIsBlockMutated(fail_block_mutated);
 
     CBlock reconstructed_block;
-    auto fill_status{pdb.FillBlock(reconstructed_block, missing, segwit_active)};
+    auto fill_status{pdb.FillBlock(reconstructed_block, reconstructed_block.GetHash(), missing, segwit_active)};
     switch (fill_status) {
     case READ_STATUS_OK:
         assert(!skipped_missing);

--- a/src/test/fuzz/signet.cpp
+++ b/src/test/fuzz/signet.cpp
@@ -29,6 +29,6 @@ FUZZ_TARGET(signet, .init = initialize_signet)
     if (!block) {
         return;
     }
-    (void)CheckSignetBlockSolution(*block, Params().GetConsensus());
+    (void)CheckSignetBlockSolution(*block, block->GetHash(), Params().GetConsensus());
     (void)SignetTxs::Create(*block, ConsumeScript(fuzzed_data_provider));
 }

--- a/src/test/validation_chainstate_tests.cpp
+++ b/src/test/validation_chainstate_tests.cpp
@@ -124,22 +124,23 @@ BOOST_FIXTURE_TEST_CASE(chainstate_update_tip, TestChain100Setup)
     const CChainParams& chainparams = Params();
     bool newblock = false;
 
+    auto block_hash{pblockone->GetHash()};
     // TODO: much of this is inlined from ProcessNewBlock(); just reuse PNB()
     // once it is changed to support multiple chainstates.
     {
         LOCK(::cs_main);
-        bool checked = CheckBlock(*pblockone, pblockone->GetHash(), state, chainparams.GetConsensus());
+        bool checked = CheckBlock(*pblockone, block_hash, state, chainparams.GetConsensus());
         BOOST_CHECK(checked);
         bool accepted = chainman.AcceptBlock(
-            pblockone, state, &pindex, true, nullptr, &newblock, true);
+            pblockone, block_hash, state, &pindex, true, nullptr, &newblock, true);
         BOOST_CHECK(accepted);
     }
 
     // UpdateTip is called here
-    bool block_added = background_cs.ActivateBestChain(state, pblockone);
+    bool block_added = background_cs.ActivateBestChain(state, pblockone, block_hash);
 
     // Ensure tip is as expected
-    BOOST_CHECK_EQUAL(background_cs.m_chain.Tip()->GetBlockHash(), pblockone->GetHash());
+    BOOST_CHECK_EQUAL(background_cs.m_chain.Tip()->GetBlockHash(), block_hash);
 
     // get_notify_tip() should be unchanged after adding a block to the background
     // validation chain.

--- a/src/test/validation_chainstate_tests.cpp
+++ b/src/test/validation_chainstate_tests.cpp
@@ -128,7 +128,7 @@ BOOST_FIXTURE_TEST_CASE(chainstate_update_tip, TestChain100Setup)
     // once it is changed to support multiple chainstates.
     {
         LOCK(::cs_main);
-        bool checked = CheckBlock(*pblockone, state, chainparams.GetConsensus());
+        bool checked = CheckBlock(*pblockone, pblockone->GetHash(), state, chainparams.GetConsensus());
         BOOST_CHECK(checked);
         bool accepted = chainman.AcceptBlock(
             pblockone, state, &pindex, true, nullptr, &newblock, true);

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -81,7 +81,7 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager, TestChain100Setup)
         c2.LoadChainTip();
     }
     BlockValidationState _;
-    BOOST_CHECK(c2.ActivateBestChain(_, nullptr));
+    BOOST_CHECK(c2.ActivateBestChain(_));
 
     BOOST_CHECK_EQUAL(manager.SnapshotBlockhash().value(), snapshot_blockhash);
     BOOST_CHECK(manager.IsSnapshotActive());

--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -77,7 +77,7 @@ BOOST_AUTO_TEST_CASE(signet_parse_tests)
 
     // empty block is invalid
     BOOST_CHECK(!SignetTxs::Create(block, challenge));
-    BOOST_CHECK(!CheckSignetBlockSolution(block, signet_params->GetConsensus()));
+    BOOST_CHECK(!CheckSignetBlockSolution(block, block.GetHash(), signet_params->GetConsensus()));
 
     // no witness commitment
     CMutableTransaction cb;
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(signet_parse_tests)
     block.vtx.push_back(MakeTransactionRef(cb));
     block.vtx.push_back(MakeTransactionRef(cb)); // Add dummy tx to exercise merkle root code
     BOOST_CHECK(!SignetTxs::Create(block, challenge));
-    BOOST_CHECK(!CheckSignetBlockSolution(block, signet_params->GetConsensus()));
+    BOOST_CHECK(!CheckSignetBlockSolution(block, block.GetHash(), signet_params->GetConsensus()));
 
     // no header is treated valid
     std::vector<uint8_t> witness_commitment_section_141{0xaa, 0x21, 0xa9, 0xed};
@@ -95,14 +95,14 @@ BOOST_AUTO_TEST_CASE(signet_parse_tests)
     cb.vout.at(0).scriptPubKey = CScript{} << OP_RETURN << witness_commitment_section_141;
     block.vtx.at(0) = MakeTransactionRef(cb);
     BOOST_CHECK(SignetTxs::Create(block, challenge));
-    BOOST_CHECK(CheckSignetBlockSolution(block, signet_params->GetConsensus()));
+    BOOST_CHECK(CheckSignetBlockSolution(block, block.GetHash(), signet_params->GetConsensus()));
 
     // no data after header, valid
     std::vector<uint8_t> witness_commitment_section_325{0xec, 0xc7, 0xda, 0xa2};
     cb.vout.at(0).scriptPubKey = CScript{} << OP_RETURN << witness_commitment_section_141 << witness_commitment_section_325;
     block.vtx.at(0) = MakeTransactionRef(cb);
     BOOST_CHECK(SignetTxs::Create(block, challenge));
-    BOOST_CHECK(CheckSignetBlockSolution(block, signet_params->GetConsensus()));
+    BOOST_CHECK(CheckSignetBlockSolution(block, block.GetHash(), signet_params->GetConsensus()));
 
     // Premature end of data, invalid
     witness_commitment_section_325.push_back(0x01);
@@ -110,21 +110,21 @@ BOOST_AUTO_TEST_CASE(signet_parse_tests)
     cb.vout.at(0).scriptPubKey = CScript{} << OP_RETURN << witness_commitment_section_141 << witness_commitment_section_325;
     block.vtx.at(0) = MakeTransactionRef(cb);
     BOOST_CHECK(!SignetTxs::Create(block, challenge));
-    BOOST_CHECK(!CheckSignetBlockSolution(block, signet_params->GetConsensus()));
+    BOOST_CHECK(!CheckSignetBlockSolution(block, block.GetHash(), signet_params->GetConsensus()));
 
     // has data, valid
     witness_commitment_section_325.push_back(0x00);
     cb.vout.at(0).scriptPubKey = CScript{} << OP_RETURN << witness_commitment_section_141 << witness_commitment_section_325;
     block.vtx.at(0) = MakeTransactionRef(cb);
     BOOST_CHECK(SignetTxs::Create(block, challenge));
-    BOOST_CHECK(CheckSignetBlockSolution(block, signet_params->GetConsensus()));
+    BOOST_CHECK(CheckSignetBlockSolution(block, block.GetHash(), signet_params->GetConsensus()));
 
     // Extraneous data, invalid
     witness_commitment_section_325.push_back(0x00);
     cb.vout.at(0).scriptPubKey = CScript{} << OP_RETURN << witness_commitment_section_141 << witness_commitment_section_325;
     block.vtx.at(0) = MakeTransactionRef(cb);
     BOOST_CHECK(!SignetTxs::Create(block, challenge));
-    BOOST_CHECK(!CheckSignetBlockSolution(block, signet_params->GetConsensus()));
+    BOOST_CHECK(!CheckSignetBlockSolution(block, block.GetHash(), signet_params->GetConsensus()));
 }
 
 //! Test retrieval of valid assumeutxo values.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4035,7 +4035,7 @@ bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensu
         return false;
 
     // Signet only: check block solution
-    if (consensusParams.signet_blocks && fCheckPOW && !CheckSignetBlockSolution(block, consensusParams)) {
+    if (consensusParams.signet_blocks && fCheckPOW && !CheckSignetBlockSolution(block, block.GetHash(), consensusParams)) {
         return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-signet-blksig", "signet block signature validation failure");
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3488,7 +3488,6 @@ bool Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<
                 // in case snapshot validation is completed during ActivateBestChainStep, the
                 // result of GetRole() changes from BACKGROUND to NORMAL.
                 const ChainstateRole chainstate_role{this->GetRole()};
-                Assert(block_hash == ((pblock == nullptr) ? std::nullopt : std::optional{pblock->GetHash()}));
                 if (!ActivateBestChainStep(state, pindexMostWork, pblock && block_hash == pindexMostWork->GetBlockHash() ? pblock : nullBlockPtr, fInvalidFound, connectTrace)) {
                     // A system error occurred
                     return false;
@@ -3935,7 +3934,6 @@ void ChainstateManager::ReceivedBlockTransactions(const CBlock& block, CBlockInd
 
 static bool CheckBlockHeader(const CBlockHeader& block, const uint256& block_hash, BlockValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true)
 {
-    Assert(block.GetHash() == block_hash);
     // Check proof of work matches claimed amount
     if (fCheckPOW && !CheckProofOfWork(block_hash, block.nBits, consensusParams))
         return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, "high-hash", "proof of work failed");
@@ -4027,7 +4025,6 @@ static bool CheckWitnessMalleation(const CBlock& block, bool expect_witness_comm
 bool CheckBlock(const CBlock& block, const uint256& block_hash, BlockValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW, bool fCheckMerkleRoot)
 {
     // These are checks that are independent of context.
-    Assert(block_hash == block.GetHash());
     if (block.fChecked)
         return true;
 
@@ -4295,7 +4292,6 @@ bool ChainstateManager::AcceptBlockHeader(const CBlockHeader& block, const uint2
     AssertLockHeld(cs_main);
 
     // Check for duplicate
-    Assert(block.GetHash() == hash);
     BlockMap::iterator miSelf{m_blockman.m_block_index.find(hash)};
     if (hash != GetConsensus().hashGenesisBlock) {
         if (miSelf != m_blockman.m_block_index.end()) {
@@ -4403,7 +4399,6 @@ void ChainstateManager::ReportHeadersPresync(const arith_uint256& work, int64_t 
 /** Store block on disk. If dbp is non-nullptr, the file is known to already reside on disk */
 bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, const uint256& block_hash, BlockValidationState& state, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock, bool min_pow_checked)
 {
-    Assert(pblock->GetHash() == block_hash);
     const CBlock& block = *pblock;
 
     if (fNewBlock) *fNewBlock = false;
@@ -4454,7 +4449,6 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
 
     const CChainParams& params{GetParams()};
 
-    Assert(block.GetHash() == pindex->GetBlockHash());
     if (!CheckBlock(block, pindex->GetBlockHash(), state, params.GetConsensus()) ||
         !ContextualCheckBlock(block, state, *this, pindex->pprev)) {
         if (Assume(state.IsInvalid())) {
@@ -4590,7 +4584,6 @@ BlockValidationState TestBlockValidity(
     }
 
     // For signets CheckBlock() verifies the challenge iff fCheckPow is set.
-    Assert(block_hash == block.GetHash());
     if (!CheckBlock(block, block_hash, state, chainstate.m_chainman.GetConsensus(), /*fCheckPow=*/check_pow, /*fCheckMerkleRoot=*/check_merkle_root)) {
         // This should never happen, but belt-and-suspenders don't approve the
         // block if it does.
@@ -4771,7 +4764,6 @@ VerifyDBResult CVerifyDB::VerifyDB(
             return VerifyDBResult::CORRUPTED_BLOCK_DB;
         }
         // check level 1: verify block validity
-        Assert(block.GetHash() == pindex->GetBlockHash());
         if (nCheckLevel >= 1 && !CheckBlock(block, pindex->GetBlockHash(), state, consensus_params)) {
             LogPrintf("Verification error: found bad block at %d, hash=%s (%s)\n",
                       pindex->nHeight, pindex->GetBlockHash().ToString(), state.ToString());

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4572,6 +4572,7 @@ MempoolAcceptResult ChainstateManager::ProcessTransaction(const CTransactionRef&
 BlockValidationState TestBlockValidity(
     Chainstate& chainstate,
     const CBlock& block,
+    const uint256& block_hash,
     const bool check_pow,
     const bool check_merkle_root)
 {
@@ -4589,7 +4590,8 @@ BlockValidationState TestBlockValidity(
     }
 
     // For signets CheckBlock() verifies the challenge iff fCheckPow is set.
-    if (!CheckBlock(block, block.GetHash(), state, chainstate.m_chainman.GetConsensus(), /*fCheckPow=*/check_pow, /*fCheckMerkleRoot=*/check_merkle_root)) {
+    Assert(block_hash == block.GetHash());
+    if (!CheckBlock(block, block_hash, state, chainstate.m_chainman.GetConsensus(), /*fCheckPow=*/check_pow, /*fCheckMerkleRoot=*/check_merkle_root)) {
         // This should never happen, but belt-and-suspenders don't approve the
         // block if it does.
         if (state.IsValid()) NONFATAL_UNREACHABLE();
@@ -4624,7 +4626,6 @@ BlockValidationState TestBlockValidity(
     // We don't want ConnectBlock to update the actual chainstate, so create
     // a cache on top of it, along with a dummy block index.
     CBlockIndex index_dummy{block};
-    uint256 block_hash(block.GetHash());
     index_dummy.pprev = tip;
     index_dummy.nHeight = tip->nHeight + 1;
     index_dummy.phashBlock = &block_hash;

--- a/src/validation.h
+++ b/src/validation.h
@@ -407,6 +407,7 @@ bool CheckBlock(const CBlock& block, const uint256& block_hash, BlockValidationS
 BlockValidationState TestBlockValidity(
     Chainstate& chainstate,
     const CBlock& block,
+    const uint256& block_hash,
     bool check_pow,
     bool check_merkle_root) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -385,7 +385,7 @@ public:
 /** Functions for validating blocks and updating the block tree */
 
 /** Context-independent validity checks */
-bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true, bool fCheckMerkleRoot = true);
+bool CheckBlock(const CBlock& block, const uint256& block_hash, BlockValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true, bool fCheckMerkleRoot = true);
 
 /**
  * Verify a block, including transactions.

--- a/src/validation.h
+++ b/src/validation.h
@@ -410,9 +410,6 @@ BlockValidationState TestBlockValidity(
     bool check_pow,
     bool check_merkle_root) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
-/** Check with the proof of work on each blockheader matches the value in nBits */
-bool HasValidProofOfWork(const std::vector<CBlockHeader>& headers, const Consensus::Params& consensusParams);
-
 /** Check if a block has been mutated (with respect to its merkle root and witness commitments). */
 bool IsBlockMutated(const CBlock& block, bool check_witness_root);
 
@@ -728,7 +725,8 @@ public:
      */
     bool ActivateBestChain(
         BlockValidationState& state,
-        std::shared_ptr<const CBlock> pblock = nullptr)
+        std::shared_ptr<const CBlock> pblock = nullptr,
+        std::optional<uint256> block_hash = {})
         EXCLUSIVE_LOCKS_REQUIRED(!m_chainstate_mutex)
         LOCKS_EXCLUDED(::cs_main);
 
@@ -960,6 +958,7 @@ private:
      */
     bool AcceptBlockHeader(
         const CBlockHeader& block,
+        const uint256& block_hash,
         BlockValidationState& state,
         CBlockIndex** ppindex,
         bool min_pow_checked) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
@@ -1256,7 +1255,7 @@ public:
      *
      * @returns   False if the block or header is invalid, or if saving to disk fails (likely a fatal error); true otherwise.
      */
-    bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, BlockValidationState& state, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock, bool min_pow_checked) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, const uint256& block_hash, BlockValidationState& state, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock, bool min_pow_checked) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     void ReceivedBlockTransactions(const CBlock& block, CBlockIndex* pindexNew, const FlatFilePos& pos) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 


### PR DESCRIPTION
WIP

<details>
<summary>i9</summary>

COMMITS="0690514d4f72aac251ee0b876cded9187d42c63e 64d7ad6765d93a675584ebd0c3e3e855c33bdb3c"; \
STOP=921129; DBCACHE=4500; \
CC=gcc; CXX=g++; \
BASE_DIR="/mnt/my_storage"; DATA_DIR="$BASE_DIR/BitcoinData"; LOG_DIR="$BASE_DIR/logs"; \
(echo ""; for c in $COMMITS; do git fetch -q origin $c && git log -1 --pretty='%h %s' $c || exit 1; done) && \
(echo "" && echo "reindex-chainstate | ${STOP} blocks | dbcache ${DBCACHE} | $(hostname) | $(uname -m) | $(lscpu | grep 'Model name' | head -1 | cut -d: -f2 | xargs) | $(nproc) cores | $(free -h | awk '/^Mem:/{print $2}') RAM | $(df -T $BASE_DIR | awk 'NR==2{print $2}') | $(lsblk -no ROTA $(df --output=source $BASE_DIR | tail -1) | grep -q 0 && echo SSD || echo HDD)"; echo "") &&\
hyperfine \
  --sort command \
  --runs 1 \
  --export-json "$BASE_DIR/rdx-$(sed -E 's/(\w{8})\w+ ?/\1-/g;s/-$//'<<<"$COMMITS")-$STOP-$DBCACHE-$CC.json" \
  --parameter-list COMMIT ${COMMITS// /,} \
  --prepare "killall bitcoind 2>/dev/null; rm -f $DATA_DIR/debug.log; git checkout {COMMIT}; git clean -fxd; git reset --hard && \
    cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_IPC=OFF -DAPPEND_CPPFLAGS="-DDISABLE_OPTIMIZED_SHA256" && ninja -C build bitcoind -j2 && \
    ./build/bin/bitcoind -datadir=$DATA_DIR -stopatheight=$STOP -dbcache=1000 -printtoconsole=0; sleep 20" \
  --conclude "killall bitcoind || true; sleep 5; grep -q 'height=0' $DATA_DIR/debug.log && grep -q 'Disabling script verification at block #1' $DATA_DIR/debug.log && grep -q 'height=$STOP' $DATA_DIR/debug.log; \
              cp $DATA_DIR/debug.log $LOG_DIR/debug-{COMMIT}-$(date +%s).log" \
  "COMPILER=$CC ./build/bin/bitcoind -datadir=$DATA_DIR -stopatheight=$STOP -dbcache=$DBCACHE -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0"; 

0690514d4f Merge bitcoin/bitcoin#33770: init: Require explicit -asmap filename
64d7ad6765 remove intermediary hash asserts

reindex-chainstate | 921129 blocks | dbcache 4500 | i9-ssd | x86_64 | Intel(R) Core(TM) i9-9900K CPU @ 3.60GHz | 16 cores | 62Gi RAM | xfs | SSD

Benchmark 1: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=921129 -dbcache=4500 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 0690514d4f72aac251ee0b876cded9187d42c63e)
  Time (abs ≡):        18740.247 s               [User: 27782.839 s, System: 850.976 s]
 
Benchmark 2: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=921129 -dbcache=4500 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 64d7ad6765d93a675584ebd0c3e3e855c33bdb3c)
  Time (abs ≡):        18709.197 s               [User: 27733.727 s, System: 829.871 s]
 
Relative speed comparison
        1.00          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=921129 -dbcache=4500 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 0690514d4f72aac251ee0b876cded9187d42c63e)
        1.00          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=921129 -dbcache=4500 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 64d7ad6765d93a675584ebd0c3e3e855c33bdb3c)
root@i9-ssd /mnt/my_storage/bitcoin # cat ../BitcoinData/debug.log | grep SHA256
2025-11-23T02:41:02Z Using the 'standard' SHA256 implementation
2025-11-23T02:41:28Z Using the 'standard' SHA256 implementation


</details>