### PR TITLE
Warm empty dbcache

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -247,12 +247,14 @@ bool CCoinsViewCache::BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &ha
     return true;
 }
 
-bool CCoinsViewCache::Flush() {
+bool CCoinsViewCache::Flush(bool reallocate_cache) {
     auto cursor{CoinsViewCacheCursor(cachedCoinsUsage, m_sentinel, cacheCoins, /*will_erase=*/true)};
     bool fOk = base->BatchWrite(cursor, hashBlock);
     if (fOk) {
         cacheCoins.clear();
-        ReallocateCache();
+        if (reallocate_cache) {
+            ReallocateCache();
+        }
     }
     cachedCoinsUsage = 0;
     return fOk;

--- a/src/coins.h
+++ b/src/coins.h
@@ -443,7 +443,7 @@ public:
      * to be forgotten.
      * If false is returned, the state of this cache (and its backing view) will be undefined.
      */
-    bool Flush();
+    bool Flush(bool reallocate_cache);
 
     /**
      * Push the modifications applied to this cache to its base while retaining

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -237,7 +237,7 @@ void SimulationTest(CCoinsView* base, bool fake_best_block)
                 unsigned int flushIndex = m_rng.randrange(stack.size() - 1);
                 if (fake_best_block) stack[flushIndex]->SetBestBlock(m_rng.rand256());
                 bool should_erase = m_rng.randrange(4) < 3;
-                BOOST_CHECK(should_erase ? stack[flushIndex]->Flush() : stack[flushIndex]->Sync());
+                BOOST_CHECK(should_erase ? stack[flushIndex]->Flush(/*reallocate_cache=*/m_rng.randbool()) : stack[flushIndex]->Sync());
                 flushed_without_erase |= !should_erase;
             }
         }
@@ -247,7 +247,7 @@ void SimulationTest(CCoinsView* base, bool fake_best_block)
                 //Remove the top cache
                 if (fake_best_block) stack.back()->SetBestBlock(m_rng.rand256());
                 bool should_erase = m_rng.randrange(4) < 3;
-                BOOST_CHECK(should_erase ? stack.back()->Flush() : stack.back()->Sync());
+                BOOST_CHECK(should_erase ? stack.back()->Flush(/*reallocate_cache=*/m_rng.randbool()) : stack.back()->Sync());
                 flushed_without_erase |= !should_erase;
                 stack.pop_back();
             }
@@ -496,13 +496,13 @@ BOOST_FIXTURE_TEST_CASE(updatecoins_simulation_test, UpdateTest)
             // Every 100 iterations, flush an intermediate cache
             if (stack.size() > 1 && m_rng.randbool() == 0) {
                 unsigned int flushIndex = m_rng.randrange(stack.size() - 1);
-                BOOST_CHECK(stack[flushIndex]->Flush());
+                BOOST_CHECK(stack[flushIndex]->Flush(/*reallocate_cache=*/m_rng.randbool()));
             }
         }
         if (m_rng.randrange(100) == 0) {
             // Every 100 iterations, change the cache stack.
             if (stack.size() > 0 && m_rng.randbool() == 0) {
-                BOOST_CHECK(stack.back()->Flush());
+                BOOST_CHECK(stack.back()->Flush(/*reallocate_cache=*/m_rng.randbool()));
                 stack.pop_back();
             }
             if (stack.size() == 0 || (stack.size() < 4 && m_rng.randbool())) {
@@ -913,7 +913,7 @@ void TestFlushBehavior(
             // hashBlock must be filled before flushing to disk; value is
             // unimportant here. This is normally done during connect/disconnect block.
             cache->SetBestBlock(m_rng.rand256());
-            erase ? cache->Flush() : cache->Sync();
+            erase ? cache->Flush(/*reallocate_cache=*/m_rng.randbool()) : cache->Sync();
         }
     };
 

--- a/src/test/validation_flush_tests.cpp
+++ b/src/test/validation_flush_tests.cpp
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
     // CRITICAL → OK via Flush
     BOOST_CHECK_EQUAL(chainstate.GetCoinsCacheSizeState(MAX_COINS_BYTES, /*max_mempool_size_bytes=*/0), CoinsCacheSizeState::CRITICAL);
     view.SetBestBlock(m_rng.rand256());
-    BOOST_REQUIRE(view.Flush());
+    BOOST_REQUIRE(view.Flush(/*reallocate_cache=*/m_rng.randbool()));
     BOOST_CHECK_EQUAL(chainstate.GetCoinsCacheSizeState(MAX_COINS_BYTES, /*max_mempool_size_bytes=*/0), CoinsCacheSizeState::OK);
 }
 


### PR DESCRIPTION
testing the effect of cold/warm restarts with:
```bash
COMMITS="57e8f34fe20620b3350ca1f0fa5c7d8d3a06be82 87aec855f803f07e7602cccf0230881bd6e355bc"; \
STOP=700000; DBCACHE=1000; \
CC=gcc; CXX=g++; \
BASE_DIR="/mnt/my_storage"; DATA_DIR="$BASE_DIR/BitcoinData"; LOG_DIR="$BASE_DIR/logs"; \
(echo ""; for c in $COMMITS; do git fetch -q origin $c && git log -1 --pretty='%h %s' $c || exit 1; done; echo "") && \
hyperfine \
  --sort command \
  --runs 3 \
  --export-json "$BASE_DIR/ibd-$(sed -E 's/(\w{8})\w+ ?/\1-/g;s/-$//'<<<"$COMMITS")-$STOP-$DBCACHE-$CC.json" \
  --parameter-list COMMIT ${COMMITS// /,} \
  --prepare "killall bitcoind 2>/dev/null; rm -rf $DATA_DIR/*; git checkout {COMMIT}; git clean -fxd; git reset --hard && \
    cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release && ninja -C build bitcoind && \
    ./build/bin/bitcoind -datadir=$DATA_DIR -stopatheight=1 -printtoconsole=0; sleep 10" \
  --cleanup "cp $DATA_DIR/debug.log $LOG_DIR/debug-{COMMIT}-$(date +%s).log" \
  "for H in $(seq -s' ' 50000 50000 $STOP); do COMPILER=$CC ./build/bin/bitcoind -datadir=$DATA_DIR -stopatheight=\$H -dbcache=$DBCACHE -blocksonly -printtoconsole=0; done"
````