### PR TITLE
refactor: don't zero-after-free during serialization

### DIFF
--- a/src/bench/prevector.cpp
+++ b/src/bench/prevector.cpp
@@ -81,7 +81,7 @@ static void PrevectorDeserialize(benchmark::Bench& bench)
         for (auto x = 0; x < 1000; ++x) {
             s0 >> t1;
         }
-        s0.Rewind();
+        s0.rewind();
     });
 }
 

--- a/src/bench/rpc_blockchain.cpp
+++ b/src/bench/rpc_blockchain.cpp
@@ -31,10 +31,7 @@ struct TestBlockAndIndex {
 
     TestBlockAndIndex()
     {
-        DataStream stream{benchmark::data::block413567};
-        std::byte a{0};
-        stream.write({&a, 1}); // Prevent compaction
-
+        SpanReader stream{benchmark::data::block413567};
         stream >> TX_WITH_WITNESS(block);
 
         blockHash = block.GetHash();

--- a/src/streams.h
+++ b/src/streams.h
@@ -134,14 +134,14 @@ protected:
     vector_type::size_type m_read_pos{0};
 
 public:
-    typedef vector_type::allocator_type   allocator_type;
-    typedef vector_type::size_type        size_type;
-    typedef vector_type::difference_type  difference_type;
-    typedef vector_type::reference        reference;
-    typedef vector_type::const_reference  const_reference;
-    typedef vector_type::value_type       value_type;
-    typedef vector_type::iterator         iterator;
-    typedef vector_type::const_iterator   const_iterator;
+    typedef vector_type::allocator_type allocator_type;
+    typedef vector_type::size_type size_type;
+    typedef vector_type::difference_type difference_type;
+    typedef vector_type::reference reference;
+    typedef vector_type::const_reference const_reference;
+    typedef vector_type::value_type value_type;
+    typedef vector_type::iterator iterator;
+    typedef vector_type::const_iterator const_iterator;
     typedef vector_type::reverse_iterator reverse_iterator;
 
     explicit DataStream() = default;
@@ -153,44 +153,29 @@ public:
         return std::string{UCharCast(data()), UCharCast(data() + size())};
     }
 
-
     //
     // Vector subset
     //
-    const_iterator begin() const                     { return vch.begin() + m_read_pos; }
-    iterator begin()                                 { return vch.begin() + m_read_pos; }
-    const_iterator end() const                       { return vch.end(); }
-    iterator end()                                   { return vch.end(); }
-    size_type size() const                           { return vch.size() - m_read_pos; }
-    bool empty() const                               { return vch.size() == m_read_pos; }
+    const_iterator begin() const { return vch.begin() + m_read_pos; }
+    iterator begin() { return vch.begin() + m_read_pos; }
+    const_iterator end() const { return vch.end(); }
+    iterator end() { return vch.end(); }
+    size_type size() const { return vch.size() - m_read_pos; }
+    bool empty() const { return vch.size() == m_read_pos; }
     void resize(size_type n, value_type c = value_type{}) { vch.resize(n + m_read_pos, c); }
-    void reserve(size_type n)                        { vch.reserve(n + m_read_pos); }
-    const_reference operator[](size_type pos) const  { return vch[pos + m_read_pos]; }
-    reference operator[](size_type pos)              { return vch[pos + m_read_pos]; }
-    void clear()                                     { vch.clear(); m_read_pos = 0; }
-    value_type* data()                               { return vch.data() + m_read_pos; }
-    const value_type* data() const                   { return vch.data() + m_read_pos; }
-
-    bool Rewind(std::optional<size_type> n = std::nullopt)
-    {
-        // Total rewind if no size is passed
-        if (!n) {
-            m_read_pos = 0;
-            return true;
-        }
-        // Rewind by n characters if the buffer hasn't been compacted yet
-        if (*n > m_read_pos)
-            return false;
-        m_read_pos -= *n;
-        return true;
-    }
-
+    void reserve(size_type n) { vch.reserve(n + m_read_pos); }
+    const_reference operator[](size_type pos) const { return vch[pos + m_read_pos]; }
+    reference operator[](size_type pos) { return vch[pos + m_read_pos]; }
+    void clear() { vch.clear(); rewind(); }
+    value_type* data() { return vch.data() + m_read_pos; }
+    const value_type* data() const { return vch.data() + m_read_pos; }
 
     //
     // Stream subset
     //
-    bool eof() const             { return size() == 0; }
-    int in_avail() const         { return size(); }
+    void rewind() { m_read_pos = 0; }
+    bool eof() const { return empty(); }
+    int in_avail() const { return size(); }
 
     void read(std::span<value_type> dst)
     {

--- a/src/streams.h
+++ b/src/streams.h
@@ -171,12 +171,6 @@ public:
     value_type* data()                               { return vch.data() + m_read_pos; }
     const value_type* data() const                   { return vch.data() + m_read_pos; }
 
-    inline void Compact()
-    {
-        vch.erase(vch.begin(), vch.begin() + m_read_pos);
-        m_read_pos = 0;
-    }
-
     bool Rewind(std::optional<size_type> n = std::nullopt)
     {
         // Total rewind if no size is passed
@@ -209,8 +203,8 @@ public:
         }
         memcpy(dst.data(), &vch[m_read_pos], dst.size());
         if (next_read_pos.value() == vch.size()) {
-            m_read_pos = 0;
-            vch.clear();
+            // If fully consumed, reset to empty state.
+            clear();
             return;
         }
         m_read_pos = next_read_pos.value();
@@ -224,8 +218,8 @@ public:
             throw std::ios_base::failure("DataStream::ignore(): end of data");
         }
         if (next_read_pos.value() == vch.size()) {
-            m_read_pos = 0;
-            vch.clear();
+            // If all bytes are ignored, reset to empty state.
+            clear();
             return;
         }
         m_read_pos = next_read_pos.value();

--- a/src/streams.h
+++ b/src/streams.h
@@ -9,7 +9,6 @@
 #include <logging.h>
 #include <serialize.h>
 #include <span.h>
-#include <support/allocators/zeroafterfree.h>
 #include <util/check.h>
 #include <util/obfuscation.h>
 #include <util/overflow.h>
@@ -18,8 +17,6 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
-#include <cstdint>
-#include <cstdio>
 #include <cstring>
 #include <ios>
 #include <limits>
@@ -129,20 +126,17 @@ public:
 class DataStream
 {
 protected:
-    using vector_type = SerializeData;
-    vector_type vch;
-    vector_type::size_type m_read_pos{0};
+    using Storage = std::vector<std::byte>;
+    Storage vch;
+    Storage::size_type m_read_pos{0};
 
 public:
-    typedef vector_type::allocator_type allocator_type;
-    typedef vector_type::size_type size_type;
-    typedef vector_type::difference_type difference_type;
-    typedef vector_type::reference reference;
-    typedef vector_type::const_reference const_reference;
-    typedef vector_type::value_type value_type;
-    typedef vector_type::iterator iterator;
-    typedef vector_type::const_iterator const_iterator;
-    typedef vector_type::reverse_iterator reverse_iterator;
+    using size_type = Storage::size_type;
+    using reference = Storage::reference;
+    using const_reference = Storage::const_reference;
+    using value_type = Storage::value_type;
+    using iterator = Storage::iterator;
+    using const_iterator = Storage::const_iterator;
 
     explicit DataStream() = default;
     explicit DataStream(std::span<const uint8_t> sp) : DataStream{std::as_bytes(sp)} {}

--- a/src/wallet/migrate.cpp
+++ b/src/wallet/migrate.cpp
@@ -6,6 +6,7 @@
 #include <crypto/common.h>
 #include <logging.h>
 #include <streams.h>
+#include <support/allocators/zeroafterfree.h>
 #include <util/translation.h>
 #include <wallet/migrate.h>
 

--- a/src/wallet/migrate.h
+++ b/src/wallet/migrate.h
@@ -5,9 +5,8 @@
 #ifndef BITCOIN_WALLET_MIGRATE_H
 #define BITCOIN_WALLET_MIGRATE_H
 
+#include <support/allocators/zeroafterfree.h>
 #include <wallet/db.h>
-
-#include <optional>
 
 namespace wallet {
 

--- a/src/wallet/test/db_tests.cpp
+++ b/src/wallet/test/db_tests.cpp
@@ -4,12 +4,13 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <support/allocators/zeroafterfree.h>
 #include <test/util/setup_common.h>
 #include <util/check.h>
 #include <util/fs.h>
 #include <util/translation.h>
-#include <wallet/sqlite.h>
 #include <wallet/migrate.h>
+#include <wallet/sqlite.h>
 #include <wallet/test/util.h>
 #include <wallet/walletutil.h>
 

--- a/src/wallet/test/util.cpp
+++ b/src/wallet/test/util.cpp
@@ -8,6 +8,7 @@
 #include <key.h>
 #include <key_io.h>
 #include <streams.h>
+#include <support/allocators/zeroafterfree.h>
 #include <test/util/setup_common.h>
 #include <validationinterface.h>
 #include <wallet/context.h>

--- a/src/wallet/test/util.h
+++ b/src/wallet/test/util.h
@@ -6,6 +6,7 @@
 #define BITCOIN_WALLET_TEST_UTIL_H
 
 #include <addresstype.h>
+#include <support/allocators/zeroafterfree.h>
 #include <wallet/db.h>
 #include <wallet/scriptpubkeyman.h>
 


### PR DESCRIPTION
<img width="2084" height="1475" alt="image" src="https://github.com/user-attachments/assets/cea69a26-c983-4b58-ab76-1865c328dac4" />

```
for compiler in gcc clang; do   if [ "$compiler" = "gcc" ]; then CC=gcc; CXX=g++; COMP_VER=$(gcc -dumpfullversion);   else CC=clang; CXX=clang++; COMP_VER=$(clang -dumpversion); fi &&   echo "> Compiler: $compiler $COMP_VER" &&   for commit in d2d3d65e9c1fdc69ae758356de32bdb02879d081 d324342ce93a433499146a86b09a2f69e405a7c1; do     git fetch origin $commit >/dev/null 2>&1 && git checkout $commit >/dev/null 2>&1 && echo "" && git log -1 --pretty='%h %s' &&     rm -rf build >/dev/null 2>&1 && cmake -B build -DBUILD_BENCH=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX >/dev/null 2>&1 &&     cmake --build build -j$(nproc) >/dev/null 2>&1 &&     for i in $(seq 0 5); do       build/bin/bench_bitcoin -filter='DataStreamInitAndFree' -min-time=10000;     done;   done; done                                                                                                                                                        
root@rpi5-4:/mnt/my_storage/bitcoin# for compiler in gcc clang; do   if [ "$compiler" = "gcc" ]; then CC=gcc; CXX=g++; COMP_VER=$(gcc -dumpfullversion);   else CC=clang; CXX=clang++; COMP_VER=$(clang -dumpversion); fi &&   echo "> Compiler: $compiler $COMP_VER" &&   for commit in d2d3d65e9c1fdc69ae758356de32bdb02879d081 d324342ce93a433499146a86b09a2f69e405a7c1; do     git fetch origin $commit >/dev/null 2>&1 && git checkout $commit >/dev/null 2>&1 && echo "" && git log -1 --pretty='%h %s' &&     rm -rf build >/dev/null 2>&1 && cmake -B build -DBUILD_BENCH=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX >/dev/null 2>&1 &&     cmake --build build -j$(nproc) >/dev/null 2>&1 &&     for i in $(seq 0 5); do       build/bin/bench_bitcoin -filter='DataStreamInitAndFree' -min-time=10000;     done;   done; done
```

> Compiler: gcc 15.0.1

d2d3d65e9c bench/streams: replace `DataStream` dummy with lightweight `SpanReader`

|               ns/MB |                MB/s |    err% |          ins/MB |          cyc/MB |    IPC |         bra/MB |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|          732,457.24 |            1,365.27 |    0.4% |    5,308,918.02 |    1,753,168.00 |  3.028 |   1,065,061.00 |    0.0% |     10.64 | `DataStreamInitAndFree`

|               ns/MB |                MB/s |    err% |          ins/MB |          cyc/MB |    IPC |         bra/MB |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|          730,263.54 |            1,369.37 |    0.1% |    5,308,918.02 |    1,748,311.58 |  3.037 |   1,065,061.00 |    0.0% |     10.65 | `DataStreamInitAndFree`

|               ns/MB |                MB/s |    err% |          ins/MB |          cyc/MB |    IPC |         bra/MB |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|          729,825.82 |            1,370.19 |    0.0% |    5,308,918.02 |    1,747,167.10 |  3.039 |   1,065,061.00 |    0.0% |     10.69 | `DataStreamInitAndFree`

|               ns/MB |                MB/s |    err% |          ins/MB |          cyc/MB |    IPC |         bra/MB |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|          729,934.13 |            1,369.99 |    0.1% |    5,308,918.02 |    1,747,514.21 |  3.038 |   1,065,061.00 |    0.0% |     10.67 | `DataStreamInitAndFree`

|               ns/MB |                MB/s |    err% |          ins/MB |          cyc/MB |    IPC |         bra/MB |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|          731,197.06 |            1,367.62 |    0.2% |    5,308,918.02 |    1,750,386.35 |  3.033 |   1,065,061.00 |    0.0% |     10.73 | `DataStreamInitAndFree`

|               ns/MB |                MB/s |    err% |          ins/MB |          cyc/MB |    IPC |         bra/MB |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|          730,506.77 |            1,368.91 |    0.1% |    5,308,918.02 |    1,748,645.94 |  3.036 |   1,065,061.00 |    0.0% |     10.69 | `DataStreamInitAndFree`

d324342ce9 serialization: stop zeroing `DataStream` bytes on destruction

|               ns/MB |                MB/s |    err% |          ins/MB |          cyc/MB |    IPC |         bra/MB |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|           66,467.06 |           15,045.05 |    5.1% |      131,532.00 |      159,121.33 |  0.827 |      16,478.00 |    0.0% |      9.85 | :wavy_dash: `DataStreamInitAndFree` (Unstable with ~12,963.4 iters. Increase `minEpochIterations` to e.g. 129634)

|               ns/MB |                MB/s |    err% |          ins/MB |          cyc/MB |    IPC |         bra/MB |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|           68,677.37 |           14,560.84 |    3.9% |      131,532.00 |      164,407.92 |  0.800 |      16,478.00 |    0.0% |     10.48 | `DataStreamInitAndFree`

|               ns/MB |                MB/s |    err% |          ins/MB |          cyc/MB |    IPC |         bra/MB |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|           63,976.19 |           15,630.82 |    5.3% |      131,532.00 |      153,136.95 |  0.859 |      16,478.00 |    0.0% |     10.43 | :wavy_dash: `DataStreamInitAndFree` (Unstable with ~14,449.4 iters. Increase `minEpochIterations` to e.g. 144494)

|               ns/MB |                MB/s |    err% |          ins/MB |          cyc/MB |    IPC |         bra/MB |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|           63,321.76 |           15,792.36 |    5.4% |      131,532.00 |      151,607.55 |  0.868 |      16,478.00 |    0.0% |     10.55 | :wavy_dash: `DataStreamInitAndFree` (Unstable with ~14,854.8 iters. Increase `minEpochIterations` to e.g. 148548)

|               ns/MB |                MB/s |    err% |          ins/MB |          cyc/MB |    IPC |         bra/MB |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|           62,451.38 |           16,012.46 |    5.2% |      131,532.00 |      149,514.53 |  0.880 |      16,478.00 |    0.0% |     10.82 | :wavy_dash: `DataStreamInitAndFree` (Unstable with ~15,301.9 iters. Increase `minEpochIterations` to e.g. 153019)

|               ns/MB |                MB/s |    err% |          ins/MB |          cyc/MB |    IPC |         bra/MB |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|           69,387.16 |           14,411.89 |    6.4% |      131,532.00 |      166,094.90 |  0.792 |      16,478.00 |    0.0% |     10.04 | :wavy_dash: `DataStreamInitAndFree` (Unstable with ~13,136.5 iters. Increase `minEpochIterations` to e.g. 131365)

> Compiler: clang 22.0.0

d2d3d65e9c bench/streams: replace `DataStream` dummy with lightweight `SpanReader`

|               ns/MB |                MB/s |    err% |          ins/MB |          cyc/MB |    IPC |         bra/MB |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|           94,580.75 |           10,572.98 |    3.9% |      197,121.00 |      226,433.31 |  0.871 |      32,871.00 |    0.0% |     11.16 | `DataStreamInitAndFree`

|               ns/MB |                MB/s |    err% |          ins/MB |          cyc/MB |    IPC |         bra/MB |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|           90,958.82 |           10,993.99 |    5.1% |      197,121.00 |      217,736.99 |  0.905 |      32,871.00 |    0.0% |     11.25 | :wavy_dash: `DataStreamInitAndFree` (Unstable with ~11,154.2 iters. Increase `minEpochIterations` to e.g. 111542)

|               ns/MB |                MB/s |    err% |          ins/MB |          cyc/MB |    IPC |         bra/MB |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|           92,194.76 |           10,846.60 |    4.9% |      197,121.00 |      220,689.26 |  0.893 |      32,871.00 |    0.0% |     11.30 | `DataStreamInitAndFree`

|               ns/MB |                MB/s |    err% |          ins/MB |          cyc/MB |    IPC |         bra/MB |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|           91,627.27 |           10,913.78 |    5.5% |      197,121.00 |      219,359.11 |  0.899 |      32,871.00 |    0.0% |     11.34 | :wavy_dash: `DataStreamInitAndFree` (Unstable with ~10,820.9 iters. Increase `minEpochIterations` to e.g. 108209)

|               ns/MB |                MB/s |    err% |          ins/MB |          cyc/MB |    IPC |         bra/MB |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|           87,235.61 |           11,463.21 |    5.2% |      197,121.00 |      208,857.27 |  0.944 |      32,871.00 |    0.0% |     11.73 | :wavy_dash: `DataStreamInitAndFree` (Unstable with ~11,321.9 iters. Increase `minEpochIterations` to e.g. 113219)

|               ns/MB |                MB/s |    err% |          ins/MB |          cyc/MB |    IPC |         bra/MB |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|           92,227.82 |           10,842.72 |    3.2% |      197,121.00 |      220,806.18 |  0.893 |      32,871.00 |    0.0% |     11.07 | `DataStreamInitAndFree`

d324342ce9 serialization: stop zeroing `DataStream` bytes on destruction

|               ns/MB |                MB/s |    err% |          ins/MB |          cyc/MB |    IPC |         bra/MB |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|           66,765.55 |           14,977.78 |    6.5% |      131,533.00 |      159,818.15 |  0.823 |      16,478.00 |    0.0% |     11.11 | :wavy_dash: `DataStreamInitAndFree` (Unstable with ~15,176.2 iters. Increase `minEpochIterations` to e.g. 151762)

|               ns/MB |                MB/s |    err% |          ins/MB |          cyc/MB |    IPC |         bra/MB |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|           65,376.58 |           15,296.00 |    5.3% |      131,533.00 |      156,508.58 |  0.840 |      16,478.00 |    0.0% |     11.28 | :wavy_dash: `DataStreamInitAndFree` (Unstable with ~15,491.1 iters. Increase `minEpochIterations` to e.g. 154911)

|               ns/MB |                MB/s |    err% |          ins/MB |          cyc/MB |    IPC |         bra/MB |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|           63,715.23 |           15,694.84 |    5.8% |      131,533.00 |      152,564.98 |  0.862 |      16,478.00 |    0.0% |     11.02 | :wavy_dash: `DataStreamInitAndFree` (Unstable with ~15,204.4 iters. Increase `minEpochIterations` to e.g. 152044)

|               ns/MB |                MB/s |    err% |          ins/MB |          cyc/MB |    IPC |         bra/MB |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|           61,714.34 |           16,203.69 |    5.2% |      131,533.00 |      147,748.42 |  0.890 |      16,478.00 |    0.0% |     10.97 | :wavy_dash: `DataStreamInitAndFree` (Unstable with ~16,357.8 iters. Increase `minEpochIterations` to e.g. 163578)

|               ns/MB |                MB/s |    err% |          ins/MB |          cyc/MB |    IPC |         bra/MB |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|           58,684.16 |           17,040.37 |   10.7% |      131,533.00 |      140,520.65 |  0.936 |      16,478.00 |    0.0% |     11.81 | :wavy_dash: `DataStreamInitAndFree` (Unstable with ~17,445.5 iters. Increase `minEpochIterations` to e.g. 174455)

|               ns/MB |                MB/s |    err% |          ins/MB |          cyc/MB |    IPC |         bra/MB |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|           64,245.00 |           15,565.41 |    5.5% |      131,533.00 |      153,693.39 |  0.856 |      16,478.00 |    0.0% |     10.88 | 