### PR TITLE
Custom CoinEntry (de)serialization

### DIFF
--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -122,9 +122,9 @@ static void SerializeCOutPoint2(benchmark::Bench& bench)
     serialized.resize(original.size());
     bench.warmup(1).batch(ops.size()).unit("outpoints").run([&] {
         serialized.clear();
-        for (auto& op : ops) WriteCOutPoint(serialized, op);
-        assert(serialized.size() == original.size());
-        assert(serialized.str() == original.str());
+        for (auto& op : ops) {
+            assert(WriteCOutPoint(serialized, op).size() == original.size());
+        }
     });
 }
 
@@ -153,8 +153,7 @@ static void DeserializeCOutPoint2(benchmark::Bench& bench)
     DataStream key_buffer;
     key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
     for (auto op : outpoints) {
-        WriteCOutPoint(key_buffer, op);
-        serialized_outpoints.emplace_back(key_buffer);
+        serialized_outpoints.emplace_back(WriteCOutPoint(key_buffer, op));
     }
 
     DataStream stream;

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -608,6 +608,9 @@ static void MutateTxSign(CMutableTransaction& tx, const std::string& flagStr)
         throw std::runtime_error("prevtxs register variable must be set.");
     UniValue prevtxsObj = registers["prevtxs"];
     {
+        DataStream key_buffer;
+        key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
+
         for (unsigned int previdx = 0; previdx < prevtxsObj.size(); previdx++) {
             const UniValue& prevOut = prevtxsObj[previdx];
             if (!prevOut.isObject())
@@ -635,7 +638,7 @@ static void MutateTxSign(CMutableTransaction& tx, const std::string& flagStr)
             CScript scriptPubKey(pkData.begin(), pkData.end());
 
             {
-                const Coin& coin = view.AccessCoin(out);
+                const Coin& coin = view.AccessCoin(out, key_buffer);
                 if (!coin.IsSpent() && coin.out.scriptPubKey != scriptPubKey) {
                     std::string err("Previous output scriptPubKey mismatch:\n");
                     err = err + ScriptToAsmStr(coin.out.scriptPubKey) + "\nvs:\n"+
@@ -669,9 +672,11 @@ static void MutateTxSign(CMutableTransaction& tx, const std::string& flagStr)
     bool fHashSingle = ((nHashType & ~SIGHASH_ANYONECANPAY) == SIGHASH_SINGLE);
 
     // Sign what we can:
+    DataStream key_buffer;
+    key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
     for (unsigned int i = 0; i < mergedTx.vin.size(); i++) {
         CTxIn& txin = mergedTx.vin[i];
-        const Coin& coin = view.AccessCoin(txin.prevout);
+        const Coin& coin = view.AccessCoin(txin.prevout, key_buffer);
         if (coin.IsSpent()) {
             continue;
         }

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -8,6 +8,10 @@
 
 #include <cstdint>
 #include <cstdlib>
+#include <stdint.h>
+#include <txdb.h>
+
+static const size_t MAX_COUTPOINT_SERIALIZED_SIZE{SerializedSize(COutPoint())};
 
 /** The maximum allowed size for a serialized block, in bytes (only for buffer size limits) */
 static const unsigned int MAX_BLOCK_SERIALIZED_SIZE = 4000000;

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_CONSENSUS_TX_VERIFY_H
 #define BITCOIN_CONSENSUS_TX_VERIFY_H
 
+#include <span.h>
 #include <consensus/amount.h>
 
 #include <cstdint>
@@ -24,7 +25,7 @@ namespace Consensus {
  * @param[out] txfee Set to the transaction fee if successful.
  * Preconditions: tx.IsCoinBase() is false.
  */
-[[nodiscard]] bool CheckTxInputs(const CTransaction& tx, TxValidationState& state, const CCoinsViewCache& inputs, int nSpendHeight, CAmount& txfee);
+[[nodiscard]] bool CheckTxInputs(const CTransaction& tx, TxValidationState& state, const CCoinsViewCache& inputs, int nSpendHeight, CAmount& txfee, Span<std::byte> key_buffer);
 } // namespace Consensus
 
 /** Auxiliary functions for transaction validation (ideally should not be exposed) */

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -28,8 +28,6 @@
 #include <thread>
 #include <utility>
 
-constexpr uint8_t DB_BEST_BLOCK{'B'};
-
 constexpr auto SYNC_LOG_INTERVAL{30s};
 constexpr auto SYNC_LOCATOR_WRITE_INTERVAL{30s};
 

--- a/src/node/coin.cpp
+++ b/src/node/coin.cpp
@@ -16,8 +16,12 @@ void FindCoins(const NodeContext& node, std::map<COutPoint, Coin>& coins)
     LOCK2(cs_main, node.mempool->cs);
     CCoinsViewCache& chain_view = node.chainman->ActiveChainstate().CoinsTip();
     CCoinsViewMemPool mempool_view(&chain_view, *node.mempool);
+
+    DataStream key_buffer;
+    key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
+
     for (auto& [outpoint, coin] : coins) {
-        if (auto c{mempool_view.GetCoin(outpoint)}) {
+        if (auto c{mempool_view.GetCoin(outpoint, key_buffer)}) {
             coin = std::move(*c);
         } else {
             coin.Clear(); // Either the coin is not in the CCoinsViewCache or is spent

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -359,7 +359,9 @@ public:
     std::optional<Coin> getUnspentOutput(const COutPoint& output) override
     {
         LOCK(::cs_main);
-        return chainman().ActiveChainstate().CoinsTip().GetCoin(output);
+        DataStream key_buffer;
+        key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
+        return chainman().ActiveChainstate().CoinsTip().GetCoin(output, key_buffer);
     }
     TransactionError broadcastTransaction(CTransactionRef tx, CAmount max_tx_fee, std::string& err_string) override
     {

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -50,9 +50,12 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
 
         // If the transaction is already confirmed in the chain, don't do anything
         // and return early.
+        DataStream key_buffer;
+        key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
+
         CCoinsViewCache &view = node.chainman->ActiveChainstate().CoinsTip();
         for (size_t o = 0; o < tx->vout.size(); o++) {
-            const Coin& existingCoin = view.AccessCoin(COutPoint(txid, o));
+            const Coin& existingCoin = view.AccessCoin(COutPoint(txid, o), key_buffer);
             // IsSpent doesn't mean the coin is spent, it means the output doesn't exist.
             // So if the output does exist, then this transaction exists in the chain.
             if (!existingCoin.IsSpent()) return TransactionError::ALREADY_IN_UTXO_SET;

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -215,13 +215,15 @@ bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
     if (tx.IsCoinBase()) {
         return true; // Coinbases don't use vin normally
     }
+    DataStream key_buffer;
+    key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
 
     if (!CheckSigopsBIP54(tx, mapInputs)) {
         return false;
     }
 
     for (unsigned int i = 0; i < tx.vin.size(); i++) {
-        const CTxOut& prev = mapInputs.AccessCoin(tx.vin[i].prevout).out;
+        const CTxOut& prev = mapInputs.AccessCoin(tx.vin[i].prevout, key_buffer).out;
 
         std::vector<std::vector<unsigned char> > vSolutions;
         TxoutType whichType = Solver(prev.scriptPubKey, vSolutions);
@@ -253,6 +255,8 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
     if (tx.IsCoinBase())
         return true; // Coinbases are skipped
 
+    DataStream key_buffer;
+    key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
     for (unsigned int i = 0; i < tx.vin.size(); i++)
     {
         // We don't care if witness for this input is empty, since it must not be bloated.
@@ -260,7 +264,7 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
         if (tx.vin[i].scriptWitness.IsNull())
             continue;
 
-        const CTxOut &prev = mapInputs.AccessCoin(tx.vin[i].prevout).out;
+        const CTxOut &prev = mapInputs.AccessCoin(tx.vin[i].prevout, key_buffer).out;
 
         // get the scriptPubKey corresponding to this input:
         CScript prevScript = prev.scriptPubKey;

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -975,10 +975,12 @@ static bool rest_getutxos(const std::any& context, HTTPRequest* req, const std::
     ChainstateManager& chainman = *maybe_chainman;
     decltype(chainman.ActiveHeight()) active_height;
     uint256 active_hash;
+    DataStream key_buffer;
+    key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
     {
-        auto process_utxos = [&vOutPoints, &outs, &hits, &active_height, &active_hash, &chainman](const CCoinsView& view, const CTxMemPool* mempool) EXCLUSIVE_LOCKS_REQUIRED(chainman.GetMutex()) {
+        auto process_utxos = [&vOutPoints, &outs, &hits, &active_height, &active_hash, &chainman, &key_buffer](const CCoinsView& view, const CTxMemPool* mempool) EXCLUSIVE_LOCKS_REQUIRED(chainman.GetMutex()) {
             for (const COutPoint& vOutPoint : vOutPoints) {
-                auto coin = !mempool || !mempool->isSpent(vOutPoint) ? view.GetCoin(vOutPoint) : std::nullopt;
+                auto coin = !mempool || !mempool->isSpent(vOutPoint) ? view.GetCoin(vOutPoint, key_buffer) : std::nullopt;
                 hits.push_back(coin.has_value());
                 if (coin) outs.emplace_back(std::move(*coin));
             }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1187,13 +1187,15 @@ static RPCHelpMan gettxout()
     CCoinsViewCache* coins_view = &active_chainstate.CoinsTip();
 
     std::optional<Coin> coin;
+    DataStream key_buffer;
+    key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
     if (fMempool) {
         const CTxMemPool& mempool = EnsureMemPool(node);
         LOCK(mempool.cs);
         CCoinsViewMemPool view(coins_view, mempool);
-        if (!mempool.isSpent(out)) coin = view.GetCoin(out);
+        if (!mempool.isSpent(out)) coin = view.GetCoin(out, key_buffer);
     } else {
-        coin = coins_view->GetCoin(out);
+        coin = coins_view->GetCoin(out, key_buffer);
     }
     if (!coin) return UniValue::VNULL;
 
@@ -2828,6 +2830,8 @@ static RPCHelpMan getdescriptoractivity()
         LOCK(mempool.cs);
         const CCoinsViewCache& coins_view = &active_chainstate.CoinsTip();
 
+        DataStream key_buffer;
+        key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
         for (const CTxMemPoolEntry& e : mempool.entryAll()) {
             const auto& tx = e.GetSharedTx();
 
@@ -2835,7 +2839,7 @@ static RPCHelpMan getdescriptoractivity()
                 CScript scriptPubKey;
                 CAmount value;
                 const auto& txin = tx->vin.at(vin_idx);
-                std::optional<Coin> coin = coins_view.GetCoin(txin.prevout);
+                std::optional<Coin> coin = coins_view.GetCoin(txin.prevout, key_buffer);
 
                 // Check if the previous output is in the chain
                 if (!coin) {

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -675,8 +675,10 @@ static RPCHelpMan combinerawtransaction()
         CCoinsViewMemPool viewMempool(&viewChain, mempool);
         view.SetBackend(viewMempool); // temporarily switch cache backend to db+mempool view
 
+        DataStream key_buffer;
+        key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
         for (const CTxIn& txin : mergedTx.vin) {
-            view.AccessCoin(txin.prevout); // Load entries from viewChain into view; can fail.
+            view.AccessCoin(txin.prevout, key_buffer); // Load entries from viewChain into view; can fail.
         }
 
         view.SetBackend(viewDummy); // switch back to avoid locking mempool for too long
@@ -686,9 +688,11 @@ static RPCHelpMan combinerawtransaction()
     // transaction to avoid rehashing.
     const CTransaction txConst(mergedTx);
     // Sign what we can:
+    DataStream key_buffer;
+    key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
     for (unsigned int i = 0; i < mergedTx.vin.size(); i++) {
         CTxIn& txin = mergedTx.vin[i];
-        const Coin& coin = view.AccessCoin(txin.prevout);
+        const Coin& coin = view.AccessCoin(txin.prevout, key_buffer);
         if (coin.IsSpent()) {
             throw JSONRPCError(RPC_VERIFY_ERROR, "Input not found or already spent");
         }

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -20,7 +20,9 @@
 #include <limits>
 #include <map>
 #include <memory>
+#include <ranges>
 #include <set>
+#include <span>
 #include <string>
 #include <utility>
 #include <vector>
@@ -404,10 +406,26 @@ struct CheckVarIntMode {
     }
 };
 
+static constexpr size_t GetVarUInt32Size(uint32_t n) noexcept
+{
+    if (n < (1 << 7)) { // 128
+        return 1;
+    } else if (n < (1 << 7) + (1 << 2 * 7)) { // 16'512
+        return 2;
+    } else {
+        return 3
+            + (n >= (1 << 7) + (1 << 2 * 7) + (1 << 3 * 7)) // 2'113'664
+            + (n >= (1 << 7) + (1 << 2 * 7) + (1 << 3 * 7) + (1 << 4 * 7)); // 270'549'120
+    }
+}
 template<VarIntMode Mode, typename I>
-inline unsigned int GetSizeOfVarInt(I n)
+unsigned int GetSizeOfVarInt(I n)
 {
     CheckVarIntMode<Mode, I>();
+    // if constexpr (std::is_same_v<I, uint32_t>) {
+    //     return GetVarUInt32Size(n);
+    // }
+
     int nRet = 0;
     while(true) {
         nRet++;
@@ -418,6 +436,44 @@ inline unsigned int GetSizeOfVarInt(I n)
     return nRet;
 }
 
+inline void WriteVarUInt32(Span<std::byte> out, uint32_t n)
+{
+    if (out.size() == 1) {
+        out[0] = static_cast<std::byte>(n);
+    } else if (out.size() == 2) {
+        out[0] = static_cast<std::byte>(((n >> 7) - 1) | 0x80);
+        out[1] = static_cast<std::byte>(n & 0x7F); // TODO make sure tests fail without the mask
+    } else {
+        auto rev{std::ranges::reverse_view(out)};
+        rev[0] = static_cast<std::byte>(n & 0x7F);
+        for (size_t i{1}; i < out.size(); ++i) {
+            n = (n >> 7) - 1;
+            rev[i] = static_cast<std::byte>((n & 0x7F) | 0x80);
+        }
+    }
+}
+
+inline void ReadVarUInt32(const Span<const std::byte> in, uint32_t& n)
+{
+    assert(!in.empty() && in.size() <= 5);
+
+    if (in.size() == 1) {
+        n = static_cast<uint8_t>(in[0]);
+    } else if (in.size() == 2) {
+        n = static_cast<uint8_t>(in[0]) & 0x7F;
+        // TODO validate it's not max
+        n = ((n + 1) << 7) | static_cast<uint8_t>(in[1]);
+    } else {
+        n = static_cast<uint8_t>(in[0]) & 0x7F;
+        for (size_t i = 1; i < in.size() - 1; ++i) {
+            n = ((n + 1) << 7) | (static_cast<uint8_t>(in[i]) & 0x7F);
+            // TODO validate it's not max
+        }
+        n = ((n + 1) << 7) | static_cast<uint8_t>(in[in.size() - 1]);
+    }
+    assert(in.size() == GetVarUInt32Size(n));
+}
+
 template<typename I>
 inline void WriteVarInt(SizeComputer& os, I n);
 
@@ -425,6 +481,7 @@ template<typename Stream, VarIntMode Mode, typename I>
 void WriteVarInt(Stream& os, I n)
 {
     CheckVarIntMode<Mode, I>();
+    // TODO if constexpr (std::is_same_v<I, uint32_t>) {
     unsigned char tmp[(sizeof(n)*8+6)/7];
     int len=0;
     while(true) {

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -26,6 +26,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <util/check.h>
 
 /**
  * The maximum size of a serialized object in bytes or number of elements
@@ -438,6 +439,7 @@ unsigned int GetSizeOfVarInt(I n)
 
 inline void WriteVarUInt32(Span<std::byte> out, uint32_t n)
 {
+    // Assert(out.size() == GetVarUInt32Size(n));
     if (out.size() == 1) {
         out[0] = static_cast<std::byte>(n);
     } else if (out.size() == 2) {
@@ -472,6 +474,7 @@ inline void ReadVarUInt32(const Span<const std::byte> in, uint32_t& n)
         n = ((n + 1) << 7) | static_cast<uint8_t>(in[in.size() - 1]);
     }
     assert(in.size() == GetVarUInt32Size(n));
+    // TODO check that reserializing it would still result in the same
 }
 
 template<typename I>

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -23,7 +23,7 @@
 
 using namespace util::hex_literals;
 
-int ApplyTxInUndo(Coin&& undo, CCoinsViewCache& view, const COutPoint& out);
+int ApplyTxInUndo(Coin&& undo, CCoinsViewCache& view, const COutPoint& out, Span<std::byte> key_buffer);
 void UpdateCoins(const CTransaction& tx, CCoinsViewCache& inputs, CTxUndo &txundo, int nHeight);
 
 namespace
@@ -46,7 +46,7 @@ class CCoinsViewTest : public CCoinsView
 public:
     CCoinsViewTest(FastRandomContext& rng) : m_rng{rng} {}
 
-    std::optional<Coin> GetCoin(const COutPoint& outpoint) const override
+    std::optional<Coin> GetCoin(const COutPoint& outpoint, Span<std::byte> key_buffer) const override
     {
         if (auto it{map_.find(outpoint)}; it != map_.end()) {
             if (!it->second.IsSpent() || m_rng.randbool()) {
@@ -149,6 +149,8 @@ void SimulationTest(CCoinsView* base, bool fake_best_block)
         txids[i] = Txid::FromUint256(m_rng.rand256());
     }
 
+    DataStream key_buffer;
+    key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
     for (unsigned int i = 0; i < NUM_SIMULATION_ITERATIONS; i++) {
         // Do a random modification.
         {
@@ -161,12 +163,12 @@ void SimulationTest(CCoinsView* base, bool fake_best_block)
             bool test_havecoin_before = m_rng.randbits(2) == 0;
             bool test_havecoin_after = m_rng.randbits(2) == 0;
 
-            bool result_havecoin = test_havecoin_before ? stack.back()->HaveCoin(COutPoint(txid, 0)) : false;
+            bool result_havecoin = test_havecoin_before ? stack.back()->HaveCoin(COutPoint(txid, 0), key_buffer) : false;
 
             // Infrequently, test usage of AccessByTxid instead of AccessCoin - the
             // former just delegates to the latter and returns the first unspent in a txn.
             const Coin& entry = (m_rng.randrange(500) == 0) ?
-                AccessByTxid(*stack.back(), txid) : stack.back()->AccessCoin(COutPoint(txid, 0));
+                AccessByTxid(*stack.back(), txid) : stack.back()->AccessCoin(COutPoint(txid, 0), key_buffer);
             BOOST_CHECK(coin == entry);
 
             if (test_havecoin_before) {
@@ -174,7 +176,7 @@ void SimulationTest(CCoinsView* base, bool fake_best_block)
             }
 
             if (test_havecoin_after) {
-                bool ret = stack.back()->HaveCoin(COutPoint(txid, 0));
+                bool ret = stack.back()->HaveCoin(COutPoint(txid, 0), key_buffer);
                 BOOST_CHECK(ret == !entry.IsSpent());
             }
 
@@ -200,7 +202,7 @@ void SimulationTest(CCoinsView* base, bool fake_best_block)
                 // Spend the coin.
                 removed_an_entry = true;
                 coin.Clear();
-                BOOST_CHECK(stack.back()->SpendCoin(COutPoint(txid, 0)));
+                BOOST_CHECK(stack.back()->SpendCoin(COutPoint(txid, 0), nullptr, key_buffer));
             }
         }
 
@@ -215,8 +217,8 @@ void SimulationTest(CCoinsView* base, bool fake_best_block)
         // Once every 1000 iterations and at the end, verify the full cache.
         if (m_rng.randrange(1000) == 1 || i == NUM_SIMULATION_ITERATIONS - 1) {
             for (const auto& entry : result) {
-                bool have = stack.back()->HaveCoin(entry.first);
-                const Coin& coin = stack.back()->AccessCoin(entry.first);
+                bool have = stack.back()->HaveCoin(entry.first, key_buffer);
+                const Coin& coin = stack.back()->AccessCoin(entry.first, key_buffer);
                 BOOST_CHECK(have == !coin.IsSpent());
                 BOOST_CHECK(coin == entry.second);
                 if (coin.IsSpent()) {
@@ -346,6 +348,8 @@ BOOST_FIXTURE_TEST_CASE(updatecoins_simulation_test, UpdateTest)
     std::set<COutPoint> duplicate_coins;
     std::set<COutPoint> utxoset;
 
+    DataStream key_buffer;
+    key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
     for (unsigned int i = 0; i < NUM_SIMULATION_ITERATIONS; i++) {
         uint32_t randiter = m_rng.rand32();
 
@@ -455,12 +459,12 @@ BOOST_FIXTURE_TEST_CASE(updatecoins_simulation_test, UpdateTest)
             // Disconnect the tx from the current UTXO
             // See code in DisconnectBlock
             // remove outputs
-            BOOST_CHECK(stack.back()->SpendCoin(utxod->first));
+            BOOST_CHECK(stack.back()->SpendCoin(utxod->first, nullptr, key_buffer));
             // restore inputs
             if (!tx.IsCoinBase()) {
                 const COutPoint &out = tx.vin[0].prevout;
                 Coin coin = undo.vprevout[0];
-                ApplyTxInUndo(std::move(coin), *(stack.back()), out);
+                ApplyTxInUndo(std::move(coin), *(stack.back()), out, key_buffer);
             }
             // Store as a candidate for reconnection
             disconnected_coins.insert(utxod->first);
@@ -474,8 +478,8 @@ BOOST_FIXTURE_TEST_CASE(updatecoins_simulation_test, UpdateTest)
         // Once every 1000 iterations and at the end, verify the full cache.
         if (m_rng.randrange(1000) == 1 || i == NUM_SIMULATION_ITERATIONS - 1) {
             for (const auto& entry : result) {
-                bool have = stack.back()->HaveCoin(entry.first);
-                const Coin& coin = stack.back()->AccessCoin(entry.first);
+                bool have = stack.back()->HaveCoin(entry.first, key_buffer);
+                const Coin& coin = stack.back()->AccessCoin(entry.first, key_buffer);
                 BOOST_CHECK(have == !coin.IsSpent());
                 BOOST_CHECK(coin == entry.second);
             }
@@ -685,8 +689,10 @@ public:
 static void CheckAccessCoin(const CAmount base_value, const MaybeCoin& cache_coin, const MaybeCoin& expected)
 {
     SingleEntryCacheTest test{base_value, cache_coin};
-    auto& coin = test.cache.AccessCoin(OUTPOINT);
-    BOOST_CHECK_EQUAL(coin.IsSpent(), !test.cache.GetCoin(OUTPOINT));
+    DataStream key_buffer;
+    key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
+    auto& coin = test.cache.AccessCoin(OUTPOINT, key_buffer);
+    BOOST_CHECK_EQUAL(coin.IsSpent(), !test.cache.GetCoin(OUTPOINT, key_buffer));
     test.cache.SelfTest(/*sanity_check=*/false);
     BOOST_CHECK_EQUAL(GetCoinsMapEntry(test.cache.map()), expected);
 }
@@ -716,7 +722,9 @@ BOOST_AUTO_TEST_CASE(ccoins_access)
 static void CheckSpendCoins(const CAmount base_value, const MaybeCoin& cache_coin, const MaybeCoin& expected)
 {
     SingleEntryCacheTest test{base_value, cache_coin};
-    test.cache.SpendCoin(OUTPOINT);
+    DataStream key_buffer;
+    key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
+    test.cache.SpendCoin(OUTPOINT, nullptr, key_buffer);
     test.cache.SelfTest();
     BOOST_CHECK_EQUAL(GetCoinsMapEntry(test.cache.map()), expected);
 }
@@ -921,8 +929,11 @@ void TestFlushBehavior(
     COutPoint outp = COutPoint(txid, 0);
     Coin coin = MakeCoin();
     // Ensure the coins views haven't seen this coin before.
-    BOOST_CHECK(!base.HaveCoin(outp));
-    BOOST_CHECK(!view->HaveCoin(outp));
+    DataStream key_buffer;
+    key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
+
+    BOOST_CHECK(!base.HaveCoin(outp, key_buffer));
+    BOOST_CHECK(!view->HaveCoin(outp, key_buffer));
 
     // --- 1. Adding a random coin to the child cache
     //
@@ -932,8 +943,8 @@ void TestFlushBehavior(
     cache_size = view->map().size();
 
     // `base` shouldn't have coin (no flush yet) but `view` should have cached it.
-    BOOST_CHECK(!base.HaveCoin(outp));
-    BOOST_CHECK(view->HaveCoin(outp));
+    BOOST_CHECK(!base.HaveCoin(outp, key_buffer));
+    BOOST_CHECK(view->HaveCoin(outp, key_buffer));
 
     BOOST_CHECK_EQUAL(GetCoinsMapEntry(view->map(), outp), CoinEntry(coin.out.nValue, CoinEntry::State::DIRTY_FRESH));
 
@@ -950,8 +961,8 @@ void TestFlushBehavior(
     BOOST_CHECK_EQUAL(GetCoinsMapEntry(view->map(), outp), CoinEntry(coin.out.nValue, CoinEntry::State::CLEAN)); // State should have been wiped.
 
     // Both views should now have the coin.
-    BOOST_CHECK(base.HaveCoin(outp));
-    BOOST_CHECK(view->HaveCoin(outp));
+    BOOST_CHECK(base.HaveCoin(outp, key_buffer));
+    BOOST_CHECK(view->HaveCoin(outp, key_buffer));
 
     if (do_erasing_flush) {
         // --- 4. Flushing the caches again (with erasing)
@@ -966,7 +977,7 @@ void TestFlushBehavior(
         // --- 5. Ensuring the entry is no longer in the cache
         //
         BOOST_CHECK(!GetCoinsMapEntry(view->map(), outp));
-        view->AccessCoin(outp);
+        view->AccessCoin(outp, key_buffer);
         BOOST_CHECK_EQUAL(GetCoinsMapEntry(view->map(), outp), CoinEntry(coin.out.nValue, CoinEntry::State::CLEAN));
     }
 
@@ -978,21 +989,21 @@ void TestFlushBehavior(
 
     // --- 6. Spend the coin.
     //
-    BOOST_CHECK(view->SpendCoin(outp));
+    BOOST_CHECK(view->SpendCoin(outp, nullptr, key_buffer));
 
     // The coin should be in the cache, but spent and marked dirty.
     BOOST_CHECK_EQUAL(GetCoinsMapEntry(view->map(), outp), SPENT_DIRTY);
-    BOOST_CHECK(!view->HaveCoin(outp)); // Coin should be considered spent in `view`.
-    BOOST_CHECK(base.HaveCoin(outp));  // But coin should still be unspent in `base`.
+    BOOST_CHECK(!view->HaveCoin(outp, key_buffer)); // Coin should be considered spent in `view`.
+    BOOST_CHECK(base.HaveCoin(outp, key_buffer));  // But coin should still be unspent in `base`.
 
     flush_all(/*erase=*/ false);
 
     // Coin should be considered spent in both views.
-    BOOST_CHECK(!view->HaveCoin(outp));
-    BOOST_CHECK(!base.HaveCoin(outp));
+    BOOST_CHECK(!view->HaveCoin(outp, key_buffer));
+    BOOST_CHECK(!base.HaveCoin(outp, key_buffer));
 
     // Spent coin should not be spendable.
-    BOOST_CHECK(!view->SpendCoin(outp));
+    BOOST_CHECK(!view->SpendCoin(outp, nullptr, key_buffer));
 
     // --- Bonus check: ensure that a coin added to the base view via one cache
     //     can be spent by another cache which has never seen it.
@@ -1000,21 +1011,21 @@ void TestFlushBehavior(
     txid = Txid::FromUint256(m_rng.rand256());
     outp = COutPoint(txid, 0);
     coin = MakeCoin();
-    BOOST_CHECK(!base.HaveCoin(outp));
-    BOOST_CHECK(!all_caches[0]->HaveCoin(outp));
-    BOOST_CHECK(!all_caches[1]->HaveCoin(outp));
+    BOOST_CHECK(!base.HaveCoin(outp, key_buffer));
+    BOOST_CHECK(!all_caches[0]->HaveCoin(outp, key_buffer));
+    BOOST_CHECK(!all_caches[1]->HaveCoin(outp, key_buffer));
 
     all_caches[0]->AddCoin(outp, std::move(coin), false);
     all_caches[0]->Sync();
-    BOOST_CHECK(base.HaveCoin(outp));
-    BOOST_CHECK(all_caches[0]->HaveCoin(outp));
+    BOOST_CHECK(base.HaveCoin(outp, key_buffer));
+    BOOST_CHECK(all_caches[0]->HaveCoin(outp, key_buffer));
     BOOST_CHECK(!all_caches[1]->HaveCoinInCache(outp));
 
-    BOOST_CHECK(all_caches[1]->SpendCoin(outp));
+    BOOST_CHECK(all_caches[1]->SpendCoin(outp, nullptr, key_buffer));
     flush_all(/*erase=*/ false);
-    BOOST_CHECK(!base.HaveCoin(outp));
-    BOOST_CHECK(!all_caches[0]->HaveCoin(outp));
-    BOOST_CHECK(!all_caches[1]->HaveCoin(outp));
+    BOOST_CHECK(!base.HaveCoin(outp, key_buffer));
+    BOOST_CHECK(!all_caches[0]->HaveCoin(outp, key_buffer));
+    BOOST_CHECK(!all_caches[1]->HaveCoin(outp, key_buffer));
 
     flush_all(/*erase=*/ true); // Erase all cache content.
 
@@ -1024,9 +1035,9 @@ void TestFlushBehavior(
     outp = COutPoint(txid, 0);
     coin = MakeCoin();
     CAmount coin_val = coin.out.nValue;
-    BOOST_CHECK(!base.HaveCoin(outp));
-    BOOST_CHECK(!all_caches[0]->HaveCoin(outp));
-    BOOST_CHECK(!all_caches[1]->HaveCoin(outp));
+    BOOST_CHECK(!base.HaveCoin(outp, key_buffer));
+    BOOST_CHECK(!all_caches[0]->HaveCoin(outp, key_buffer));
+    BOOST_CHECK(!all_caches[1]->HaveCoin(outp, key_buffer));
 
     // Add and spend from same cache without flushing.
     all_caches[0]->AddCoin(outp, std::move(coin), false);
@@ -1034,15 +1045,15 @@ void TestFlushBehavior(
     // Coin should be FRESH in the cache.
     BOOST_CHECK_EQUAL(GetCoinsMapEntry(all_caches[0]->map(), outp), CoinEntry(coin_val, CoinEntry::State::DIRTY_FRESH));
     // Base shouldn't have seen coin.
-    BOOST_CHECK(!base.HaveCoin(outp));
+    BOOST_CHECK(!base.HaveCoin(outp, key_buffer));
 
-    BOOST_CHECK(all_caches[0]->SpendCoin(outp));
+    BOOST_CHECK(all_caches[0]->SpendCoin(outp, nullptr, key_buffer));
     all_caches[0]->Sync();
 
     // Ensure there is no sign of the coin after spend/flush.
     BOOST_CHECK(!GetCoinsMapEntry(all_caches[0]->map(), outp));
     BOOST_CHECK(!all_caches[0]->HaveCoinInCache(outp));
-    BOOST_CHECK(!base.HaveCoin(outp));
+    BOOST_CHECK(!base.HaveCoin(outp, key_buffer));
 }
 }; // struct FlushTest
 

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -93,7 +93,9 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsView& backend
             },
             [&] {
                 Coin move_to;
-                (void)coins_view_cache.SpendCoin(random_out_point, fuzzed_data_provider.ConsumeBool() ? &move_to : nullptr);
+                DataStream key_buffer;
+                key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
+                (void)coins_view_cache.SpendCoin(random_out_point, fuzzed_data_provider.ConsumeBool() ? &move_to : nullptr, key_buffer);
             },
             [&] {
                 coins_view_cache.Uncache(random_out_point);
@@ -173,22 +175,26 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsView& backend
     }
 
     {
-        const Coin& coin_using_access_coin = coins_view_cache.AccessCoin(random_out_point);
+        DataStream key_buffer;
+        key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
+        const Coin& coin_using_access_coin = coins_view_cache.AccessCoin(random_out_point, key_buffer);
         const bool exists_using_access_coin = !(coin_using_access_coin == EMPTY_COIN);
-        const bool exists_using_have_coin = coins_view_cache.HaveCoin(random_out_point);
+        DataStream key_buffer;
+        key_buffer.resize(MAX_BLOCK_SERIALIZED_SIZE);
+        const bool exists_using_have_coin = coins_view_cache.HaveCoin(random_out_point, key_buffer);
         const bool exists_using_have_coin_in_cache = coins_view_cache.HaveCoinInCache(random_out_point);
-        if (auto coin{coins_view_cache.GetCoin(random_out_point)}) {
+        if (auto coin{coins_view_cache.GetCoin(random_out_point, key_buffer)}) {
             assert(*coin == coin_using_access_coin);
             assert(exists_using_access_coin && exists_using_have_coin_in_cache && exists_using_have_coin);
         } else {
             assert(!exists_using_access_coin && !exists_using_have_coin_in_cache && !exists_using_have_coin);
         }
         // If HaveCoin on the backend is true, it must also be on the cache if the coin wasn't spent.
-        const bool exists_using_have_coin_in_backend = backend_coins_view.HaveCoin(random_out_point);
+        const bool exists_using_have_coin_in_backend = backend_coins_view.HaveCoin(random_out_point, key_buffer);
         if (!coin_using_access_coin.IsSpent() && exists_using_have_coin_in_backend) {
             assert(exists_using_have_coin);
         }
-        if (auto coin{backend_coins_view.GetCoin(random_out_point)}) {
+        if (auto coin{backend_coins_view.GetCoin(random_out_point, key_buffer)}) {
             assert(exists_using_have_coin_in_backend);
             // Note we can't assert that `coin_using_get_coin == *coin` because the coin in
             // the cache may have been modified but not yet flushed.
@@ -240,8 +246,10 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsView& backend
                 bool expected_code_path = false;
                 const int height{int(fuzzed_data_provider.ConsumeIntegral<uint32_t>() >> 1)};
                 const bool possible_overwrite = fuzzed_data_provider.ConsumeBool();
+                DataStream key_buffer;
+                key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
                 try {
-                    AddCoins(coins_view_cache, transaction, height, possible_overwrite);
+                    AddCoins(coins_view_cache, transaction, height, possible_overwrite, key_buffer);
                     expected_code_path = true;
                 } catch (const std::logic_error& e) {
                     if (e.what() == std::string{"Attempted to overwrite an unspent coin (when possible_overwrite is false)"}) {
@@ -260,7 +268,7 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsView& backend
                 const CTransaction transaction{random_mutable_transaction};
                 if (ContainsSpentInput(transaction, coins_view_cache)) {
                     // Avoid:
-                    // consensus/tx_verify.cpp:171: bool Consensus::CheckTxInputs(const CTransaction &, TxValidationState &, const CCoinsViewCache &, int, CAmount &): Assertion `!coin.IsSpent()' failed.
+                    // consensus/tx_verify.cpp:171: bool Consensus::CheckTxInputs(const CTransaction &, TxValidationState &, const CCoinsViewCache &, int, CAmount &): Assertion `!coin.IsSpent()' failed. // TODO
                     return;
                 }
                 TxValidationState dummy;
@@ -268,7 +276,9 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsView& backend
                     // It is not allowed to call CheckTxInputs if CheckTransaction failed
                     return;
                 }
-                if (Consensus::CheckTxInputs(transaction, state, coins_view_cache, fuzzed_data_provider.ConsumeIntegralInRange<int>(0, std::numeric_limits<int>::max()), tx_fee_out)) {
+                DataStream key_buffer;
+                key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
+                if (Consensus::CheckTxInputs(transaction, state, coins_view_cache, fuzzed_data_provider.ConsumeIntegralInRange<int>(0, std::numeric_limits<int>::max()), tx_fee_out, key_buffer)) {
                     assert(MoneyRange(tx_fee_out));
                 }
             },

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -218,8 +218,10 @@ FUZZ_TARGET(tx_pool_standard, .init = initialize_tx_pool)
 
     // Helper to query an amount
     const CCoinsViewMemPool amount_view{WITH_LOCK(::cs_main, return &chainstate.CoinsTip()), tx_pool};
+    DataStream key_buffer;
+    key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
     const auto GetAmount = [&](const COutPoint& outpoint) {
-        auto coin{amount_view.GetCoin(outpoint).value()};
+        auto coin{amount_view.GetCoin(outpoint, key_buffer).value()};
         return coin.out.nValue;
     };
 

--- a/src/test/fuzz/util.cpp
+++ b/src/test/fuzz/util.cpp
@@ -239,8 +239,10 @@ CKey ConsumePrivateKey(FuzzedDataProvider& fuzzed_data_provider, std::optional<b
 
 bool ContainsSpentInput(const CTransaction& tx, const CCoinsViewCache& inputs) noexcept
 {
+    DataStream key_buffer;
+    key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
     for (const CTxIn& tx_in : tx.vin) {
-        const Coin& coin = inputs.AccessCoin(tx_in.prevout);
+        const Coin& coin = inputs.AccessCoin(tx_in.prevout, key_buffer);
         if (coin.IsSpent()) {
             return true;
         }

--- a/src/test/fuzz/utxo_snapshot.cpp
+++ b/src/test/fuzz/utxo_snapshot.cpp
@@ -186,8 +186,10 @@ void utxo_snapshot_fuzz(FuzzBufferType buffer)
         Assert(*chainman.ActiveChainstate().m_from_snapshot_blockhash ==
                *chainman.SnapshotBlockhash());
         const auto& coinscache{chainman.ActiveChainstate().CoinsTip()};
+        DataStream key_buffer;
+        key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
         for (const auto& block : *g_chain) {
-            Assert(coinscache.HaveCoin(COutPoint{block->vtx.at(0)->GetHash(), 0}));
+            Assert(coinscache.HaveCoin(COutPoint{block->vtx.at(0)->GetHash(), 0}, key_buffer));
             const auto* index{chainman.m_blockman.LookupBlockIndex(block->GetHash())};
             Assert(index);
             Assert(index->nTx == 0);

--- a/src/test/script_p2sh_tests.cpp
+++ b/src/test/script_p2sh_tests.cpp
@@ -336,7 +336,9 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
     txFrom.vout[6].scriptPubKey = GetScriptForDestination(ScriptHash(twentySigops));
     txFrom.vout[6].nValue = 6000;
 
-    AddCoins(coins, CTransaction(txFrom), 0);
+    DataStream key_buffer;
+    key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
+    AddCoins(coins, CTransaction(txFrom), 0, false, key_buffer);
 
     CMutableTransaction txTo;
     txTo.vout.resize(1);

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -14,6 +14,7 @@
 #include <txdb.h>
 
 #include <boost/test/unit_test.hpp>
+#include <consensus/consensus.h>
 
 BOOST_FIXTURE_TEST_SUITE(serialize_tests, BasicTestingSetup)
 

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <hash.h>
+#include <random.h>
 #include <serialize.h>
 #include <streams.h>
 #include <test/util/setup_common.h>
@@ -10,6 +11,7 @@
 
 #include <cstdint>
 #include <string>
+#include <txdb.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -494,6 +496,65 @@ BOOST_AUTO_TEST_CASE(with_params_derived)
 
     BOOST_CHECK_EQUAL(stream.str(), "\x0F\x02xy"
                                     "0f\x02XY");
+}
+
+BOOST_AUTO_TEST_CASE(varint_serialization_equivalence)
+{
+    FastRandomContext rnd;
+    for (size_t i{0}; i < 1000; ++i) {
+        const auto num{rnd.randbool() ? rnd.randrange(rnd.randbool() ? 128 : 16'512) : rnd.rand32()};
+        const auto original_opn{GetSizeOfVarInt<VarIntMode::DEFAULT>(num)};
+        const auto actual_opn{GetVarUInt32Size(num)};
+        BOOST_CHECK_EQUAL(actual_opn, original_opn);
+    }
+}
+
+namespace {
+struct TestCoinEntry {
+    COutPoint* outpoint;
+    uint8_t key;
+    explicit TestCoinEntry(const COutPoint* ptr) : outpoint(const_cast<COutPoint*>(ptr)), key(DB_COIN)  {}
+
+    SERIALIZE_METHODS(TestCoinEntry, obj) { READWRITE(obj.key, obj.outpoint->hash, VARINT(obj.outpoint->n)); }
+};
+}
+
+BOOST_AUTO_TEST_CASE(outpoint_serialization_equivalence)
+{
+    FastRandomContext rnd;
+    for (size_t i{0}; i < 1000; ++i) {
+        const COutPoint op{Txid::FromUint256(rnd.rand256()), rnd.randbool() ? rnd.randrange(rnd.randbool() ? 128 : 16'512) : rnd.rand32()};
+
+        DataStream original;
+        original << TestCoinEntry(&op);
+        BOOST_CHECK_EQUAL(original.size(), SerializedSize(op));
+
+        DataStream actual;
+        actual.resize(SerializedSize(op));
+        size_t written{WriteCOutPoint(actual, op)};
+        BOOST_CHECK_EQUAL(written, actual.size());
+
+        BOOST_CHECK_EQUAL(original.str(), actual.str());
+        BOOST_CHECK_EQUAL(written - 1 - sizeof(uint256), GetSizeOfVarInt<VarIntMode::DEFAULT>(op.n));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(outpoint_serialization_roundtrip)
+{
+    FastRandomContext rnd;
+    for (size_t i{0}; i < 1000; ++i) {
+        const COutPoint op{Txid::FromUint256(rnd.rand256()), rnd.randbool() ? rnd.randrange(rnd.randbool() ? 128 : 16'512) : rnd.rand32()};
+
+        DataStream serialized;
+        serialized.resize(SerializedSize(op));
+        WriteCOutPoint(serialized, op);
+
+        COutPoint deserialized;
+        ReadCOutPoint(serialized, deserialized);
+
+        BOOST_CHECK_EQUAL(op.hash, deserialized.hash);
+        BOOST_CHECK_EQUAL(op.n, deserialized.n);
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -501,12 +501,23 @@ BOOST_AUTO_TEST_CASE(with_params_derived)
 
 BOOST_AUTO_TEST_CASE(varint_serialization_equivalence)
 {
-    FastRandomContext rnd;
+    FastRandomContext rng{/*fDeterministic=*/false};
     for (size_t i{0}; i < 1000; ++i) {
-        const auto num{rnd.randbool() ? rnd.randrange(rnd.randbool() ? 128 : 16'512) : rnd.rand32()};
+        // SizeOfVarInt
+        const auto num{rng.randbool() ? rng.randrange(rng.randbool() ? 128 : 16'512) : rng.rand32()};
         const auto original_opn{GetSizeOfVarInt<VarIntMode::DEFAULT>(num)};
         const auto actual_opn{GetVarUInt32Size(num)};
         BOOST_CHECK_EQUAL(actual_opn, original_opn);
+
+        // VARINT
+        DataStream original;
+        original << VARINT(num);
+
+        DataStream actual;
+        actual.resize(actual_opn);
+        WriteVarUInt32(actual, num);
+
+        BOOST_CHECK_EQUAL(actual.str(), original.str());
     }
 }
 
@@ -522,36 +533,39 @@ struct TestCoinEntry {
 
 BOOST_AUTO_TEST_CASE(outpoint_serialization_equivalence)
 {
-    FastRandomContext rnd;
+    FastRandomContext rng{/*fDeterministic=*/false};
+
+    DataStream actual;
+    actual.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
+
     for (size_t i{0}; i < 1000; ++i) {
-        const COutPoint op{Txid::FromUint256(rnd.rand256()), rnd.randbool() ? rnd.randrange(rnd.randbool() ? 128 : 16'512) : rnd.rand32()};
+        const COutPoint op{Txid::FromUint256(rng.rand256()), rng.randbool() ? rng.randrange(rng.randbool() ? 128 : 16'512) : rng.rand32()};
 
         DataStream original;
         original << TestCoinEntry(&op);
         BOOST_CHECK_EQUAL(original.size(), SerializedSize(op));
 
-        DataStream actual;
-        actual.resize(SerializedSize(op));
-        size_t written{WriteCOutPoint(actual, op)};
-        BOOST_CHECK_EQUAL(written, actual.size());
-
-        BOOST_CHECK_EQUAL(original.str(), actual.str());
-        BOOST_CHECK_EQUAL(written - 1 - sizeof(uint256), GetSizeOfVarInt<VarIntMode::DEFAULT>(op.n));
+        auto serialized{WriteCOutPoint(actual, op)};
+        BOOST_CHECK_EQUAL(serialized.size(), original.size());
+        BOOST_CHECK_EQUAL(serialized.size() - 1 - sizeof(uint256), GetSizeOfVarInt<VarIntMode::DEFAULT>(op.n));
+        BOOST_CHECK_EQUAL_COLLECTIONS(serialized.begin(), serialized.end(), original.begin(), original.end());
     }
 }
 
 BOOST_AUTO_TEST_CASE(outpoint_serialization_roundtrip)
 {
-    FastRandomContext rnd;
-    for (size_t i{0}; i < 1000; ++i) {
-        const COutPoint op{Txid::FromUint256(rnd.rand256()), rnd.randbool() ? rnd.randrange(rnd.randbool() ? 128 : 16'512) : rnd.rand32()};
+    FastRandomContext rng{/*fDeterministic=*/false};
 
-        DataStream serialized;
-        serialized.resize(SerializedSize(op));
-        WriteCOutPoint(serialized, op);
+    DataStream serialized;
+    serialized.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
+
+    for (size_t i{0}; i < 1000; ++i) {
+        const COutPoint op{Txid::FromUint256(rng.rand256()), rng.randbool() ? rng.randrange(rng.randbool() ? 128 : 16'512) : rng.rand32()};
+
+        auto bytes{WriteCOutPoint(serialized, op)};
 
         COutPoint deserialized;
-        ReadCOutPoint(serialized, deserialized);
+        ReadCOutPoint(bytes, deserialized);
 
         BOOST_CHECK_EQUAL(op.hash, deserialized.hash);
         BOOST_CHECK_EQUAL(op.n, deserialized.n);

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -104,7 +104,9 @@ static void BuildTxs(CMutableTransaction& spendingTx, CCoinsViewCache& coins, CM
     spendingTx.vout[0].nValue = 1;
     spendingTx.vout[0].scriptPubKey = CScript();
 
-    AddCoins(coins, CTransaction(creationTx), 0);
+    DataStream key_buffer;
+    key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
+    AddCoins(coins, CTransaction(creationTx), 0, false, key_buffer);
 }
 
 BOOST_AUTO_TEST_CASE(GetTxSigOpCost)

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -458,15 +458,17 @@ std::pair<CMutableTransaction, CAmount> TestChain100Setup::CreateValidTransactio
     // - Populate a CoinsViewCache with the unspent output
     CCoinsView coins_view;
     CCoinsViewCache coins_cache(&coins_view);
+    DataStream key_buffer;
+    key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
     for (const auto& input_transaction : input_transactions) {
-        AddCoins(coins_cache, *input_transaction.get(), input_height);
+        AddCoins(coins_cache, *input_transaction.get(), input_height, false, key_buffer);
     }
     // Build Outpoint to Coin map for SignTransaction
     std::map<COutPoint, Coin> input_coins;
     CAmount inputs_amount{0};
     for (const auto& outpoint_to_spend : inputs) {
         // Use GetCoin to properly populate utxo_to_spend
-        auto utxo_to_spend{coins_cache.GetCoin(outpoint_to_spend).value()};
+        auto utxo_to_spend{coins_cache.GetCoin(outpoint_to_spend, key_buffer).value()};
         input_coins.insert({outpoint_to_spend, utxo_to_spend});
         inputs_amount += utxo_to_spend.out.nValue;
     }

--- a/src/test/util/transaction_utils.cpp
+++ b/src/test/util/transaction_utils.cpp
@@ -59,14 +59,16 @@ std::vector<CMutableTransaction> SetupDummyInputs(FillableSigningProvider& keyst
     dummyTransactions[0].vout[0].scriptPubKey << ToByteVector(key[0].GetPubKey()) << OP_CHECKSIG;
     dummyTransactions[0].vout[1].nValue = nValues[1];
     dummyTransactions[0].vout[1].scriptPubKey << ToByteVector(key[1].GetPubKey()) << OP_CHECKSIG;
-    AddCoins(coinsRet, CTransaction(dummyTransactions[0]), 0);
+    DataStream key_buffer;
+    key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
+    AddCoins(coinsRet, CTransaction(dummyTransactions[0]), 0, false, key_buffer);
 
     dummyTransactions[1].vout.resize(2);
     dummyTransactions[1].vout[0].nValue = nValues[2];
     dummyTransactions[1].vout[0].scriptPubKey = GetScriptForDestination(PKHash(key[2].GetPubKey()));
     dummyTransactions[1].vout[1].nValue = nValues[3];
     dummyTransactions[1].vout[1].scriptPubKey = GetScriptForDestination(PKHash(key[3].GetPubKey()));
-    AddCoins(coinsRet, CTransaction(dummyTransactions[1]), 0);
+    AddCoins(coinsRet, CTransaction(dummyTransactions[1]), 0, false, key_buffer);
 
     return dummyTransactions;
 }

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -200,9 +200,11 @@ struct SnapshotTestSetup : TestChain100Setup {
             initial_size = ibd_coinscache.GetCacheSize();
             size_t total_coins{0};
 
+            DataStream key_buffer;
+            key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
             for (CTransactionRef& txn : m_coinbase_txns) {
                 COutPoint op{txn->GetHash(), 0};
-                BOOST_CHECK(ibd_coinscache.HaveCoin(op));
+                BOOST_CHECK(ibd_coinscache.HaveCoin(op, key_buffer));
                 total_coins++;
             }
 
@@ -300,6 +302,8 @@ struct SnapshotTestSetup : TestChain100Setup {
             LOCK(::cs_main);
             int chains_tested{0};
 
+            DataStream key_buffer;
+            key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
             for (Chainstate* chainstate : chainman.GetAll()) {
                 BOOST_TEST_MESSAGE("Checking coins in " << chainstate->ToString());
                 CCoinsViewCache& coinscache = chainstate->CoinsTip();
@@ -311,7 +315,7 @@ struct SnapshotTestSetup : TestChain100Setup {
 
                 for (CTransactionRef& txn : m_coinbase_txns) {
                     COutPoint op{txn->GetHash(), 0};
-                    BOOST_CHECK(coinscache.HaveCoin(op));
+                    BOOST_CHECK(coinscache.HaveCoin(op, key_buffer));
                     total_coins++;
                 }
 
@@ -333,6 +337,8 @@ struct SnapshotTestSetup : TestChain100Setup {
             size_t coins_in_background{0};
             size_t coins_missing_from_background{0};
 
+            DataStream key_buffer;
+            key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
             for (Chainstate* chainstate : chainman.GetAll()) {
                 BOOST_TEST_MESSAGE("Checking coins in " << chainstate->ToString());
                 CCoinsViewCache& coinscache = chainstate->CoinsTip();
@@ -340,7 +346,7 @@ struct SnapshotTestSetup : TestChain100Setup {
 
                 for (CTransactionRef& txn : m_coinbase_txns) {
                     COutPoint op{txn->GetHash(), 0};
-                    if (coinscache.HaveCoin(op)) {
+                    if (coinscache.HaveCoin(op, key_buffer)) {
                         (is_background ? coins_in_background : coins_in_active)++;
                     } else if (is_background) {
                         coins_missing_from_background++;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -49,13 +49,13 @@ void CCoinsViewDB::ResizeCache(size_t new_cache_size)
     }
 }
 
-std::optional<Coin> CCoinsViewDB::GetCoin(const COutPoint& outpoint) const
+std::optional<Coin> CCoinsViewDB::GetCoin(const COutPoint& outpoint, Span<std::byte> key_buffer) const
 {
     if (Coin coin; m_db->Read(CoinEntry(&outpoint), coin)) return coin; // TODO WriteCOutPoint
     return std::nullopt;
 }
 
-bool CCoinsViewDB::HaveCoin(const COutPoint &outpoint) const {
+bool CCoinsViewDB::HaveCoin(const COutPoint &outpoint, Span<std::byte> key_buffer) const {
     return m_db->Exists(CoinEntry(&outpoint)); // TODO WriteCOutPoint
 }
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -19,32 +19,16 @@
 #include <iterator>
 #include <utility>
 
-static constexpr uint8_t DB_COIN{'C'};
-static constexpr uint8_t DB_BEST_BLOCK{'B'};
-static constexpr uint8_t DB_HEAD_BLOCKS{'H'};
-// Keys used in previous version that might still be found in the DB:
-static constexpr uint8_t DB_COINS{'c'};
-
 bool CCoinsViewDB::NeedsUpgrade()
 {
+    // Keys used in previous version that might still be found in the DB:
+    constexpr uint8_t DB_COINS{'c'};
+
     std::unique_ptr<CDBIterator> cursor{m_db->NewIterator()};
-    // DB_COINS was deprecated in v0.15.0, commit
-    // 1088b02f0ccd7358d2b7076bb9e122d59d502d02
+    // DB_COINS was deprecated in v0.15.0, commit 1088b02f0ccd7358d2b7076bb9e122d59d502d02
     cursor->Seek(std::make_pair(DB_COINS, uint256{}));
     return cursor->Valid();
 }
-
-namespace {
-
-struct CoinEntry {
-    COutPoint* outpoint;
-    uint8_t key;
-    explicit CoinEntry(const COutPoint* ptr) : outpoint(const_cast<COutPoint*>(ptr)), key(DB_COIN)  {}
-
-    SERIALIZE_METHODS(CoinEntry, obj) { READWRITE(obj.key, obj.outpoint->hash, VARINT(obj.outpoint->n)); }
-};
-
-} // namespace
 
 CCoinsViewDB::CCoinsViewDB(DBParams db_params, CoinsViewOptions options) :
     m_db_params{std::move(db_params)},
@@ -67,12 +51,12 @@ void CCoinsViewDB::ResizeCache(size_t new_cache_size)
 
 std::optional<Coin> CCoinsViewDB::GetCoin(const COutPoint& outpoint) const
 {
-    if (Coin coin; m_db->Read(CoinEntry(&outpoint), coin)) return coin;
+    if (Coin coin; m_db->Read(CoinEntry(&outpoint), coin)) return coin; // TODO WriteCOutPoint
     return std::nullopt;
 }
 
 bool CCoinsViewDB::HaveCoin(const COutPoint &outpoint) const {
-    return m_db->Exists(CoinEntry(&outpoint));
+    return m_db->Exists(CoinEntry(&outpoint)); // TODO WriteCOutPoint
 }
 
 uint256 CCoinsViewDB::GetBestBlock() const {
@@ -118,7 +102,7 @@ bool CCoinsViewDB::BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashB
 
     for (auto it{cursor.Begin()}; it != cursor.End();) {
         if (it->second.IsDirty()) {
-            CoinEntry entry(&it->first);
+            CoinEntry entry(&it->first); // TODO WriteCOutPoint
             if (it->second.coin.IsSpent()) {
                 batch.Erase(entry);
             } else {
@@ -192,7 +176,7 @@ std::unique_ptr<CCoinsViewCursor> CCoinsViewDB::Cursor() const
     i->pcursor->Seek(DB_COIN);
     // Cache key of first record
     if (i->pcursor->Valid()) {
-        CoinEntry entry(&i->keyTmp.second);
+        CoinEntry entry(&i->keyTmp.second); // TODO WriteCOutPoint
         i->pcursor->GetKey(entry);
         i->keyTmp.first = entry.key;
     } else {
@@ -224,7 +208,7 @@ bool CCoinsViewDBCursor::Valid() const
 void CCoinsViewDBCursor::Next()
 {
     pcursor->Next();
-    CoinEntry entry(&keyTmp.second);
+    CoinEntry entry(&keyTmp.second); // TODO WriteCOutPoint
     if (!pcursor->Valid() || !pcursor->GetKey(entry)) {
         keyTmp.first = 0; // Invalidate cached key after last record so that Valid() and GetKey() return false
     } else {

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -24,6 +24,47 @@ class uint256;
 //! -dbbatchsize default (bytes)
 static const int64_t nDefaultDbBatchSize = 16 << 20;
 
+static constexpr uint8_t DB_COIN{'C'};
+static constexpr uint8_t DB_BEST_BLOCK{'B'};
+static constexpr uint8_t DB_HEAD_BLOCKS{'H'};
+
+struct CoinEntry {
+    COutPoint* outpoint;
+    uint8_t key;
+    explicit CoinEntry(const COutPoint* ptr) : outpoint(const_cast<COutPoint*>(ptr)), key(DB_COIN)  {}
+
+    SERIALIZE_METHODS(CoinEntry, obj) { READWRITE(obj.key, obj.outpoint->hash, VARINT(obj.outpoint->n)); }
+};
+
+inline size_t SerializedSize(const COutPoint& op) noexcept
+{
+    return 1 + sizeof(uint256) + GetVarUInt32Size(op.n);
+}
+
+inline size_t WriteCOutPoint(Span<std::byte> out, const COutPoint& op) noexcept
+{
+    const size_t size{SerializedSize(op)};
+    assert(out.size() >= size);
+
+    out[0] = std::byte{DB_COIN};
+    std::memcpy(&out[1], op.hash.begin(), sizeof(uint256));
+    WriteVarUInt32(out.subspan(1 + sizeof(uint256)), op.n);
+
+    return size;
+}
+
+inline void ReadCOutPoint(Span<const std::byte> in, COutPoint& op)
+{
+    assert(!in.empty());
+    assert(static_cast<uint8_t>(in[0]) == DB_COIN);
+    in = in.subspan(1);
+
+    assert(in.size() >= sizeof(uint256));
+    op.hash = Txid::FromUint256(uint256({reinterpret_cast<const uint8_t*>(in.begin()), sizeof(uint256)}));
+
+    ReadVarUInt32(in.subspan(sizeof(uint256)), op.n);
+}
+
 //! User-controlled performance and debug options.
 struct CoinsViewOptions {
     //! Maximum database write batch size in bytes.

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -36,7 +36,7 @@ struct CoinEntry {
     SERIALIZE_METHODS(CoinEntry, obj) { READWRITE(obj.key, obj.outpoint->hash, VARINT(obj.outpoint->n)); }
 };
 
-inline size_t SerializedSize(const COutPoint& op) noexcept
+static constexpr size_t SerializedSize(const COutPoint& op) noexcept
 {
     return 1 + sizeof(uint256) + GetVarUInt32Size(op.n);
 }
@@ -84,8 +84,8 @@ protected:
 public:
     explicit CCoinsViewDB(DBParams db_params, CoinsViewOptions options);
 
-    std::optional<Coin> GetCoin(const COutPoint& outpoint) const override;
-    bool HaveCoin(const COutPoint &outpoint) const override;
+    std::optional<Coin> GetCoin(const COutPoint& outpoint, Span<std::byte> key_buffer) const override;
+    bool HaveCoin(const COutPoint &outpoint, Span<std::byte> key_buffer) const override;
     uint256 GetBestBlock() const override;
     std::vector<uint256> GetHeadBlocks() const override;
     bool BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashBlock) override;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -31,7 +31,9 @@
 #include <numeric>
 #include <optional>
 #include <ranges>
+#include <streams.h>
 #include <string_view>
+#include <txdb.h>
 #include <utility>
 
 TRACEPOINT_SEMAPHORE(mempool, added);
@@ -706,6 +708,8 @@ void CTxMemPool::check(const CCoinsViewCache& active_coins_tip, int64_t spendhei
 
     CCoinsViewCache mempoolDuplicate(const_cast<CCoinsViewCache*>(&active_coins_tip));
 
+    DataStream key_buffer;
+    key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
     for (const auto& it : GetSortedDepthAndScore()) {
         checkTotal += it->GetTxSize();
         check_total_fee += it->GetFee();
@@ -724,7 +728,7 @@ void CTxMemPool::check(const CCoinsViewCache& active_coins_tip, int64_t spendhei
             // We are iterating through the mempool entries sorted in order by ancestor count.
             // All parents must have been checked before their children and their coins added to
             // the mempoolDuplicate coins cache.
-            assert(mempoolDuplicate.HaveCoin(txin.prevout));
+            assert(mempoolDuplicate.HaveCoin(txin.prevout, key_buffer));
             // Check whether its inputs are marked in mapNextTx.
             auto it3 = mapNextTx.find(txin.prevout);
             assert(it3 != mapNextTx.end());
@@ -777,9 +781,9 @@ void CTxMemPool::check(const CCoinsViewCache& active_coins_tip, int64_t spendhei
         TxValidationState dummy_state; // Not used. CheckTxInputs() should always pass
         CAmount txfee = 0;
         assert(!tx.IsCoinBase());
-        assert(Consensus::CheckTxInputs(tx, dummy_state, mempoolDuplicate, spendheight, txfee));
-        for (const auto& input: tx.vin) mempoolDuplicate.SpendCoin(input.prevout);
-        AddCoins(mempoolDuplicate, tx, std::numeric_limits<int>::max());
+        assert(Consensus::CheckTxInputs(tx, dummy_state, mempoolDuplicate, spendheight, txfee, key_buffer));
+        for (const auto& input: tx.vin) mempoolDuplicate.SpendCoin(input.prevout, nullptr, key_buffer);
+        AddCoins(mempoolDuplicate, tx, std::numeric_limits<int>::max(), false, key_buffer);
     }
     for (const auto& [_, next_tx] : mapNextTx) {
         auto it = mapTx.find(next_tx->GetHash());
@@ -1006,7 +1010,7 @@ bool CTxMemPool::HasNoInputsOf(const CTransaction &tx) const
 
 CCoinsViewMemPool::CCoinsViewMemPool(CCoinsView* baseIn, const CTxMemPool& mempoolIn) : CCoinsViewBacked(baseIn), mempool(mempoolIn) { }
 
-std::optional<Coin> CCoinsViewMemPool::GetCoin(const COutPoint& outpoint) const
+std::optional<Coin> CCoinsViewMemPool::GetCoin(const COutPoint& outpoint, Span<std::byte> key_buffer) const
 {
     // Check to see if the inputs are made available by another tx in the package.
     // These Coins would not be available in the underlying CoinsView.
@@ -1026,7 +1030,7 @@ std::optional<Coin> CCoinsViewMemPool::GetCoin(const COutPoint& outpoint) const
         }
         return std::nullopt;
     }
-    return base->GetCoin(outpoint);
+    return base->GetCoin(outpoint, key_buffer);
 }
 
 void CCoinsViewMemPool::PackageAddTransaction(const CTransactionRef& tx)

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -935,7 +935,7 @@ public:
     CCoinsViewMemPool(CCoinsView* baseIn, const CTxMemPool& mempoolIn);
     /** GetCoin, returning whether it exists and is not spent. Also updates m_non_base_coins if the
      * coin is not fetched from base. */
-    std::optional<Coin> GetCoin(const COutPoint& outpoint) const override;
+    std::optional<Coin> GetCoin(const COutPoint& outpoint, Span<std::byte> key_buffer) const override;
     /** Add the coins created by this transaction. These coins are only temporarily stored in
      * m_temp_added and cannot be flushed to the back end. Only used for package validation. */
     void PackageAddTransaction(const CTransactionRef& tx);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -185,8 +185,10 @@ std::optional<std::vector<int>> CalculatePrevHeights(
 {
     std::vector<int> prev_heights;
     prev_heights.resize(tx.vin.size());
+    DataStream key_buffer;
+    key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
     for (size_t i = 0; i < tx.vin.size(); ++i) {
-        if (auto coin{coins.GetCoin(tx.vin[i].prevout)}) {
+        if (auto coin{coins.GetCoin(tx.vin[i].prevout, key_buffer)}) {
             prev_heights[i] = coin->nHeight == MEMPOOL_HEIGHT
                               ? tip.nHeight + 1 // Assume all mempool transaction confirm in the next block.
                               : coin->nHeight;
@@ -371,9 +373,11 @@ void Chainstate::MaybeUpdateMempoolForReorg(
 
         // If the transaction spends any coinbase outputs, it must be mature.
         if (it->GetSpendsCoinbase()) {
+            DataStream key_buffer;
+            key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
             for (const CTxIn& txin : tx.vin) {
                 if (m_mempool->exists(txin.prevout.hash)) continue;
-                const Coin& coin{CoinsTip().AccessCoin(txin.prevout)};
+                const Coin& coin{CoinsTip().AccessCoin(txin.prevout, key_buffer)};
                 assert(!coin.IsSpent());
                 const auto mempool_spend_height{m_chain.Tip()->nHeight + 1};
                 if (coin.IsCoinBase() && mempool_spend_height - coin.nHeight < COINBASE_MATURITY) {
@@ -406,8 +410,10 @@ static bool CheckInputsFromMempoolAndCache(const CTransaction& tx, TxValidationS
     AssertLockHeld(pool.cs);
 
     assert(!tx.IsCoinBase());
+    DataStream key_buffer;
+    key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
     for (const CTxIn& txin : tx.vin) {
-        const Coin& coin = view.AccessCoin(txin.prevout);
+        const Coin& coin = view.AccessCoin(txin.prevout, key_buffer);
 
         // This coin was checked in PreChecks and MemPoolAccept
         // has been holding cs_main since then.
@@ -424,7 +430,7 @@ static bool CheckInputsFromMempoolAndCache(const CTransaction& tx, TxValidationS
             assert(txFrom->vout.size() > txin.prevout.n);
             assert(txFrom->vout[txin.prevout.n] == coin.out);
         } else {
-            const Coin& coinFromUTXOSet = coins_tip.AccessCoin(txin.prevout);
+            const Coin& coinFromUTXOSet = coins_tip.AccessCoin(txin.prevout, key_buffer);
             assert(!coinFromUTXOSet.IsSpent());
             assert(coinFromUTXOSet.out == coin.out);
         }
@@ -850,6 +856,8 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
 
     const CCoinsViewCache& coins_cache = m_active_chainstate.CoinsTip();
     // do all inputs exist?
+    DataStream key_buffer;
+    key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
     for (const CTxIn& txin : tx.vin) {
         if (!coins_cache.HaveCoinInCache(txin.prevout)) {
             coins_to_uncache.push_back(txin.prevout);
@@ -858,7 +866,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         // Note: this call may add txin.prevout to the coins cache
         // (coins_cache.cacheCoins) by way of FetchCoin(). It should be removed
         // later (via coins_to_uncache) if this tx turns out to be invalid.
-        if (!m_view.HaveCoin(txin.prevout)) {
+        if (!m_view.HaveCoin(txin.prevout, key_buffer)) {
             // Are inputs missing because we already have the tx?
             for (size_t out = 0; out < tx.vout.size(); out++) {
                 // Optimistically just do efficient check of cache for outputs
@@ -893,7 +901,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     }
 
     // The mempool holds txs for the next block, so pass height+1 to CheckTxInputs
-    if (!Consensus::CheckTxInputs(tx, state, m_view, m_active_chainstate.m_chain.Height() + 1, ws.m_base_fees)) {
+    if (!Consensus::CheckTxInputs(tx, state, m_view, m_active_chainstate.m_chain.Height() + 1, ws.m_base_fees, key_buffer)) {
         return false; // state filled in by CheckTxInputs
     }
 
@@ -912,7 +920,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     // during reorgs to ensure COINBASE_MATURITY is still met.
     bool fSpendsCoinbase = false;
     for (const CTxIn &txin : tx.vin) {
-        const Coin &coin = m_view.AccessCoin(txin.prevout);
+        const Coin &coin = m_view.AccessCoin(txin.prevout, key_buffer);
         if (coin.IsCoinBase()) {
             fSpendsCoinbase = true;
             break;
@@ -2080,16 +2088,18 @@ void Chainstate::InvalidBlockFound(CBlockIndex* pindex, const BlockValidationSta
 void UpdateCoins(const CTransaction& tx, CCoinsViewCache& inputs, CTxUndo &txundo, int nHeight)
 {
     // mark inputs spent
+    DataStream key_buffer;
+    key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
     if (!tx.IsCoinBase()) {
         txundo.vprevout.reserve(tx.vin.size());
         for (const CTxIn &txin : tx.vin) {
             txundo.vprevout.emplace_back();
-            bool is_spent = inputs.SpendCoin(txin.prevout, &txundo.vprevout.back());
+            bool is_spent = inputs.SpendCoin(txin.prevout, &txundo.vprevout.back(), key_buffer);
             assert(is_spent);
         }
     }
     // add outputs
-    AddCoins(inputs, tx, nHeight);
+    AddCoins(inputs, tx, nHeight, false, key_buffer);
 }
 
 std::optional<std::pair<ScriptError, std::string>> CScriptCheck::operator()() {
@@ -2168,9 +2178,11 @@ bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
         std::vector<CTxOut> spent_outputs;
         spent_outputs.reserve(tx.vin.size());
 
+        DataStream key_buffer;
+        key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
         for (const auto& txin : tx.vin) {
             const COutPoint& prevout = txin.prevout;
-            const Coin& coin = inputs.AccessCoin(prevout);
+            const Coin& coin = inputs.AccessCoin(prevout, key_buffer);
             assert(!coin.IsSpent());
             spent_outputs.emplace_back(coin.out);
         }
@@ -2227,11 +2239,11 @@ bool FatalError(Notifications& notifications, BlockValidationState& state, const
  * @param out The out point that corresponds to the tx input.
  * @return A DisconnectResult as an int
  */
-int ApplyTxInUndo(Coin&& undo, CCoinsViewCache& view, const COutPoint& out)
+int ApplyTxInUndo(Coin&& undo, CCoinsViewCache& view, const COutPoint& out, Span<std::byte> key_buffer)
 {
     bool fClean = true;
 
-    if (view.HaveCoin(out)) fClean = false; // overwriting transaction output
+    if (view.HaveCoin(out, key_buffer)) fClean = false; // overwriting transaction output
 
     if (undo.nHeight == 0) {
         // Missing undo metadata (height and coinbase). Older versions included this
@@ -2289,13 +2301,14 @@ DisconnectResult Chainstate::DisconnectBlock(const CBlock& block, const CBlockIn
         bool is_coinbase = tx.IsCoinBase();
         bool is_bip30_exception = (is_coinbase && !fEnforceBIP30);
 
-        // Check that all outputs are available and match the outputs in the block itself
-        // exactly.
+        // Check that all outputs are available and match the outputs in the block itself exactly.
+        DataStream key_buffer;
+        key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
         for (size_t o = 0; o < tx.vout.size(); o++) {
             if (!tx.vout[o].scriptPubKey.IsUnspendable()) {
                 COutPoint out(hash, o);
                 Coin coin;
-                bool is_spent = view.SpendCoin(out, &coin);
+                bool is_spent = view.SpendCoin(out, &coin, key_buffer);
                 if (!is_spent || tx.vout[o] != coin.out || pindex->nHeight != coin.nHeight || is_coinbase != coin.fCoinBase) {
                     if (!is_bip30_exception) {
                         fClean = false; // transaction output mismatch
@@ -2311,10 +2324,12 @@ DisconnectResult Chainstate::DisconnectBlock(const CBlock& block, const CBlockIn
                 LogError("DisconnectBlock(): transaction and undo data inconsistent\n");
                 return DISCONNECT_FAILED;
             }
+            DataStream key_buffer;
+            key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
             for (unsigned int j = tx.vin.size(); j > 0;) {
                 --j;
                 const COutPoint& out = tx.vin[j].prevout;
-                int res = ApplyTxInUndo(std::move(txundo.vprevout[j]), view, out);
+                int res = ApplyTxInUndo(std::move(txundo.vprevout[j]), view, out, key_buffer);
                 if (res == DISCONNECT_FAILED) return DISCONNECT_FAILED;
                 fClean = fClean && res != DISCONNECT_UNCLEAN;
             }
@@ -2537,9 +2552,11 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     // consensus change that ensures coinbases at those heights cannot
     // duplicate earlier coinbases.
     if (fEnforceBIP30 || pindex->nHeight >= BIP34_IMPLIES_BIP30_LIMIT) {
+        DataStream key_buffer;
+        key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
         for (const auto& tx : block.vtx) {
             for (size_t o = 0; o < tx->vout.size(); o++) {
-                if (view.HaveCoin(COutPoint(tx->GetHash(), o))) {
+                if (view.HaveCoin(COutPoint(tx->GetHash(), o), key_buffer)) {
                     state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-txns-BIP30",
                                   "tried to overwrite transaction");
                 }
@@ -2585,6 +2602,8 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     int nInputs = 0;
     int64_t nSigOpsCost = 0;
     blockundo.vtxundo.reserve(block.vtx.size() - 1);
+    DataStream key_buffer;
+    key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
     for (unsigned int i = 0; i < block.vtx.size(); i++)
     {
         if (!state.IsValid()) break;
@@ -2596,7 +2615,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
         {
             CAmount txfee = 0;
             TxValidationState tx_state;
-            if (!Consensus::CheckTxInputs(tx, tx_state, view, pindex->nHeight, txfee)) {
+            if (!Consensus::CheckTxInputs(tx, tx_state, view, pindex->nHeight, txfee, key_buffer)) {
                 // Any transaction validation failure in ConnectBlock is a block consensus failure
                 state.Invalid(BlockValidationResult::BLOCK_CONSENSUS,
                               tx_state.GetRejectReason(),
@@ -2615,7 +2634,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
             // be in ConnectBlock because they require the UTXO set
             prevheights.resize(tx.vin.size());
             for (size_t j = 0; j < tx.vin.size(); j++) {
-                prevheights[j] = view.AccessCoin(tx.vin[j].prevout).nHeight;
+                prevheights[j] = view.AccessCoin(tx.vin[j].prevout, key_buffer).nHeight;
             }
 
             if (!SequenceLocks(tx, nLockTimeFlags, prevheights, *pindex)) {
@@ -4838,15 +4857,16 @@ bool Chainstate::RollforwardBlock(const CBlockIndex* pindex, CCoinsViewCache& in
         LogError("ReplayBlock(): ReadBlock failed at %d, hash=%s\n", pindex->nHeight, pindex->GetBlockHash().ToString());
         return false;
     }
-
+    DataStream key_buffer;
+    key_buffer.resize(MAX_COUTPOINT_SERIALIZED_SIZE);
     for (const CTransactionRef& tx : block.vtx) {
         if (!tx->IsCoinBase()) {
             for (const CTxIn &txin : tx->vin) {
-                inputs.SpendCoin(txin.prevout);
+                inputs.SpendCoin(txin.prevout, nullptr, key_buffer);
             }
         }
         // Pass check = true as every addition may be an overwrite.
-        AddCoins(inputs, *tx, pindex->nHeight, true);
+        AddCoins(inputs, *tx, pindex->nHeight, true, key_buffer);
     }
     return true;
 }


### PR DESCRIPTION
|        ns/outpoints |         outpoints/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|              779.84 |        1,282,310.21 |    0.1% |     11.00 | `SerializeCOutPoint`
|               43.21 |       23,143,428.09 |    0.1% |     10.99 | `SerializeCOutPoint2`

18x faster serialization B-)
