### PR TITLE
log: warn on oversized `-dbcache`

### DIFF
--- a/src/common/system.h
+++ b/src/common/system.h
@@ -9,6 +9,7 @@
 #include <bitcoin-build-config.h> // IWYU pragma: keep
 
 #include <cstdint>
+#include <optional>
 #include <string>
 
 // Application startup time (used for uptime calculation)
@@ -28,5 +29,10 @@ void runCommand(const std::string& strCommand);
  * @note This does count virtual cores, such as those provided by HyperThreading.
  */
 int GetNumCores();
+
+/**
+ * Return the total RAM available on the current system, if detectable.
+ */
+std::optional<size_t> GetTotalRAM();
 
 #endif // BITCOIN_COMMON_SYSTEM_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1734,6 +1734,12 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     // cache size calculations
     const auto [index_cache_sizes, kernel_cache_sizes] = CalculateCacheSizes(args, g_enabled_filter_types.size());
+    if (auto total_ram{GetTotalRAM()}) {
+        size_t cap{(*total_ram < 2048_MiB) ? DEFAULT_KERNEL_CACHE : (*total_ram * 75) / 100};
+        if (kernel_cache_sizes.coins > cap) {
+            LogWarning("A %d MiB dbcache may be too large for a system memory of only %d MiB.", kernel_cache_sizes.coins >> 20, *total_ram >> 20);
+        }
+    }
 
     LogInfo("Cache configuration:");
     LogInfo("* Using %.1f MiB for block index database", kernel_cache_sizes.block_tree_db * (1.0 / 1024 / 1024));


### PR DESCRIPTION
### Summary

Oversized allocations can cause out-of-memory errors or heavy swapping, [grinding the system to a halt](https://x.com/murchandamus/status/1964432335849607224).

### Fix

Added a minimal system helper to query total physical RAM on [Linux/macOS/Windows](https://godbolt.org/z/KTTx73Y94).

`CalculateCacheSizes()` now emits a startup warning if the configured `-dbcache` exceeds a cap derived from system RAM.
If total RAM < 2 GiB, cap is `DEFAULT_KERNEL_CACHE` (`450MiB`), otherwise it's 75% of total RAM.
We're not modifying the set value, just issuing a warning.

### Cap

The threshold is chosen to be close to values commonly used in [raspiblitz](https://github.com/raspiblitz/raspiblitz/blob/dev/home.admin/_provision.setup.sh#L98-L115):

| Total RAM | `dbcache` (MiB) | raspiblitz % | proposed cap (MiB) |
|----------:|----------------:|-------------:|-------------------:|
|     1 GiB |             512 |        50.0% |               450* |
|     2 GiB |            1536 |        75.0% |               1536 |
|     4 GiB |            2560 |        62.5% |               3072 |
|     8 GiB |            4096 |        50.0% |               6144 |
|    16 GiB |            4096 |        25.0% |              12288 |
|    32 GiB |            4096 |        12.5% |              24576 |

### Reproducer

Starting `bitcoind` on a 64 GiB system with a dbcache of 60GiB with:
> ./build/bin/bitcoind -dbcache=60000

warns now as follows:
```
2025-09-07T04:32:20Z [warning] A 59990 MiB dbcache may be too large for system memory of only 65536 MiB.
2025-09-07T04:32:20Z Cache configuration:
2025-09-07T04:32:20Z * Using 2.0 MiB for block index database
2025-09-07T04:32:20Z * Using 8.0 MiB for chain state database
2025-09-07T04:32:20Z * Using 59990.0 MiB for in-memory UTXO set (plus up to 286.1 MiB of unused mempool space)
```