### PR TITLE
refactor: replace std::unordered_map with std::map in CCoinsMap

### DIFF
--- a/src/bench/CMakeLists.txt
+++ b/src/bench/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(bench_bitcoin
   checkblockindex.cpp
   checkqueue.cpp
   cluster_linearize.cpp
+  coinsviewcacheasync.cpp
   connectblock.cpp
   crypto_hash.cpp
   descriptors.cpp

--- a/src/bench/coinsviewcacheasync.cpp
+++ b/src/bench/coinsviewcacheasync.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bench/bench.h>
+#include <bench/data/block413567.raw.h>
+#include <coins.h>
+#include <coinsviewcacheasync.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+#include <serialize.h>
+#include <streams.h>
+#include <sync.h>
+#include <test/util/setup_common.h>
+#include <txdb.h>
+#include <validation.h>
+
+#include <cassert>
+#include <ranges>
+#include <utility>
+
+static void CoinsViewCacheAsyncBenchmark(benchmark::Bench& bench)
+{
+    CBlock block;
+    DataStream{benchmark::data::block413567} >> TX_WITH_WITNESS(block);
+    const auto testing_setup{MakeNoLogFileContext<const TestingSetup>(ChainType::MAIN, { .coins_db_in_memory = false })};
+    Chainstate& chainstate{testing_setup->m_node.chainman->ActiveChainstate()};
+    auto& coins_tip{WITH_LOCK(testing_setup->m_node.chainman->GetMutex(), return chainstate.CoinsTip();)};
+
+    for (const auto& tx : block.vtx | std::views::drop(1)) {
+        for (const auto& in : tx->vin) {
+            Coin coin{};
+            coin.out.nValue = 1;
+            coins_tip.EmplaceCoinInternalDANGER(COutPoint{in.prevout}, std::move(coin));
+        }
+    }
+    chainstate.ForceFlushStateToDisk();
+    const auto& coins_db{WITH_LOCK(testing_setup->m_node.chainman->GetMutex(), return chainstate.CoinsDB();)};
+    CoinsViewCacheAsync async_cache{coins_tip, coins_db};
+
+    bench.run([&] {
+        async_cache.StartFetching(block);
+        for (const auto& tx : block.vtx | std::views::drop(1)) {
+            for (const auto& in : tx->vin) {
+                const auto have{async_cache.HaveCoin(in.prevout)};
+                assert(have);
+            }
+        }
+        async_cache.Reset();
+    });
+}
+
+BENCHMARK(CoinsViewCacheAsyncBenchmark, benchmark::PriorityLevel::HIGH);

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -173,6 +173,12 @@ bool CCoinsViewCache::HaveCoinInCache(const COutPoint &outpoint) const {
     return (it != cacheCoins.end() && !it->second.coin.IsSpent());
 }
 
+std::optional<Coin> CCoinsViewCache::GetPossiblySpentCoinFromCache(const COutPoint& outpoint) const noexcept
+{
+    if (auto it{cacheCoins.find(outpoint)}; it != cacheCoins.end()) return it->second.coin;
+    return std::nullopt;
+}
+
 uint256 CCoinsViewCache::GetBestBlock() const {
     if (hashBlock.IsNull())
         hashBlock = base->GetBestBlock();

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -36,7 +36,7 @@ size_t CCoinsViewBacked::EstimateSize() const { return base->EstimateSize(); }
 
 CCoinsViewCache::CCoinsViewCache(CCoinsView* baseIn, bool deterministic) :
     CCoinsViewBacked(baseIn), m_deterministic(deterministic),
-    cacheCoins(0, SaltedOutpointHasher(/*deterministic=*/deterministic), CCoinsMap::key_equal{}, &m_cache_coins_memory_resource)
+    cacheCoins(CCoinsMap::key_compare{}, &m_cache_coins_memory_resource)
 {
     m_sentinel.second.SelfRef(m_sentinel);
 }
@@ -319,7 +319,7 @@ void CCoinsViewCache::ReallocateCache()
     cacheCoins.~CCoinsMap();
     m_cache_coins_memory_resource.~CCoinsMapMemoryResource();
     ::new (&m_cache_coins_memory_resource) CCoinsMapMemoryResource{};
-    ::new (&cacheCoins) CCoinsMap{0, SaltedOutpointHasher{/*deterministic=*/m_deterministic}, CCoinsMap::key_equal{}, &m_cache_coins_memory_resource};
+    ::new (&cacheCoins) CCoinsMap{CCoinsMap::key_compare{}, &m_cache_coins_memory_resource};
 }
 
 void CCoinsViewCache::SanityCheck() const

--- a/src/coins.h
+++ b/src/coins.h
@@ -402,6 +402,14 @@ public:
     bool HaveCoinInCache(const COutPoint &outpoint) const;
 
     /**
+     * Retrieve the coin from the cache even if it is spent, without calling
+     * the backing CCoinsView if no coin exists.
+     * Used in CoinsViewCacheAsync to make sure we do not add a coin from the backing
+     * view when it is spent in the cache but not yet flushed to the parent.
+     */
+    std::optional<Coin> GetPossiblySpentCoinFromCache(const COutPoint& outpoint) const noexcept;
+
+    /**
      * Return a reference to Coin in the cache, or coinEmpty if not found. This is
      * more efficient than GetCoin.
      *
@@ -443,7 +451,7 @@ public:
      * after flushing and should be destroyed to deallocate.
      * If false is returned, the state of this cache (and its backing view) will be undefined.
      */
-    bool Flush(bool will_reuse_cache = true);
+    virtual bool Flush(bool will_reuse_cache = true);
 
     /**
      * Push the modifications applied to this cache to its base while retaining
@@ -484,7 +492,7 @@ private:
      * @note this is marked const, but may actually append to `cacheCoins`, increasing
      * memory usage.
      */
-    CCoinsMap::iterator FetchCoin(const COutPoint &outpoint) const;
+    virtual CCoinsMap::iterator FetchCoin(const COutPoint &outpoint) const;
 };
 
 //! Utility function to add all of a transaction's outputs to a cache.

--- a/src/coins.h
+++ b/src/coins.h
@@ -14,13 +14,12 @@
 #include <support/allocators/pool.h>
 #include <uint256.h>
 #include <util/check.h>
-#include <util/hasher.h>
 
 #include <cassert>
 #include <cstdint>
 
 #include <functional>
-#include <unordered_map>
+#include <map>
 
 /**
  * A UTXO entry.
@@ -215,18 +214,17 @@ public:
 
 /**
  * PoolAllocator's MAX_BLOCK_SIZE_BYTES parameter here uses sizeof the data, and adds the size
- * of 4 pointers. We do not know the exact node size used in the std::unordered_node implementation
+ * of 4 pointers. We do not know the exact node size used in the std::map implementation
  * because it is implementation defined. Most implementations have an overhead of 1 or 2 pointers,
  * so nodes can be connected in a linked list, and in some cases the hash value is stored as well.
  * Using an additional sizeof(void*)*4 for MAX_BLOCK_SIZE_BYTES should thus be sufficient so that
  * all implementations can allocate the nodes from the PoolAllocator.
  */
-using CCoinsMap = std::unordered_map<COutPoint,
-                                     CCoinsCacheEntry,
-                                     SaltedOutpointHasher,
-                                     std::equal_to<COutPoint>,
-                                     PoolAllocator<CoinsCachePair,
-                                                   sizeof(CoinsCachePair) + sizeof(void*) * 4>>;
+using CCoinsMap = std::map<
+    COutPoint,
+    CCoinsCacheEntry,
+    std::less<COutPoint>,
+    PoolAllocator<CoinsCachePair, sizeof(CoinsCachePair) + sizeof(void*) * 4>>;
 
 using CCoinsMapMemoryResource = CCoinsMap::allocator_type::ResourceType;
 

--- a/src/coinsviewcacheasync.h
+++ b/src/coinsviewcacheasync.h
@@ -1,0 +1,245 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_COINSVIEWCACHEASYNC_H
+#define BITCOIN_COINSVIEWCACHEASYNC_H
+
+#include <attributes.h>
+#include <coins.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+#include <tinyformat.h>
+#include <util/threadnames.h>
+
+#include <algorithm>
+#include <atomic>
+#include <barrier>
+#include <cstdint>
+#include <optional>
+#include <ranges>
+#include <thread>
+#include <utility>
+#include <vector>
+
+static constexpr int32_t WORKER_THREADS{4};
+
+/**
+ * CCoinsViewCache subclass that asynchronously fetches block inputs in parallel.
+ * Only used in ConnectBlock to pass as an ephemeral view that can be reset if the block is invalid.
+ * It provides the same interface as CCoinsViewCache, overriding the FetchCoin private method and Flush.
+ * It adds an additional StartFetching method to provide the block, and Reset to reset the state if Flush is not called.
+ *
+ * The cache spawns a fixed set of worker threads that fetch Coins for each input in a block.
+ * When FetchCoin() is called, the main thread waits for the corresponding coin to be fetched and returns it.
+ * While waiting, the main thread will also fetch coins to maximize parallelism.
+ *
+ * Worker threads are synchronized with the main thread using a barrier, which is used at the beginning of fetching to
+ * start the workers and at the end to ensure all workers have finished before the next block is started.
+ */
+class CoinsViewCacheAsync : public CCoinsViewCache
+{
+private:
+    //! The latest input not yet being fetched. Workers atomically increment this when fetching.
+    mutable std::atomic_uint32_t m_input_head{0};
+    //! The latest input not yet accessed by a consumer. Only the main thread increments this.
+    mutable uint32_t m_input_tail{0};
+
+    //! The inputs of the block which is being fetched.
+    struct InputToFetch {
+        //! Workers set this after setting the coin. The main thread tests this before reading the coin.
+        std::atomic_flag ready{};
+        //! The outpoint of the input to fetch;
+        const COutPoint& outpoint;
+        //! The coin that workers will fetch and main thread will insert into cache.
+        std::optional<Coin> coin{std::nullopt};
+
+        /**
+         * We only move when m_inputs reallocates during setup.
+         * We never move after work begins, so we don't have to copy other members.
+         */
+        InputToFetch(InputToFetch&& other) noexcept : outpoint{other.outpoint} {}
+        explicit InputToFetch(const COutPoint& o LIFETIMEBOUND) noexcept : outpoint{o} {}
+    };
+    mutable std::vector<InputToFetch> m_inputs{};
+
+    /**
+     * The first 8 bytes of txids of all txs in the block being fetched. This is used to filter out inputs that
+     * are created earlier in the same block, since they will not be in the db or the cache.
+     * Using only the first 8 bytes is a performance improvement, versus storing the entire 32 bytes. In case of a
+     * collision of an input being spent having the same first 8 bytes as a txid of a tx elsewhere in the block,
+     * the input will not be fetched in the background. The input will still be fetched later on the main thread.
+     * Using a sorted vector and binary search lookups is a performance improvement. It is faster than
+     * using std::unordered_set with salted hash or std::set.
+     */
+    std::vector<uint64_t> m_txids{};
+
+    //! DB coins view to fetch from.
+    const CCoinsView& m_db;
+
+    /**
+     * Similar to CCoinsViewCache::GetCoin, but it does not mutate internally.
+     * Therefore safe to call from any thread once inside the barrier.
+     */
+    std::optional<Coin> GetCoinWithoutMutating(const COutPoint& outpoint) const
+    {
+        if (auto coin{static_cast<CCoinsViewCache*>(base)->GetPossiblySpentCoinFromCache(outpoint)}) {
+            if (!coin->IsSpent()) [[likely]] return coin;
+            return std::nullopt;
+        }
+        return m_db.GetCoin(outpoint);
+    }
+
+    /**
+     * Claim and fetch the next input in the queue. Safe to call from any thread once inside the barrier.
+     *
+     * @return true if there are more inputs in the queue to fetch
+     * @return false if there are no more inputs in the queue to fetch
+     */
+    bool ProcessInputInBackground() const noexcept
+    {
+        const auto i{m_input_head.fetch_add(1, std::memory_order_relaxed)};
+        if (i >= m_inputs.size()) [[unlikely]] return false;
+
+        auto& input{m_inputs[i]};
+        // Inputs spending a coin from a tx earlier in the block won't be in the cache or db
+        if (std::ranges::binary_search(m_txids, input.outpoint.hash.ToUint256().GetUint64(0))) {
+            // We can use relaxed ordering here since we don't write the coin.
+            input.ready.test_and_set(std::memory_order_relaxed);
+            input.ready.notify_one();
+            return true;
+        }
+
+        if (auto coin{GetCoinWithoutMutating(input.outpoint)}) [[likely]] input.coin.emplace(std::move(*coin));
+        // We need release here, so writing coin in the line above happens before the main thread acquires.
+        input.ready.test_and_set(std::memory_order_release);
+        input.ready.notify_one();
+        return true;
+    }
+
+    //! Get the index in m_inputs for the given outpoint. Advances m_input_tail if found.
+    std::optional<uint32_t> GetInputIndex(const COutPoint& outpoint) const noexcept
+    {
+        // This assumes ConnectBlock accesses all inputs in the same order as they are added to m_inputs
+        // in StartFetching. Some outpoints are not accessed because they are created by the block, so we scan until we
+        // come across the requested input. The input will be cached after access, so we can advance the tail so
+        // future accesses won't have to scan previously accessed inputs.
+        for (const auto i : std::views::iota(m_input_tail, m_inputs.size())) [[likely]] {
+            if (m_inputs[i].outpoint == outpoint) {
+                m_input_tail = i + 1;
+                return i;
+            }
+        }
+        return std::nullopt;
+    }
+
+    CCoinsMap::iterator FetchCoin(const COutPoint& outpoint) const override
+    {
+        auto [ret, inserted]{cacheCoins.try_emplace(outpoint)};
+        if (!inserted) return ret;
+
+        if (const auto i{GetInputIndex(outpoint)}) [[likely]] {
+            auto& input{m_inputs[*i]};
+            // Check if the coin is ready to be read. We need to acquire to match the worker thread's release.
+            while (!input.ready.test(std::memory_order_acquire)) {
+                // Work instead of waiting if the coin is not ready
+                if (!ProcessInputInBackground()) {
+                    // No more work, just wait
+                    input.ready.wait(/*old=*/false, std::memory_order_acquire);
+                    break;
+                }
+            }
+            if (input.coin) [[likely]] ret->second.coin = std::move(*input.coin);
+        }
+
+        if (ret->second.coin.IsSpent()) [[unlikely]] {
+            // We will only get in here for BIP30 checks, txid collisions, or a block with missing or spent inputs.
+            if (auto coin{GetCoinWithoutMutating(outpoint)}) {
+                ret->second.coin = std::move(*coin);
+            } else {
+                cacheCoins.erase(ret);
+                return cacheCoins.end();
+            }
+        }
+
+        cachedCoinsUsage += ret->second.coin.DynamicMemoryUsage();
+        return ret;
+    }
+
+    std::vector<std::thread> m_worker_threads{};
+    std::barrier<> m_barrier;
+
+    //! Stop all worker threads.
+    void StopFetching() noexcept
+    {
+        if (m_inputs.empty()) return;
+        // Skip fetching the rest of the inputs by moving the head to the end.
+        m_input_head.store(m_inputs.size(), std::memory_order_relaxed);
+        // Wait for all threads to stop.
+        m_barrier.arrive_and_wait();
+        m_inputs.clear();
+    }
+
+public:
+    //! Start fetching all block inputs in parallel.
+    void StartFetching(const CBlock& block) noexcept
+    {
+        // Loop through the inputs of the block and set them in the queue. Also construct the set of txids to filter.
+        for (const auto& tx : block.vtx | std::views::drop(1)) [[likely]] {
+            for (const auto& input : tx->vin) [[likely]] m_inputs.emplace_back(input.prevout);
+            m_txids.emplace_back(tx->GetHash().ToUint256().GetUint64(0));
+        }
+        // Don't start threads if there's nothing to fetch.
+        if (m_inputs.empty()) [[unlikely]] return;
+        // Sort txids so we can do binary search lookups.
+        std::ranges::sort(m_txids);
+        // Start workers by entering the barrier.
+        m_barrier.arrive_and_wait();
+    }
+
+    //! Stop fetching and reset state. Must be called before block is destroyed.
+    void Reset() noexcept
+    {
+        StopFetching();
+        m_input_head.store(0, std::memory_order_relaxed);
+        m_input_tail = 0;
+        m_txids.clear();
+        cacheCoins.clear();
+        cachedCoinsUsage = 0;
+        hashBlock.SetNull();
+    }
+
+    bool Flush(bool will_reuse_cache) override
+    {
+        // We need to stop workers from accessing base before we mutate it.
+        StopFetching();
+        const auto ret{CCoinsViewCache::Flush(will_reuse_cache)};
+        Reset();
+        return ret;
+    }
+
+    explicit CoinsViewCacheAsync(CCoinsViewCache& cache, const CCoinsView& db,
+        int32_t num_workers = WORKER_THREADS) noexcept
+        : CCoinsViewCache{&cache}, m_db{db}, m_barrier{num_workers + 1}
+    {
+        for (const auto n : std::views::iota(0, num_workers)) {
+            m_worker_threads.emplace_back([this, n] {
+                util::ThreadRename(strprintf("inputfetch.%i", n));
+                while (true) {
+                    m_barrier.arrive_and_wait();
+                    while (ProcessInputInBackground()) [[likely]] {}
+                    if (m_inputs.empty()) [[unlikely]] return;
+                    m_barrier.arrive_and_wait();
+                }
+            });
+        }
+    }
+
+    ~CoinsViewCacheAsync() override
+    {
+        m_barrier.arrive_and_drop();
+        for (auto& t : m_worker_threads) t.join();
+    }
+};
+
+#endif // BITCOIN_COINSVIEWCACHEASYNC_H

--- a/src/memusage.h
+++ b/src/memusage.h
@@ -196,14 +196,8 @@ static inline size_t DynamicUsage(const std::unordered_map<X, Y, Z>& m)
     return MallocUsage(sizeof(unordered_node<std::pair<const X, Y> >)) * m.size() + MallocUsage(sizeof(void*) * m.bucket_count());
 }
 
-template <class Key, class T, class Hash, class Pred, std::size_t MAX_BLOCK_SIZE_BYTES, std::size_t ALIGN_BYTES>
-static inline size_t DynamicUsage(const std::unordered_map<Key,
-                                                           T,
-                                                           Hash,
-                                                           Pred,
-                                                           PoolAllocator<std::pair<const Key, T>,
-                                                                         MAX_BLOCK_SIZE_BYTES,
-                                                                         ALIGN_BYTES>>& m)
+template <class Key, class T, class Compare, std::size_t MAX_BLOCK_SIZE_BYTES, std::size_t ALIGN_BYTES>
+static inline size_t DynamicUsage(const std::map<Key, T, Compare, PoolAllocator<std::pair<const Key, T>, MAX_BLOCK_SIZE_BYTES, ALIGN_BYTES>>& m)
 {
     auto* pool_resource = m.get_allocator().resource();
 
@@ -212,7 +206,7 @@ static inline size_t DynamicUsage(const std::unordered_map<Key,
     size_t estimated_list_node_size = MallocUsage(sizeof(void*) * 3);
     size_t usage_resource = estimated_list_node_size * pool_resource->NumAllocatedChunks();
     size_t usage_chunks = MallocUsage(pool_resource->ChunkSizeBytes()) * pool_resource->NumAllocatedChunks();
-    return usage_resource + usage_chunks + MallocUsage(sizeof(void*) * m.bucket_count());
+    return usage_resource + usage_chunks;
 }
 
 } // namespace memusage

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(test_bitcoin
   cluster_linearize_tests.cpp
   coins_tests.cpp
   coinscachepair_tests.cpp
+  coinsviewcacheasync_tests.cpp
   coinstatsindex_tests.cpp
   common_url_tests.cpp
   compress_tests.cpp

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -661,7 +661,7 @@ static void WriteCoinsViewEntry(CCoinsView& view, const MaybeCoin& cache_coin)
     CoinsCachePair sentinel{};
     sentinel.second.SelfRef(sentinel);
     CCoinsMapMemoryResource resource;
-    CCoinsMap map{0, CCoinsMap::hasher{}, CCoinsMap::key_equal{}, &resource};
+    CCoinsMap map{CCoinsMap::key_compare{}, &resource};
     if (cache_coin) InsertCoinsMapEntry(map, sentinel, *cache_coin);
     auto cursor{CoinsViewCacheCursor(sentinel, map, /*will_erase=*/true)};
     BOOST_CHECK(view.BatchWrite(cursor, {}));
@@ -1066,10 +1066,8 @@ BOOST_AUTO_TEST_CASE(coins_resource_is_used)
     PoolResourceTester::CheckAllDataAccountedFor(resource);
 
     {
-        CCoinsMap map{0, CCoinsMap::hasher{}, CCoinsMap::key_equal{}, &resource};
+        CCoinsMap map{CCoinsMap::key_compare{}, &resource};
         BOOST_TEST(memusage::DynamicUsage(map) >= resource.ChunkSizeBytes());
-
-        map.reserve(1000);
 
         // The resource has preallocated a chunk, so we should have space for at several nodes without the need to allocate anything else.
         const auto usage_before = memusage::DynamicUsage(map);

--- a/src/test/coinsviewcacheasync_tests.cpp
+++ b/src/test/coinsviewcacheasync_tests.cpp
@@ -1,0 +1,221 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <coins.h>
+#include <coinsviewcacheasync.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+#include <primitives/transaction_identifier.h>
+#include <txdb.h>
+#include <uint256.h>
+#include <util/byte_units.h>
+#include <util/hasher.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <cstdint>
+#include <cstring>
+#include <ranges>
+#include <unordered_set>
+
+BOOST_AUTO_TEST_SUITE(coinsviewcacheasync_tests)
+
+struct NoAccessCoinsView : CCoinsView {
+    std::optional<Coin> GetCoin(const COutPoint&) const override { abort(); }
+};
+
+static CBlock CreateBlock() noexcept
+{
+    static constexpr auto NUM_TXS{100};
+    CBlock block;
+    CMutableTransaction coinbase;
+    coinbase.vin.emplace_back();
+    block.vtx.push_back(MakeTransactionRef(coinbase));
+
+    Txid prevhash{Txid::FromUint256(uint256{1})};
+
+    for (const auto i : std::views::iota(1, NUM_TXS)) {
+        CMutableTransaction tx;
+        Txid txid;
+        if (i % 3 == 0) {
+            // External input
+            txid = Txid::FromUint256(uint256(i));
+        } else if (i % 3 == 1) {
+            // Internal spend (prev tx)
+            txid = prevhash;
+        } else {
+            // Test shortid collisions (looks internal, but is external)
+            uint256 u{};
+            std::memcpy(u.begin(), prevhash.ToUint256().begin(), 8);
+            txid = Txid::FromUint256(u);
+        }
+        tx.vin.emplace_back(txid, 0);
+        prevhash = tx.GetHash();
+        block.vtx.push_back(MakeTransactionRef(tx));
+    }
+
+    return block;
+}
+
+void PopulateView(const CBlock& block, CCoinsView& view, bool spent = false)
+{
+    CCoinsViewCache cache{&view};
+    cache.SetBestBlock(uint256::ONE);
+
+    std::unordered_set<Txid, SaltedTxidHasher> txids{};
+    txids.reserve(block.vtx.size() - 1);
+    for (const auto& tx : block.vtx | std::views::drop(1)) {
+        for (const auto& in : tx->vin) {
+            if (!txids.contains(in.prevout.hash)) {
+                Coin coin{};
+                if (!spent) coin.out.nValue = 1;
+                cache.EmplaceCoinInternalDANGER(COutPoint{in.prevout}, std::move(coin));
+            }
+        }
+        txids.emplace(tx->GetHash());
+    }
+
+    cache.Flush();
+}
+
+void CheckCache(const CBlock& block, const CCoinsViewCache& cache)
+{
+    uint32_t counter{0};
+    std::unordered_set<Txid, SaltedTxidHasher> txids{};
+    txids.reserve(block.vtx.size() - 1);
+
+    for (const auto& tx : block.vtx) {
+        if (tx->IsCoinBase()) {
+            BOOST_CHECK(!cache.GetPossiblySpentCoinFromCache(tx->vin[0].prevout));
+        } else {
+            for (const auto& in : tx->vin) {
+                const auto& outpoint{in.prevout};
+                const auto& first{cache.AccessCoin(outpoint)};
+                const auto& second{cache.AccessCoin(outpoint)};
+                BOOST_CHECK_EQUAL(&first, &second);
+                const auto should_have{!txids.contains(outpoint.hash)};
+                if (should_have) ++counter;
+                const auto have{cache.GetPossiblySpentCoinFromCache(outpoint)};
+                BOOST_CHECK_EQUAL(should_have, !!have);
+            }
+            txids.emplace(tx->GetHash());
+        }
+    }
+    BOOST_CHECK_EQUAL(cache.GetCacheSize(), counter);
+}
+
+
+BOOST_AUTO_TEST_CASE(fetch_inputs_from_db)
+{
+    const auto block{CreateBlock()};
+    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    PopulateView(block, db);
+    NoAccessCoinsView no_access;
+    CCoinsViewCache main_cache{&no_access};
+    CoinsViewCacheAsync view{main_cache, db};
+    for (auto i{0}; i < 3; ++i) {
+        view.StartFetching(block);
+        CheckCache(block, view);
+        view.Reset();
+    }
+}
+
+BOOST_AUTO_TEST_CASE(fetch_inputs_from_cache)
+{
+    const auto block{CreateBlock()};
+    const CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    NoAccessCoinsView no_access;
+    CCoinsViewCache main_cache{&no_access};
+    PopulateView(block, main_cache);
+    CoinsViewCacheAsync view{main_cache, db};
+    for (auto i{0}; i < 3; ++i) {
+        view.StartFetching(block);
+        CheckCache(block, view);
+        view.Reset();
+    }
+}
+
+// Test for the case where a block spends coins that are spent in the cache, but
+// the spentness has not been flushed to the db.
+BOOST_AUTO_TEST_CASE(fetch_no_double_spend)
+{
+    const auto block{CreateBlock()};
+    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    PopulateView(block, db);
+    NoAccessCoinsView no_access;
+    CCoinsViewCache main_cache{&no_access};
+    // Add all inputs as spent already in cache
+    PopulateView(block, main_cache, /*spent=*/true);
+    CoinsViewCacheAsync view{main_cache, db};
+    for (auto i{0}; i < 3; ++i) {
+        view.StartFetching(block);
+        for (const auto& tx : block.vtx) {
+            for (const auto& in : tx->vin) {
+                const auto& c{view.AccessCoin(in.prevout)};
+                BOOST_CHECK(c.IsSpent());
+            }
+        }
+        // Coins are not added to the view, even though they exist unspent in the parent db
+        BOOST_CHECK_EQUAL(view.GetCacheSize(), 0);
+        view.Reset();
+    }
+}
+
+BOOST_AUTO_TEST_CASE(fetch_no_inputs)
+{
+    const auto block{CreateBlock()};
+    const CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    NoAccessCoinsView no_access;
+    CCoinsViewCache main_cache{&no_access};
+    CoinsViewCacheAsync view{main_cache, db};
+    for (auto i{0}; i < 3; ++i) {
+        view.StartFetching(block);
+        for (const auto& tx : block.vtx) {
+            for (const auto& in : tx->vin) {
+                const auto& c{view.AccessCoin(in.prevout)};
+                BOOST_CHECK(c.IsSpent());
+            }
+        }
+        BOOST_CHECK_EQUAL(view.GetCacheSize(), 0);
+        view.Reset();
+    }
+}
+
+// Test that the main thread can make progress with no workers
+BOOST_AUTO_TEST_CASE(fetch_main_thread)
+{
+    const auto block{CreateBlock()};
+    const CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    NoAccessCoinsView no_access;
+    CCoinsViewCache main_cache{&no_access};
+    PopulateView(block, main_cache);
+    CoinsViewCacheAsync view{main_cache, db, /*num_workers=*/0};
+    for (auto i{0}; i < 3; ++i) {
+        view.StartFetching(block);
+        CheckCache(block, view);
+        view.Reset();
+    }
+}
+
+// Access coin that is not a block's input
+BOOST_AUTO_TEST_CASE(access_non_input_coin)
+{
+    const auto block{CreateBlock()};
+    const CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    NoAccessCoinsView no_access;
+    CCoinsViewCache main_cache{&no_access};
+    Coin coin{};
+    coin.out.nValue = 1;
+    const COutPoint outpoint{Txid::FromUint256(uint256::ZERO), 0};
+    main_cache.EmplaceCoinInternalDANGER(COutPoint{Txid::FromUint256(uint256::ZERO), 0}, std::move(coin));
+    CoinsViewCacheAsync view{main_cache, db, /*num_workers=*/0};
+    for (auto i{0}; i < 3; ++i) {
+        view.StartFetching(block);
+        const auto& accessed_coin{view.AccessCoin(outpoint)};
+        BOOST_CHECK(!accessed_coin.IsSpent());
+        view.Reset();
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/fuzz/CMakeLists.txt
+++ b/src/test/fuzz/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(fuzz
   cluster_linearize.cpp
   coins_view.cpp
   coinscache_sim.cpp
+  coinsviewcacheasync.cpp
   connman.cpp
   crypto.cpp
   crypto_aes256.cpp

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -126,7 +126,7 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsView& backend
                 CoinsCachePair sentinel{};
                 sentinel.second.SelfRef(sentinel);
                 CCoinsMapMemoryResource resource;
-                CCoinsMap coins_map{0, SaltedOutpointHasher{/*deterministic=*/true}, CCoinsMap::key_equal{}, &resource};
+                CCoinsMap coins_map{CCoinsMap::key_compare{}, &resource};
                 LIMITED_WHILE(good_data && fuzzed_data_provider.ConsumeBool(), 10'000)
                 {
                     CCoinsCacheEntry coins_cache_entry;

--- a/src/test/fuzz/coinsviewcacheasync.cpp
+++ b/src/test/fuzz/coinsviewcacheasync.cpp
@@ -1,0 +1,181 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <coins.h>
+#include <coinsviewcacheasync.h>
+#include <consensus/amount.h>
+#include <dbwrapper.h>
+#include <logging.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+#include <primitives/transaction_identifier.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <test/util/random.h>
+#include <txdb.h>
+#include <uint256.h>
+#include <util/byte_units.h>
+#include <util/hasher.h>
+
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <map>
+#include <optional>
+#include <unordered_set>
+#include <utility>
+
+std::optional<CoinsViewCacheAsync> g_async_cache{};
+std::optional<CCoinsViewDB> g_db{};
+
+static void setup_threadpool_test()
+{
+    LogInstance().DisableLogging();
+    auto db_params = DBParams{
+        .path = "",
+        .cache_bytes = 1_MiB,
+        .memory_only = true,
+    };
+    g_db.emplace(std::move(db_params), CoinsViewOptions{});
+    CCoinsViewCache cache{nullptr};
+    g_async_cache.emplace(cache, *g_db);
+}
+
+FUZZ_TARGET(coinsviewcacheasync, .init = setup_threadpool_test)
+{
+    SeedRandomStateForTest(SeedRand::ZEROS);
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+
+    LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 10000)
+    {
+        CBlock block;
+        Txid prevhash{Txid::FromUint256(ConsumeUInt256(fuzzed_data_provider))};
+
+        std::map<const COutPoint, const Coin> db_map{};
+        std::map<const COutPoint, const Coin> cache_map{};
+        std::vector<COutPoint> input_outpoints{};
+
+        CCoinsViewCache main_cache(&*g_db);
+        // Used for writing to the db and erasing between iterations
+        CCoinsViewCache dummy_cache(&*g_db);
+        dummy_cache.SetBestBlock(uint256::ONE);
+
+        LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 10000)
+        {
+            CMutableTransaction tx;
+
+            LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 10000)
+            {
+                Txid txid;
+                if (fuzzed_data_provider.ConsumeBool()) {
+                    txid = Txid::FromUint256(ConsumeUInt256(fuzzed_data_provider));
+                } else if (fuzzed_data_provider.ConsumeBool()) {
+                    txid = prevhash;
+                } else {
+                    // Test shortid collisions
+                    uint256 u{ConsumeUInt256(fuzzed_data_provider)};
+                    std::memcpy(u.begin(), prevhash.ToUint256().begin(), 8);
+                    txid = Txid::FromUint256(u);
+                }
+                const auto index{fuzzed_data_provider.ConsumeIntegral<uint32_t>()};
+                const COutPoint outpoint{txid, index};
+
+                tx.vin.emplace_back(outpoint);
+
+                if (fuzzed_data_provider.ConsumeBool()) {
+                    Coin coin{};
+                    coin.fCoinBase = fuzzed_data_provider.ConsumeBool();
+                    coin.nHeight =
+                        fuzzed_data_provider.ConsumeIntegralInRange<int32_t>(
+                            0, std::numeric_limits<int32_t>::max());
+                    coin.out.nValue = ConsumeMoney(fuzzed_data_provider);
+                    assert(!coin.IsSpent());
+                    db_map.try_emplace(outpoint, coin);
+                    dummy_cache.EmplaceCoinInternalDANGER(
+                        COutPoint(outpoint),
+                        std::move(coin));
+                }
+
+                // Add a different coin to the cache
+                if (fuzzed_data_provider.ConsumeBool()) {
+                    Coin coin{};
+                    coin.fCoinBase = fuzzed_data_provider.ConsumeBool();
+                    coin.nHeight =
+                        fuzzed_data_provider.ConsumeIntegralInRange<int32_t>(
+                            0, std::numeric_limits<int32_t>::max());
+                    coin.out.nValue =
+                        fuzzed_data_provider.ConsumeIntegralInRange<int64_t>(
+                            -1, MAX_MONEY);
+                    cache_map.try_emplace(outpoint, coin);
+                    main_cache.EmplaceCoinInternalDANGER(
+                        COutPoint(outpoint),
+                        std::move(coin));
+                }
+
+                input_outpoints.emplace_back(outpoint);
+            }
+
+            prevhash = tx.GetHash();
+            block.vtx.push_back(MakeTransactionRef(tx));
+        }
+
+        (void)dummy_cache.Sync();
+        CoinsViewCacheAsync& cache(*g_async_cache);
+        cache.SetBackend(main_cache);
+        cache.StartFetching(block);
+
+        std::unordered_set<COutPoint, SaltedOutpointHasher> outpoints_in_cache{};
+        LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), static_cast<uint32_t>(input_outpoints.size() * 10))
+        {
+            COutPoint outpoint;
+            if (fuzzed_data_provider.ConsumeBool()) {
+                const auto index{fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, input_outpoints.size() - 1)};
+                outpoint = input_outpoints[index];
+            } else {
+                const auto txid{Txid::FromUint256(ConsumeUInt256(fuzzed_data_provider))};
+                const auto index{fuzzed_data_provider.ConsumeIntegral<uint32_t>()};
+                outpoint = COutPoint(txid, index);
+            }
+            const auto& accessed_coin{cache.AccessCoin(outpoint)};
+            const auto coin{cache.GetPossiblySpentCoinFromCache(outpoint)};
+            if (coin) {
+                assert(!coin->IsSpent());
+                assert(coin->fCoinBase == accessed_coin.fCoinBase);
+                assert(coin->nHeight == accessed_coin.nHeight);
+                assert(coin->out == accessed_coin.out);
+                outpoints_in_cache.emplace(outpoint);
+            }
+            const auto& db_it{db_map.find(outpoint)};
+            const auto cache_it{cache_map.find(outpoint)};
+            if (!coin) {
+                assert(accessed_coin.IsSpent());
+                // If we don't have a coin, then it's either spent in cache or missing
+                const auto spent_cache_coin{cache_it != cache_map.end() && cache_it->second.IsSpent()};
+                const auto no_coin{cache_it == cache_map.end() && db_it == db_map.end()};
+                assert(spent_cache_coin || no_coin);
+            } else if (cache_it != cache_map.end()) {
+                // Make sure we have the main cache coin if it exists instead of db
+                const auto& cache_coin{cache_it->second};
+                assert(!cache_coin.IsSpent());
+                assert(coin->fCoinBase == cache_coin.fCoinBase);
+                assert(coin->nHeight == cache_coin.nHeight);
+                assert(coin->out == cache_coin.out);
+            } else {
+                assert(db_it != db_map.end());
+                // Check any coins not in the main cache are the same as the db
+                const auto& db_coin{db_it->second};
+                assert(coin->fCoinBase == db_coin.fCoinBase);
+                assert(coin->nHeight == db_coin.nHeight);
+                assert(coin->out == db_coin.out);
+            }
+        }
+        assert(cache.GetCacheSize() == outpoints_in_cache.size());
+        fuzzed_data_provider.ConsumeBool() ? (void)cache.Flush(/*will_reuse_cache=*/true) : cache.Reset();
+        for (const auto& pair : db_map) {
+            dummy_cache.SpendCoin(pair.first);
+        }
+        (void)dummy_cache.Flush();
+    }
+}

--- a/src/test/pool_tests.cpp
+++ b/src/test/pool_tests.cpp
@@ -12,7 +12,7 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <unordered_map>
+#include <map>
 #include <vector>
 
 BOOST_FIXTURE_TEST_SUITE(pool_tests, BasicTestingSetup)
@@ -156,20 +156,19 @@ BOOST_AUTO_TEST_CASE(random_allocations)
 
 BOOST_AUTO_TEST_CASE(memusage_test)
 {
-    auto std_map = std::unordered_map<int64_t, int64_t>{};
+    auto std_map = std::map<int64_t, int64_t>{};
 
-    using Map = std::unordered_map<int64_t,
-                                   int64_t,
-                                   std::hash<int64_t>,
-                                   std::equal_to<int64_t>,
-                                   PoolAllocator<std::pair<const int64_t, int64_t>,
-                                                 sizeof(std::pair<const int64_t, int64_t>) + sizeof(void*) * 4>>;
+    using Map = std::map<int64_t,
+                         int64_t,
+                         std::less<int64_t>,
+                         PoolAllocator<std::pair<const int64_t, int64_t>,
+                                       sizeof(std::pair<const int64_t, int64_t>) + sizeof(void*) * 4>>;
     auto resource = Map::allocator_type::ResourceType(1024);
 
     PoolResourceTester::CheckAllDataAccountedFor(resource);
 
     {
-        auto resource_map = Map{0, std::hash<int64_t>{}, std::equal_to<int64_t>{}, &resource};
+        auto resource_map = Map{Map::key_compare{}, &resource};
 
         // can't have the same resource usage
         BOOST_TEST(memusage::DynamicUsage(std_map) != memusage::DynamicUsage(resource_map));

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1872,6 +1872,7 @@ void CoinsViews::InitCache()
 {
     AssertLockHeld(::cs_main);
     m_cacheview = std::make_unique<CCoinsViewCache>(&m_catcherview);
+    m_connect_block_view = std::make_unique<CoinsViewCacheAsync>(*m_cacheview, m_catcherview);
 }
 
 Chainstate::Chainstate(
@@ -3083,7 +3084,8 @@ bool Chainstate::ConnectTip(
     LogDebug(BCLog::BENCH, "  - Load block from disk: %.2fms\n",
              Ticks<MillisecondsDouble>(time_2 - time_1));
     {
-        CCoinsViewCache view(&CoinsTip());
+        auto& view{*m_coins_views->m_connect_block_view};
+        view.StartFetching(*block_to_connect);
         bool rv = ConnectBlock(*block_to_connect, state, pindexNew, view);
         if (m_chainman.m_options.signals) {
             m_chainman.m_options.signals->BlockChecked(block_to_connect, state);
@@ -3092,6 +3094,7 @@ bool Chainstate::ConnectTip(
             if (state.IsInvalid())
                 InvalidBlockFound(pindexNew, state);
             LogError("%s: ConnectBlock %s failed, %s\n", __func__, pindexNew->GetBlockHash().ToString(), state.ToString());
+            view.Reset();
             return false;
         }
         time_3 = SteadyClock::now();

--- a/src/validation.h
+++ b/src/validation.h
@@ -10,6 +10,7 @@
 #include <attributes.h>
 #include <chain.h>
 #include <checkqueue.h>
+#include <coinsviewcacheasync.h>
 #include <consensus/amount.h>
 #include <cuckoocache.h>
 #include <deploymentstatus.h>
@@ -484,6 +485,10 @@ public:
     //! This is the top layer of the cache hierarchy - it keeps as many coins in memory as
     //! can fit per the dbcache setting.
     std::unique_ptr<CCoinsViewCache> m_cacheview GUARDED_BY(cs_main);
+
+    //! Used as an empty view that is only passed into ConnectBlock to help speed up block validation,
+    //! as well as not pollute the underlying cache with newly created coins in case the block is invalid.
+    std::unique_ptr<CoinsViewCacheAsync> m_connect_block_view GUARDED_BY(cs_main);
 
     //! This constructor initializes CCoinsViewDB and CCoinsViewErrorCatcher instances, but it
     //! *does not* create a CCoinsViewCache instance by default. This is done separately because the

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -16,6 +16,7 @@
 #include <script/descriptor.h>
 #include <script/script.h>
 #include <script/signingprovider.h>
+#include <util/hasher.h>
 #include <util/result.h>
 #include <util/time.h>
 #include <wallet/crypter.h>


### PR DESCRIPTION
```
for DBCACHE in 300 3000; do \
  COMMITS="07bf275fb51946b33020679b6188443d8932ac22 9c1b3ff08f9ab624d141d26b8efc298eca7ca277"; \
  STOP=926629; \
  DATA_DIR="$HOME/Library/Application Support/Bitcoin"; LOG_DIR="$HOME/bitcoin-reindex-logs"; mkdir -p "$LOG_DIR"; \
  COMMA_COMMITS=${COMMITS// /,}; \
  (echo ""; for c in $(echo $COMMITS); do git fetch -q origin $c && git log -1 --pretty='%h %s' $c || exit 1; done) && \
  (echo "" && echo "reindex-chainstate | ${STOP} blocks | dbcache ${DBCACHE} | $(hostname) | $(uname -m) | $(sysctl -n machdep.cpu.brand_string) | $(nproc) cores | $(printf '%.1fGiB' "$(( $(sysctl -n hw.memsize)/1024/1024/1024 ))") RAM | SSD | $(sw_vers -productName) $(sw_vers -productVersion) $(sw_vers -buildVersion) | $(xcrun clang --version | head -1)"; echo "") && \
  hyperfine \
    --sort command \
    --runs 1 \
    --export-json "$LOG_DIR/rdx-$(echo "$COMMITS" | sed -E 's/([a-f0-9]{8})[a-f0-9]+ ?/\1-/g;s/-$//')-$STOP-$DBCACHE-appleclang.json" \
    --parameter-list COMMIT "$COMMA_COMMITS" \
    --prepare "killall -9 bitcoind 2>/dev/null || true; rm -f \"$DATA_DIR\"/debug.log; git checkout {COMMIT}; git reset --hard && \
      cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release && ninja -C build bitcoind -j2 && \
      ./build/bin/bitcoind -datadir=\"$DATA_DIR\" -stopatheight=$STOP -dbcache=1000 -printtoconsole=0; sleep 20" \
    --conclude "killall bitcoind 2>/dev/null || true; sleep 5; grep -q 'height=0' \"$DATA_DIR\"/debug.log && grep -q 'Disabling script verification at block #1' \"$DATA_DIR\"/debug.log && grep -q \"height=$STOP\" \"$DATA_DIR\"/debug.log || { echo 'debug.log assertions failed'; exit 1; }; \
                cp \"$DATA_DIR\"/debug.log \"$LOG_DIR\"/debug-{COMMIT}-\$(date +%s).log 2>/dev/null || true" \
    "./build/bin/bitcoind -datadir=\"$DATA_DIR\" -stopatheight=$STOP -dbcache=$DBCACHE -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0";
done
```

```
07bf275fb5 validation: fetch block inputs via CCoinsViewCacheAsync during connection
9c1b3ff08f refactor: replace std::unordered_map with std::map in CCoinsMap

reindex-chainstate | 926629 blocks | dbcache 300 | M4-Max.local | arm64 | Apple M4 Max | 16 cores | 64.0GiB RAM | SSD | macOS 26.1 25B78 | Apple clang version 17.0.0 (clang-1700.6.3.2)

Benchmark 1: ./build/bin/bitcoind -datadir="/Users/lorinc/Library/Application Support/Bitcoin" -stopatheight=926629 -dbcache=300 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 07bf275fb51946b33020679b6188443d8932ac22)
  Time (abs ≡):        6856.857 s               [User: 19038.577 s, System: 1907.361 s]
 
Benchmark 2: ./build/bin/bitcoind -datadir="/Users/lorinc/Library/Application Support/Bitcoin" -stopatheight=926629 -dbcache=300 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 9c1b3ff08f9ab624d141d26b8efc298eca7ca277)
  Time (abs ≡):        8669.588 s               [User: 22865.615 s, System: 2341.697 s]
 
Relative speed comparison
        1.00          ./build/bin/bitcoind -datadir="/Users/lorinc/Library/Application Support/Bitcoin" -stopatheight=926629 -dbcache=300 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 07bf275fb51946b33020679b6188443d8932ac22)
        1.26          ./build/bin/bitcoind -datadir="/Users/lorinc/Library/Application Support/Bitcoin" -stopatheight=926629 -dbcache=300 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 9c1b3ff08f9ab624d141d26b8efc298eca7ca277)
```

```
07bf275fb5 validation: fetch block inputs via CCoinsViewCacheAsync during connection
9c1b3ff08f refactor: replace std::unordered_map with std::map in CCoinsMap

reindex-chainstate | 926629 blocks | dbcache 3000 | M4-Max.local | arm64 | Apple M4 Max | 16 cores | 64.0GiB RAM | SSD | macOS 26.1 25B78 | Apple clang version 17.0.0 (clang-1700.6.3.2)

Benchmark 1: ./build/bin/bitcoind -datadir="/Users/lorinc/Library/Application Support/Bitcoin" -stopatheight=926629 -dbcache=3000 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 07bf275fb51946b33020679b6188443d8932ac22)
  Time (abs ≡):        5425.449 s               [User: 11645.367 s, System: 1110.416 s]
 
Benchmark 2: ./build/bin/bitcoind -datadir="/Users/lorinc/Library/Application Support/Bitcoin" -stopatheight=926629 -dbcache=3000 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 9c1b3ff08f9ab624d141d26b8efc298eca7ca277)
  Time (abs ≡):        8756.607 s               [User: 16738.824 s, System: 1215.130 s]
 
Relative speed comparison
        1.00          ./build/bin/bitcoind -datadir="/Users/lorinc/Library/Application Support/Bitcoin" -stopatheight=926629 -dbcache=3000 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 07bf275fb51946b33020679b6188443d8932ac22)
        1.61          ./build/bin/bitcoind -datadir="/Users/lorinc/Library/Application Support/Bitcoin" -stopatheight=926629 -dbcache=3000 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 9c1b3ff08f9ab624d141d26b8efc298eca7ca277)
```