### PR TITLE
util: optimize prefetching in validation

### DIFF
--- a/src/bench/CMakeLists.txt
+++ b/src/bench/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(bench_bitcoin
   checkblockindex.cpp
   checkqueue.cpp
   cluster_linearize.cpp
+  coinsviewcacheasync.cpp
   connectblock.cpp
   crypto_hash.cpp
   descriptors.cpp

--- a/src/bench/coinsviewcacheasync.cpp
+++ b/src/bench/coinsviewcacheasync.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bench/bench.h>
+#include <bench/data/block413567.raw.h>
+#include <coins.h>
+#include <coinsviewcacheasync.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+#include <serialize.h>
+#include <streams.h>
+#include <sync.h>
+#include <test/util/setup_common.h>
+#include <txdb.h>
+#include <validation.h>
+
+#include <cassert>
+#include <ranges>
+#include <utility>
+
+static void CoinsViewCacheAsyncBenchmark(benchmark::Bench& bench)
+{
+    CBlock block;
+    DataStream{benchmark::data::block413567} >> TX_WITH_WITNESS(block);
+    const auto testing_setup{MakeNoLogFileContext<const TestingSetup>(ChainType::MAIN, { .coins_db_in_memory = false })};
+    Chainstate& chainstate{testing_setup->m_node.chainman->ActiveChainstate()};
+    auto& coins_tip{WITH_LOCK(testing_setup->m_node.chainman->GetMutex(), return chainstate.CoinsTip();)};
+
+    for (const auto& tx : block.vtx | std::views::drop(1)) {
+        for (const auto& in : tx->vin) {
+            Coin coin{};
+            coin.out.nValue = 1;
+            coins_tip.EmplaceCoinInternalDANGER(COutPoint{in.prevout}, std::move(coin));
+        }
+    }
+    chainstate.ForceFlushStateToDisk();
+    const auto& coins_db{WITH_LOCK(testing_setup->m_node.chainman->GetMutex(), return chainstate.CoinsDB();)};
+    CoinsViewCacheAsync async_cache{coins_tip, coins_db};
+
+    bench.run([&] {
+        async_cache.StartFetching(block);
+        for (const auto& tx : block.vtx | std::views::drop(1)) {
+            for (const auto& in : tx->vin) {
+                const auto have{async_cache.HaveCoin(in.prevout)};
+                assert(have);
+            }
+        }
+        async_cache.Reset();
+    });
+}
+
+BENCHMARK(CoinsViewCacheAsyncBenchmark, benchmark::PriorityLevel::HIGH);

--- a/src/checkqueue.h
+++ b/src/checkqueue.h
@@ -9,8 +9,10 @@
 #include <sync.h>
 #include <tinyformat.h>
 #include <util/threadnames.h>
+#include <util/prefetch.h>
 
 #include <algorithm>
+#include <cstddef>
 #include <iterator>
 #include <optional>
 #include <vector>
@@ -127,8 +129,9 @@ private:
             }
             // execute work
             if (do_work) {
-                for (T& check : vChecks) {
-                    local_result = check();
+                for (size_t idx = 0; idx < vChecks.size(); ++idx) {
+                    if (idx + 1 < vChecks.size()) util::Prefetch(&vChecks[idx + 1]);
+                    local_result = vChecks[idx]();
                     if (local_result.has_value()) break;
                 }
             }

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -173,6 +173,12 @@ bool CCoinsViewCache::HaveCoinInCache(const COutPoint &outpoint) const {
     return (it != cacheCoins.end() && !it->second.coin.IsSpent());
 }
 
+std::optional<Coin> CCoinsViewCache::GetPossiblySpentCoinFromCache(const COutPoint& outpoint) const noexcept
+{
+    if (auto it{cacheCoins.find(outpoint)}; it != cacheCoins.end()) return it->second.coin;
+    return std::nullopt;
+}
+
 uint256 CCoinsViewCache::GetBestBlock() const {
     if (hashBlock.IsNull())
         hashBlock = base->GetBestBlock();

--- a/src/coins.h
+++ b/src/coins.h
@@ -402,6 +402,14 @@ public:
     bool HaveCoinInCache(const COutPoint &outpoint) const;
 
     /**
+     * Retrieve the coin from the cache even if it is spent, without calling
+     * the backing CCoinsView if no coin exists.
+     * Used in CoinsViewCacheAsync to make sure we do not add a coin from the backing
+     * view when it is spent in the cache but not yet flushed to the parent.
+     */
+    std::optional<Coin> GetPossiblySpentCoinFromCache(const COutPoint& outpoint) const noexcept;
+
+    /**
      * Return a reference to Coin in the cache, or coinEmpty if not found. This is
      * more efficient than GetCoin.
      *
@@ -443,7 +451,7 @@ public:
      * after flushing and should be destroyed to deallocate.
      * If false is returned, the state of this cache (and its backing view) will be undefined.
      */
-    bool Flush(bool will_reuse_cache = true);
+    virtual bool Flush(bool will_reuse_cache = true);
 
     /**
      * Push the modifications applied to this cache to its base while retaining
@@ -484,7 +492,7 @@ private:
      * @note this is marked const, but may actually append to `cacheCoins`, increasing
      * memory usage.
      */
-    CCoinsMap::iterator FetchCoin(const COutPoint &outpoint) const;
+    virtual CCoinsMap::iterator FetchCoin(const COutPoint &outpoint) const;
 };
 
 //! Utility function to add all of a transaction's outputs to a cache.

--- a/src/coinsviewcacheasync.h
+++ b/src/coinsviewcacheasync.h
@@ -1,0 +1,245 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_COINSVIEWCACHEASYNC_H
+#define BITCOIN_COINSVIEWCACHEASYNC_H
+
+#include <attributes.h>
+#include <coins.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+#include <tinyformat.h>
+#include <util/threadnames.h>
+
+#include <algorithm>
+#include <atomic>
+#include <barrier>
+#include <cstdint>
+#include <optional>
+#include <ranges>
+#include <thread>
+#include <utility>
+#include <vector>
+
+static constexpr int32_t WORKER_THREADS{4};
+
+/**
+ * CCoinsViewCache subclass that asynchronously fetches block inputs in parallel.
+ * Only used in ConnectBlock to pass as an ephemeral view that can be reset if the block is invalid.
+ * It provides the same interface as CCoinsViewCache, overriding the FetchCoin private method and Flush.
+ * It adds an additional StartFetching method to provide the block, and Reset to reset the state if Flush is not called.
+ *
+ * The cache spawns a fixed set of worker threads that fetch Coins for each input in a block.
+ * When FetchCoin() is called, the main thread waits for the corresponding coin to be fetched and returns it.
+ * While waiting, the main thread will also fetch coins to maximize parallelism.
+ *
+ * Worker threads are synchronized with the main thread using a barrier, which is used at the beginning of fetching to
+ * start the workers and at the end to ensure all workers have finished before the next block is started.
+ */
+class CoinsViewCacheAsync : public CCoinsViewCache
+{
+private:
+    //! The latest input not yet being fetched. Workers atomically increment this when fetching.
+    mutable std::atomic_uint32_t m_input_head{0};
+    //! The latest input not yet accessed by a consumer. Only the main thread increments this.
+    mutable uint32_t m_input_tail{0};
+
+    //! The inputs of the block which is being fetched.
+    struct InputToFetch {
+        //! Workers set this after setting the coin. The main thread tests this before reading the coin.
+        std::atomic_flag ready{};
+        //! The outpoint of the input to fetch;
+        const COutPoint& outpoint;
+        //! The coin that workers will fetch and main thread will insert into cache.
+        std::optional<Coin> coin{std::nullopt};
+
+        /**
+         * We only move when m_inputs reallocates during setup.
+         * We never move after work begins, so we don't have to copy other members.
+         */
+        InputToFetch(InputToFetch&& other) noexcept : outpoint{other.outpoint} {}
+        explicit InputToFetch(const COutPoint& o LIFETIMEBOUND) noexcept : outpoint{o} {}
+    };
+    mutable std::vector<InputToFetch> m_inputs{};
+
+    /**
+     * The first 8 bytes of txids of all txs in the block being fetched. This is used to filter out inputs that
+     * are created earlier in the same block, since they will not be in the db or the cache.
+     * Using only the first 8 bytes is a performance improvement, versus storing the entire 32 bytes. In case of a
+     * collision of an input being spent having the same first 8 bytes as a txid of a tx elsewhere in the block,
+     * the input will not be fetched in the background. The input will still be fetched later on the main thread.
+     * Using a sorted vector and binary search lookups is a performance improvement. It is faster than
+     * using std::unordered_set with salted hash or std::set.
+     */
+    std::vector<uint64_t> m_txids{};
+
+    //! DB coins view to fetch from.
+    const CCoinsView& m_db;
+
+    /**
+     * Similar to CCoinsViewCache::GetCoin, but it does not mutate internally.
+     * Therefore safe to call from any thread once inside the barrier.
+     */
+    std::optional<Coin> GetCoinWithoutMutating(const COutPoint& outpoint) const
+    {
+        if (auto coin{static_cast<CCoinsViewCache*>(base)->GetPossiblySpentCoinFromCache(outpoint)}) {
+            if (!coin->IsSpent()) [[likely]] return coin;
+            return std::nullopt;
+        }
+        return m_db.GetCoin(outpoint);
+    }
+
+    /**
+     * Claim and fetch the next input in the queue. Safe to call from any thread once inside the barrier.
+     *
+     * @return true if there are more inputs in the queue to fetch
+     * @return false if there are no more inputs in the queue to fetch
+     */
+    bool ProcessInputInBackground() const noexcept
+    {
+        const auto i{m_input_head.fetch_add(1, std::memory_order_relaxed)};
+        if (i >= m_inputs.size()) [[unlikely]] return false;
+
+        auto& input{m_inputs[i]};
+        // Inputs spending a coin from a tx earlier in the block won't be in the cache or db
+        if (std::ranges::binary_search(m_txids, input.outpoint.hash.ToUint256().GetUint64(0))) {
+            // We can use relaxed ordering here since we don't write the coin.
+            input.ready.test_and_set(std::memory_order_relaxed);
+            input.ready.notify_one();
+            return true;
+        }
+
+        if (auto coin{GetCoinWithoutMutating(input.outpoint)}) [[likely]] input.coin.emplace(std::move(*coin));
+        // We need release here, so writing coin in the line above happens before the main thread acquires.
+        input.ready.test_and_set(std::memory_order_release);
+        input.ready.notify_one();
+        return true;
+    }
+
+    //! Get the index in m_inputs for the given outpoint. Advances m_input_tail if found.
+    std::optional<uint32_t> GetInputIndex(const COutPoint& outpoint) const noexcept
+    {
+        // This assumes ConnectBlock accesses all inputs in the same order as they are added to m_inputs
+        // in StartFetching. Some outpoints are not accessed because they are created by the block, so we scan until we
+        // come across the requested input. The input will be cached after access, so we can advance the tail so
+        // future accesses won't have to scan previously accessed inputs.
+        for (const auto i : std::views::iota(m_input_tail, m_inputs.size())) [[likely]] {
+            if (m_inputs[i].outpoint == outpoint) {
+                m_input_tail = i + 1;
+                return i;
+            }
+        }
+        return std::nullopt;
+    }
+
+    CCoinsMap::iterator FetchCoin(const COutPoint& outpoint) const override
+    {
+        auto [ret, inserted]{cacheCoins.try_emplace(outpoint)};
+        if (!inserted) return ret;
+
+        if (const auto i{GetInputIndex(outpoint)}) [[likely]] {
+            auto& input{m_inputs[*i]};
+            // Check if the coin is ready to be read. We need to acquire to match the worker thread's release.
+            while (!input.ready.test(std::memory_order_acquire)) {
+                // Work instead of waiting if the coin is not ready
+                if (!ProcessInputInBackground()) {
+                    // No more work, just wait
+                    input.ready.wait(/*old=*/false, std::memory_order_acquire);
+                    break;
+                }
+            }
+            if (input.coin) [[likely]] ret->second.coin = std::move(*input.coin);
+        }
+
+        if (ret->second.coin.IsSpent()) [[unlikely]] {
+            // We will only get in here for BIP30 checks, txid collisions, or a block with missing or spent inputs.
+            if (auto coin{GetCoinWithoutMutating(outpoint)}) {
+                ret->second.coin = std::move(*coin);
+            } else {
+                cacheCoins.erase(ret);
+                return cacheCoins.end();
+            }
+        }
+
+        cachedCoinsUsage += ret->second.coin.DynamicMemoryUsage();
+        return ret;
+    }
+
+    std::vector<std::thread> m_worker_threads{};
+    std::barrier<> m_barrier;
+
+    //! Stop all worker threads.
+    void StopFetching() noexcept
+    {
+        if (m_inputs.empty()) return;
+        // Skip fetching the rest of the inputs by moving the head to the end.
+        m_input_head.store(m_inputs.size(), std::memory_order_relaxed);
+        // Wait for all threads to stop.
+        m_barrier.arrive_and_wait();
+        m_inputs.clear();
+    }
+
+public:
+    //! Start fetching all block inputs in parallel.
+    void StartFetching(const CBlock& block) noexcept
+    {
+        // Loop through the inputs of the block and set them in the queue. Also construct the set of txids to filter.
+        for (const auto& tx : block.vtx | std::views::drop(1)) [[likely]] {
+            for (const auto& input : tx->vin) [[likely]] m_inputs.emplace_back(input.prevout);
+            m_txids.emplace_back(tx->GetHash().ToUint256().GetUint64(0));
+        }
+        // Don't start threads if there's nothing to fetch.
+        if (m_inputs.empty()) [[unlikely]] return;
+        // Sort txids so we can do binary search lookups.
+        std::ranges::sort(m_txids);
+        // Start workers by entering the barrier.
+        m_barrier.arrive_and_wait();
+    }
+
+    //! Stop fetching and reset state. Must be called before block is destroyed.
+    void Reset() noexcept
+    {
+        StopFetching();
+        m_input_head.store(0, std::memory_order_relaxed);
+        m_input_tail = 0;
+        m_txids.clear();
+        cacheCoins.clear();
+        cachedCoinsUsage = 0;
+        hashBlock.SetNull();
+    }
+
+    bool Flush(bool will_reuse_cache) override
+    {
+        // We need to stop workers from accessing base before we mutate it.
+        StopFetching();
+        const auto ret{CCoinsViewCache::Flush(will_reuse_cache)};
+        Reset();
+        return ret;
+    }
+
+    explicit CoinsViewCacheAsync(CCoinsViewCache& cache, const CCoinsView& db,
+        int32_t num_workers = WORKER_THREADS) noexcept
+        : CCoinsViewCache{&cache}, m_db{db}, m_barrier{num_workers + 1}
+    {
+        for (const auto n : std::views::iota(0, num_workers)) {
+            m_worker_threads.emplace_back([this, n] {
+                util::ThreadRename(strprintf("inputfetch.%i", n));
+                while (true) {
+                    m_barrier.arrive_and_wait();
+                    while (ProcessInputInBackground()) [[likely]] {}
+                    if (m_inputs.empty()) [[unlikely]] return;
+                    m_barrier.arrive_and_wait();
+                }
+            });
+        }
+    }
+
+    ~CoinsViewCacheAsync() override
+    {
+        m_barrier.arrive_and_drop();
+        for (auto& t : m_worker_threads) t.join();
+    }
+};
+
+#endif // BITCOIN_COINSVIEWCACHEASYNC_H

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(test_bitcoin
   cluster_linearize_tests.cpp
   coins_tests.cpp
   coinscachepair_tests.cpp
+  coinsviewcacheasync_tests.cpp
   coinstatsindex_tests.cpp
   common_url_tests.cpp
   compress_tests.cpp

--- a/src/test/coinsviewcacheasync_tests.cpp
+++ b/src/test/coinsviewcacheasync_tests.cpp
@@ -1,0 +1,221 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <coins.h>
+#include <coinsviewcacheasync.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+#include <primitives/transaction_identifier.h>
+#include <txdb.h>
+#include <uint256.h>
+#include <util/byte_units.h>
+#include <util/hasher.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <cstdint>
+#include <cstring>
+#include <ranges>
+#include <unordered_set>
+
+BOOST_AUTO_TEST_SUITE(coinsviewcacheasync_tests)
+
+struct NoAccessCoinsView : CCoinsView {
+    std::optional<Coin> GetCoin(const COutPoint&) const override { abort(); }
+};
+
+static CBlock CreateBlock() noexcept
+{
+    static constexpr auto NUM_TXS{100};
+    CBlock block;
+    CMutableTransaction coinbase;
+    coinbase.vin.emplace_back();
+    block.vtx.push_back(MakeTransactionRef(coinbase));
+
+    Txid prevhash{Txid::FromUint256(uint256{1})};
+
+    for (const auto i : std::views::iota(1, NUM_TXS)) {
+        CMutableTransaction tx;
+        Txid txid;
+        if (i % 3 == 0) {
+            // External input
+            txid = Txid::FromUint256(uint256(i));
+        } else if (i % 3 == 1) {
+            // Internal spend (prev tx)
+            txid = prevhash;
+        } else {
+            // Test shortid collisions (looks internal, but is external)
+            uint256 u{};
+            std::memcpy(u.begin(), prevhash.ToUint256().begin(), 8);
+            txid = Txid::FromUint256(u);
+        }
+        tx.vin.emplace_back(txid, 0);
+        prevhash = tx.GetHash();
+        block.vtx.push_back(MakeTransactionRef(tx));
+    }
+
+    return block;
+}
+
+void PopulateView(const CBlock& block, CCoinsView& view, bool spent = false)
+{
+    CCoinsViewCache cache{&view};
+    cache.SetBestBlock(uint256::ONE);
+
+    std::unordered_set<Txid, SaltedTxidHasher> txids{};
+    txids.reserve(block.vtx.size() - 1);
+    for (const auto& tx : block.vtx | std::views::drop(1)) {
+        for (const auto& in : tx->vin) {
+            if (!txids.contains(in.prevout.hash)) {
+                Coin coin{};
+                if (!spent) coin.out.nValue = 1;
+                cache.EmplaceCoinInternalDANGER(COutPoint{in.prevout}, std::move(coin));
+            }
+        }
+        txids.emplace(tx->GetHash());
+    }
+
+    cache.Flush();
+}
+
+void CheckCache(const CBlock& block, const CCoinsViewCache& cache)
+{
+    uint32_t counter{0};
+    std::unordered_set<Txid, SaltedTxidHasher> txids{};
+    txids.reserve(block.vtx.size() - 1);
+
+    for (const auto& tx : block.vtx) {
+        if (tx->IsCoinBase()) {
+            BOOST_CHECK(!cache.GetPossiblySpentCoinFromCache(tx->vin[0].prevout));
+        } else {
+            for (const auto& in : tx->vin) {
+                const auto& outpoint{in.prevout};
+                const auto& first{cache.AccessCoin(outpoint)};
+                const auto& second{cache.AccessCoin(outpoint)};
+                BOOST_CHECK_EQUAL(&first, &second);
+                const auto should_have{!txids.contains(outpoint.hash)};
+                if (should_have) ++counter;
+                const auto have{cache.GetPossiblySpentCoinFromCache(outpoint)};
+                BOOST_CHECK_EQUAL(should_have, !!have);
+            }
+            txids.emplace(tx->GetHash());
+        }
+    }
+    BOOST_CHECK_EQUAL(cache.GetCacheSize(), counter);
+}
+
+
+BOOST_AUTO_TEST_CASE(fetch_inputs_from_db)
+{
+    const auto block{CreateBlock()};
+    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    PopulateView(block, db);
+    NoAccessCoinsView no_access;
+    CCoinsViewCache main_cache{&no_access};
+    CoinsViewCacheAsync view{main_cache, db};
+    for (auto i{0}; i < 3; ++i) {
+        view.StartFetching(block);
+        CheckCache(block, view);
+        view.Reset();
+    }
+}
+
+BOOST_AUTO_TEST_CASE(fetch_inputs_from_cache)
+{
+    const auto block{CreateBlock()};
+    const CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    NoAccessCoinsView no_access;
+    CCoinsViewCache main_cache{&no_access};
+    PopulateView(block, main_cache);
+    CoinsViewCacheAsync view{main_cache, db};
+    for (auto i{0}; i < 3; ++i) {
+        view.StartFetching(block);
+        CheckCache(block, view);
+        view.Reset();
+    }
+}
+
+// Test for the case where a block spends coins that are spent in the cache, but
+// the spentness has not been flushed to the db.
+BOOST_AUTO_TEST_CASE(fetch_no_double_spend)
+{
+    const auto block{CreateBlock()};
+    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    PopulateView(block, db);
+    NoAccessCoinsView no_access;
+    CCoinsViewCache main_cache{&no_access};
+    // Add all inputs as spent already in cache
+    PopulateView(block, main_cache, /*spent=*/true);
+    CoinsViewCacheAsync view{main_cache, db};
+    for (auto i{0}; i < 3; ++i) {
+        view.StartFetching(block);
+        for (const auto& tx : block.vtx) {
+            for (const auto& in : tx->vin) {
+                const auto& c{view.AccessCoin(in.prevout)};
+                BOOST_CHECK(c.IsSpent());
+            }
+        }
+        // Coins are not added to the view, even though they exist unspent in the parent db
+        BOOST_CHECK_EQUAL(view.GetCacheSize(), 0);
+        view.Reset();
+    }
+}
+
+BOOST_AUTO_TEST_CASE(fetch_no_inputs)
+{
+    const auto block{CreateBlock()};
+    const CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    NoAccessCoinsView no_access;
+    CCoinsViewCache main_cache{&no_access};
+    CoinsViewCacheAsync view{main_cache, db};
+    for (auto i{0}; i < 3; ++i) {
+        view.StartFetching(block);
+        for (const auto& tx : block.vtx) {
+            for (const auto& in : tx->vin) {
+                const auto& c{view.AccessCoin(in.prevout)};
+                BOOST_CHECK(c.IsSpent());
+            }
+        }
+        BOOST_CHECK_EQUAL(view.GetCacheSize(), 0);
+        view.Reset();
+    }
+}
+
+// Test that the main thread can make progress with no workers
+BOOST_AUTO_TEST_CASE(fetch_main_thread)
+{
+    const auto block{CreateBlock()};
+    const CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    NoAccessCoinsView no_access;
+    CCoinsViewCache main_cache{&no_access};
+    PopulateView(block, main_cache);
+    CoinsViewCacheAsync view{main_cache, db, /*num_workers=*/0};
+    for (auto i{0}; i < 3; ++i) {
+        view.StartFetching(block);
+        CheckCache(block, view);
+        view.Reset();
+    }
+}
+
+// Access coin that is not a block's input
+BOOST_AUTO_TEST_CASE(access_non_input_coin)
+{
+    const auto block{CreateBlock()};
+    const CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    NoAccessCoinsView no_access;
+    CCoinsViewCache main_cache{&no_access};
+    Coin coin{};
+    coin.out.nValue = 1;
+    const COutPoint outpoint{Txid::FromUint256(uint256::ZERO), 0};
+    main_cache.EmplaceCoinInternalDANGER(COutPoint{Txid::FromUint256(uint256::ZERO), 0}, std::move(coin));
+    CoinsViewCacheAsync view{main_cache, db, /*num_workers=*/0};
+    for (auto i{0}; i < 3; ++i) {
+        view.StartFetching(block);
+        const auto& accessed_coin{view.AccessCoin(outpoint)};
+        BOOST_CHECK(!accessed_coin.IsSpent());
+        view.Reset();
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/fuzz/CMakeLists.txt
+++ b/src/test/fuzz/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(fuzz
   cluster_linearize.cpp
   coins_view.cpp
   coinscache_sim.cpp
+  coinsviewcacheasync.cpp
   connman.cpp
   crypto.cpp
   crypto_aes256.cpp

--- a/src/test/fuzz/coinsviewcacheasync.cpp
+++ b/src/test/fuzz/coinsviewcacheasync.cpp
@@ -1,0 +1,181 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <coins.h>
+#include <coinsviewcacheasync.h>
+#include <consensus/amount.h>
+#include <dbwrapper.h>
+#include <logging.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+#include <primitives/transaction_identifier.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <test/util/random.h>
+#include <txdb.h>
+#include <uint256.h>
+#include <util/byte_units.h>
+#include <util/hasher.h>
+
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <map>
+#include <optional>
+#include <unordered_set>
+#include <utility>
+
+std::optional<CoinsViewCacheAsync> g_async_cache{};
+std::optional<CCoinsViewDB> g_db{};
+
+static void setup_threadpool_test()
+{
+    LogInstance().DisableLogging();
+    auto db_params = DBParams{
+        .path = "",
+        .cache_bytes = 1_MiB,
+        .memory_only = true,
+    };
+    g_db.emplace(std::move(db_params), CoinsViewOptions{});
+    CCoinsViewCache cache{nullptr};
+    g_async_cache.emplace(cache, *g_db);
+}
+
+FUZZ_TARGET(coinsviewcacheasync, .init = setup_threadpool_test)
+{
+    SeedRandomStateForTest(SeedRand::ZEROS);
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+
+    LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 10000)
+    {
+        CBlock block;
+        Txid prevhash{Txid::FromUint256(ConsumeUInt256(fuzzed_data_provider))};
+
+        std::map<const COutPoint, const Coin> db_map{};
+        std::map<const COutPoint, const Coin> cache_map{};
+        std::vector<COutPoint> input_outpoints{};
+
+        CCoinsViewCache main_cache(&*g_db);
+        // Used for writing to the db and erasing between iterations
+        CCoinsViewCache dummy_cache(&*g_db);
+        dummy_cache.SetBestBlock(uint256::ONE);
+
+        LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 10000)
+        {
+            CMutableTransaction tx;
+
+            LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 10000)
+            {
+                Txid txid;
+                if (fuzzed_data_provider.ConsumeBool()) {
+                    txid = Txid::FromUint256(ConsumeUInt256(fuzzed_data_provider));
+                } else if (fuzzed_data_provider.ConsumeBool()) {
+                    txid = prevhash;
+                } else {
+                    // Test shortid collisions
+                    uint256 u{ConsumeUInt256(fuzzed_data_provider)};
+                    std::memcpy(u.begin(), prevhash.ToUint256().begin(), 8);
+                    txid = Txid::FromUint256(u);
+                }
+                const auto index{fuzzed_data_provider.ConsumeIntegral<uint32_t>()};
+                const COutPoint outpoint{txid, index};
+
+                tx.vin.emplace_back(outpoint);
+
+                if (fuzzed_data_provider.ConsumeBool()) {
+                    Coin coin{};
+                    coin.fCoinBase = fuzzed_data_provider.ConsumeBool();
+                    coin.nHeight =
+                        fuzzed_data_provider.ConsumeIntegralInRange<int32_t>(
+                            0, std::numeric_limits<int32_t>::max());
+                    coin.out.nValue = ConsumeMoney(fuzzed_data_provider);
+                    assert(!coin.IsSpent());
+                    db_map.try_emplace(outpoint, coin);
+                    dummy_cache.EmplaceCoinInternalDANGER(
+                        COutPoint(outpoint),
+                        std::move(coin));
+                }
+
+                // Add a different coin to the cache
+                if (fuzzed_data_provider.ConsumeBool()) {
+                    Coin coin{};
+                    coin.fCoinBase = fuzzed_data_provider.ConsumeBool();
+                    coin.nHeight =
+                        fuzzed_data_provider.ConsumeIntegralInRange<int32_t>(
+                            0, std::numeric_limits<int32_t>::max());
+                    coin.out.nValue =
+                        fuzzed_data_provider.ConsumeIntegralInRange<int64_t>(
+                            -1, MAX_MONEY);
+                    cache_map.try_emplace(outpoint, coin);
+                    main_cache.EmplaceCoinInternalDANGER(
+                        COutPoint(outpoint),
+                        std::move(coin));
+                }
+
+                input_outpoints.emplace_back(outpoint);
+            }
+
+            prevhash = tx.GetHash();
+            block.vtx.push_back(MakeTransactionRef(tx));
+        }
+
+        (void)dummy_cache.Sync();
+        CoinsViewCacheAsync& cache(*g_async_cache);
+        cache.SetBackend(main_cache);
+        cache.StartFetching(block);
+
+        std::unordered_set<COutPoint, SaltedOutpointHasher> outpoints_in_cache{};
+        LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), static_cast<uint32_t>(input_outpoints.size() * 10))
+        {
+            COutPoint outpoint;
+            if (fuzzed_data_provider.ConsumeBool()) {
+                const auto index{fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, input_outpoints.size() - 1)};
+                outpoint = input_outpoints[index];
+            } else {
+                const auto txid{Txid::FromUint256(ConsumeUInt256(fuzzed_data_provider))};
+                const auto index{fuzzed_data_provider.ConsumeIntegral<uint32_t>()};
+                outpoint = COutPoint(txid, index);
+            }
+            const auto& accessed_coin{cache.AccessCoin(outpoint)};
+            const auto coin{cache.GetPossiblySpentCoinFromCache(outpoint)};
+            if (coin) {
+                assert(!coin->IsSpent());
+                assert(coin->fCoinBase == accessed_coin.fCoinBase);
+                assert(coin->nHeight == accessed_coin.nHeight);
+                assert(coin->out == accessed_coin.out);
+                outpoints_in_cache.emplace(outpoint);
+            }
+            const auto& db_it{db_map.find(outpoint)};
+            const auto cache_it{cache_map.find(outpoint)};
+            if (!coin) {
+                assert(accessed_coin.IsSpent());
+                // If we don't have a coin, then it's either spent in cache or missing
+                const auto spent_cache_coin{cache_it != cache_map.end() && cache_it->second.IsSpent()};
+                const auto no_coin{cache_it == cache_map.end() && db_it == db_map.end()};
+                assert(spent_cache_coin || no_coin);
+            } else if (cache_it != cache_map.end()) {
+                // Make sure we have the main cache coin if it exists instead of db
+                const auto& cache_coin{cache_it->second};
+                assert(!cache_coin.IsSpent());
+                assert(coin->fCoinBase == cache_coin.fCoinBase);
+                assert(coin->nHeight == cache_coin.nHeight);
+                assert(coin->out == cache_coin.out);
+            } else {
+                assert(db_it != db_map.end());
+                // Check any coins not in the main cache are the same as the db
+                const auto& db_coin{db_it->second};
+                assert(coin->fCoinBase == db_coin.fCoinBase);
+                assert(coin->nHeight == db_coin.nHeight);
+                assert(coin->out == db_coin.out);
+            }
+        }
+        assert(cache.GetCacheSize() == outpoints_in_cache.size());
+        fuzzed_data_provider.ConsumeBool() ? (void)cache.Flush(/*will_reuse_cache=*/true) : cache.Reset();
+        for (const auto& pair : db_map) {
+            dummy_cache.SpendCoin(pair.first);
+        }
+        (void)dummy_cache.Flush();
+    }
+}

--- a/src/util/prefetch.h
+++ b/src/util/prefetch.h
@@ -1,0 +1,25 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_PREFETCH_H
+#define BITCOIN_UTIL_PREFETCH_H
+
+#include <attributes.h>
+
+#include <cstddef>
+
+namespace util {
+
+ALWAYS_INLINE void Prefetch(const void* ptr) noexcept
+{
+#if defined(__clang__) || defined(__GNUC__)
+    __builtin_prefetch(ptr, 0 /* read */, 0 /* no temporal locality */);
+#else
+    (void)ptr;
+#endif
+}
+
+} // namespace util
+
+#endif // BITCOIN_UTIL_PREFETCH_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -54,6 +54,7 @@
 #include <util/fs_helpers.h>
 #include <util/hasher.h>
 #include <util/moneystr.h>
+#include <util/prefetch.h>
 #include <util/rbf.h>
 #include <util/result.h>
 #include <util/signalinterrupt.h>
@@ -2566,6 +2567,12 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     for (unsigned int i = 0; i < block.vtx.size(); i++)
     {
         if (!state.IsValid()) break;
+        if (i + 1 < block.vtx.size()) [[likely]] {
+            const CTransaction* next_tx{block.vtx[i + 1].get()};
+            util::Prefetch(next_tx);
+            if (next_tx && !next_tx->vin.empty()) util::Prefetch(next_tx->vin.data());
+            if (next_tx && !next_tx->vout.empty()) util::Prefetch(next_tx->vout.data());
+        }
         const CTransaction &tx = *(block.vtx[i]);
 
         nInputs += tx.vin.size();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1873,6 +1873,7 @@ void CoinsViews::InitCache()
 {
     AssertLockHeld(::cs_main);
     m_cacheview = std::make_unique<CCoinsViewCache>(&m_catcherview);
+    m_connect_block_view = std::make_unique<CoinsViewCacheAsync>(*m_cacheview, m_catcherview);
 }
 
 Chainstate::Chainstate(
@@ -3113,7 +3114,8 @@ bool Chainstate::ConnectTip(
     LogDebug(BCLog::BENCH, "  - Load block from disk: %.2fms\n",
              Ticks<MillisecondsDouble>(time_2 - time_1));
     {
-        CCoinsViewCache view(&CoinsTip());
+        auto& view{*m_coins_views->m_connect_block_view};
+        view.StartFetching(*block_to_connect);
         bool rv = ConnectBlock(*block_to_connect, state, pindexNew, view);
         if (m_chainman.m_options.signals) {
             m_chainman.m_options.signals->BlockChecked(block_to_connect, state);
@@ -3122,6 +3124,7 @@ bool Chainstate::ConnectTip(
             if (state.IsInvalid())
                 InvalidBlockFound(pindexNew, state);
             LogError("%s: ConnectBlock %s failed, %s\n", __func__, pindexNew->GetBlockHash().ToString(), state.ToString());
+            view.Reset();
             return false;
         }
         time_3 = SteadyClock::now();

--- a/src/validation.h
+++ b/src/validation.h
@@ -10,6 +10,7 @@
 #include <attributes.h>
 #include <chain.h>
 #include <checkqueue.h>
+#include <coinsviewcacheasync.h>
 #include <consensus/amount.h>
 #include <cuckoocache.h>
 #include <deploymentstatus.h>
@@ -487,6 +488,10 @@ public:
     //! This is the top layer of the cache hierarchy - it keeps as many coins in memory as
     //! can fit per the dbcache setting.
     std::unique_ptr<CCoinsViewCache> m_cacheview GUARDED_BY(cs_main);
+
+    //! Used as an empty view that is only passed into ConnectBlock to help speed up block validation,
+    //! as well as not pollute the underlying cache with newly created coins in case the block is invalid.
+    std::unique_ptr<CoinsViewCacheAsync> m_connect_block_view GUARDED_BY(cs_main);
 
     //! This constructor initializes CCoinsViewDB and CCoinsViewErrorCatcher instances, but it
     //! *does not* create a CCoinsViewCache instance by default. This is done separately because the


### PR DESCRIPTION
```
for DBCACHE in 300 3000; do \
  COMMITS="7fc95cf847bc847983a73bd9f575c50ae1154af7 14d81054c92de497b299e34f70c405b578c3c4e6 10070cad746444b635ff0c7491f0e1f698c664ba"; \
  STOP=926629; \
  CC=gcc; CXX=g++; \
  BASE_DIR="/mnt/my_storage"; DATA_DIR="$BASE_DIR/BitcoinData"; LOG_DIR="$BASE_DIR/logs"; \
  (echo ""; for c in $COMMITS; do git fetch -q origin $c && git log -1 --pretty='%h %s' $c || exit 1; done) && \
  (echo "" && echo "reindex-chainstate | ${STOP} blocks | dbcache ${DBCACHE} | $(hostname) | $(uname -m) | $(lscpu | grep 'Model name' | head -1 | cut -d: -f2 | xargs) | $(nproc) cores | $(free -h | awk '/^Mem:/{print $2}') RAM | $(df -T $BASE_DIR | awk 'NR==2{print $2}') | $(lsblk -no ROTA $(df --output=source $BASE_DIR | tail -1) | grep -q 0 && echo SSD || echo HDD)"; echo "") &&\
  hyperfine \
    --sort command \
    --runs 1 \
    --export-json "$BASE_DIR/rdx-$(sed -E 's/(\w{8})\w+ ?/\1-/g;s/-$//'<<<"$COMMITS")-$STOP-$DBCACHE-$CC.json" \
    --parameter-list COMMIT ${COMMITS// /,} \
    --prepare "killall -9 bitcoind 2>/dev/null; rm -f $DATA_DIR/debug.log; git checkout {COMMIT}; git clean -fxd; git reset --hard && \
      cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release && ninja -C build bitcoind -j2 && \
      ./build/bin/bitcoind -datadir=$DATA_DIR -stopatheight=$STOP -dbcache=1000 -printtoconsole=0; sleep 20" \
    --conclude "killall bitcoind || true; sleep 5; grep -q 'height=0' $DATA_DIR/debug.log && grep -q 'Disabling script verification at block #1' $DATA_DIR/debug.log && grep -q 'height=$STOP' $DATA_DIR/debug.log; \
                cp $DATA_DIR/debug.log $LOG_DIR/debug-{COMMIT}-$(date +%s).log" \
    "COMPILER=$CC ./build/bin/bitcoind -datadir=$DATA_DIR -stopatheight=$STOP -dbcache=$DBCACHE -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0";
done
```

```
7fc95cf847 validation: fetch block inputs via CCoinsViewCacheAsync during connection
14d81054c9 refactor: replace list with vector for allocated_chunks in PoolResource
10070cad74 refactor: update PoolResource constructor to use maximum block size

reindex-chainstate | 926629 blocks | dbcache 300 | i9-ssd | x86_64 | Intel(R) Core(TM) i9-9900K CPU @ 3.60GHz | 16 cores | 62Gi RAM | xfs | SSD

Benchmark 1: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=926629 -dbcache=300 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 7fc95cf847bc847983a73bd9f575c50ae1154af7)
  Time (abs ≡):        15369.443 s               [User: 46244.302 s, System: 2326.321 s]
 
Benchmark 2: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=926629 -dbcache=300 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 14d81054c92de497b299e34f70c405b578c3c4e6)
  Time (abs ≡):        15365.743 s               [User: 46251.100 s, System: 2376.054 s]
 
Benchmark 3: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=926629 -dbcache=300 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 10070cad746444b635ff0c7491f0e1f698c664ba)
  Time (abs ≡):        15396.075 s               [User: 46362.843 s, System: 2422.010 s]
 
Relative speed comparison
        1.00          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=926629 -dbcache=300 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 7fc95cf847bc847983a73bd9f575c50ae1154af7)
        1.00          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=926629 -dbcache=300 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 14d81054c92de497b299e34f70c405b578c3c4e6)
        1.00          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=926629 -dbcache=300 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 10070cad746444b635ff0c7491f0e1f698c664ba)
```



```
7fc95cf847 validation: fetch block inputs via CCoinsViewCacheAsync during connection
14d81054c9 refactor: replace list with vector for allocated_chunks in PoolResource
10070cad74 refactor: update PoolResource constructor to use maximum block size

reindex-chainstate | 926629 blocks | dbcache 3000 | i9-ssd | x86_64 | Intel(R) Core(TM) i9-9900K CPU @ 3.60GHz | 16 cores | 62Gi RAM | xfs | SSD

Benchmark 1: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=926629 -dbcache=3000 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 7fc95cf847bc847983a73bd9f575c50ae1154af7)
  Time (abs ≡):        14027.819 s               [User: 31816.619 s, System: 1084.014 s]
 
Benchmark 2: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=926629 -dbcache=3000 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 14d81054c92de497b299e34f70c405b578c3c4e6)
  Time (abs ≡):        13984.099 s               [User: 31690.111 s, System: 1061.398 s]
 
Benchmark 3: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=926629 -dbcache=3000 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 10070cad746444b635ff0c7491f0e1f698c664ba)
  Time (abs ≡):        13985.503 s               [User: 31697.141 s, System: 1065.364 s]
 
Relative speed comparison
        1.00          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=926629 -dbcache=3000 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 7fc95cf847bc847983a73bd9f575c50ae1154af7)
        1.00          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=926629 -dbcache=3000 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 14d81054c92de497b299e34f70c405b578c3c4e6)
        1.00          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=926629 -dbcache=3000 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 10070cad746444b635ff0c7491f0e1f698c664ba)
```