### PR TITLE
WIP net_processing: avoid IBD stall after empty HEADERS

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2837,15 +2837,35 @@ void PeerManagerImpl::ProcessHeadersMessage(CNode& pfrom, Peer& peer,
         // If we were in the middle of headers sync, receiving an empty headers
         // message suggests that the peer suddenly has nothing to give us
         // (perhaps it reorged to our chain). Clear download state for this peer.
-        LOCK(peer.m_headers_sync_mutex);
-        if (peer.m_headers_sync) {
-            peer.m_headers_sync.reset(nullptr);
-            LOCK(m_headers_presync_mutex);
-            m_headers_presync_stats.erase(pfrom.GetId());
+        {
+            LOCK(peer.m_headers_sync_mutex);
+            if (peer.m_headers_sync) {
+                peer.m_headers_sync.reset(nullptr);
+                LOCK(m_headers_presync_mutex);
+                m_headers_presync_stats.erase(pfrom.GetId());
+            }
+        }
+        bool reset_sync_state{false};
+        {
+            // If this peer sends an empty headers response during initial headers
+            // sync, avoid getting stuck syncing from it (which blocks syncing from
+            // other peers). See the logic around nSyncStarted in SendMessages().
+            LOCK(cs_main);
+            CNodeState& state{*Assert(State(pfrom.GetId()))};
+            const CBlockIndex* best_header{m_chainman.m_best_header ? m_chainman.m_best_header : m_chainman.ActiveChain().Tip()};
+            if (state.fSyncStarted && best_header != nullptr && best_header->Time() <= NodeClock::now() - 24h) {
+                state.fSyncStarted = false;
+                assert(nSyncStarted > 0);
+                nSyncStarted--;
+                peer.m_headers_sync_timeout = 0us;
+                reset_sync_state = true;
+            }
         }
         // A headers message with no headers cannot be an announcement, so assume
         // it is a response to our last getheaders request, if there is one.
-        peer.m_last_getheaders_timestamp = {};
+        // If we reset the sync state above, keep the last-getheaders timestamp
+        // intact to avoid immediately selecting the same peer for headers sync.
+        if (!reset_sync_state) peer.m_last_getheaders_timestamp = {};
         return;
     }
 

--- a/test/functional/p2p_addnode_ibd_stall.py
+++ b/test/functional/p2p_addnode_ibd_stall.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+
+class AddnodeIBDStallTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 3
+        self.setup_clean_chain = True
+
+    def setup_network(self):
+        self.setup_nodes()
+
+    def run_test(self):
+        node_a = self.nodes[0]
+        node_b = self.nodes[1]
+        node_c = self.nodes[2]
+
+        # Mine blocks on node_c so it has a longer chain, while leaving node_a
+        # and node_b at height 0.
+        target_height = 10
+        self.generate(node_c, target_height, sync_fun=self.no_op)
+        assert_equal(node_a.getblockcount(), 0)
+        assert_equal(node_b.getblockcount(), 0)
+        assert_equal(node_c.getblockcount(), target_height)
+
+        # Connect B->A first, so B starts initial headers sync with A (which has
+        # nothing new, so it will respond with an empty headers message).
+        self.connect_nodes(1, 0)
+
+        a_subver = node_a.getnetworkinfo()["subversion"]
+
+        def peerinfo_to_a():
+            for peer in node_b.getpeerinfo():
+                if peer["subver"] == a_subver and not peer["inbound"]:
+                    return peer
+            return None
+
+        # Wait until B has sent GETHEADERS and received the empty HEADERS response.
+        self.wait_until(lambda: peerinfo_to_a() and peerinfo_to_a()["bytessent_per_msg"].get("getheaders", 0) > 0)
+        self.wait_until(lambda: peerinfo_to_a() and peerinfo_to_a()["bytesrecv_per_msg"].get("headers", 0) > 0)
+
+        # Now connect B->C. B should sync from C even while still connected to A.
+        self.connect_nodes(1, 2)
+        self.wait_until(lambda: node_b.getblockcount() == target_height)
+
+
+if __name__ == "__main__":
+    AddnodeIBDStallTest(__file__).main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -317,6 +317,7 @@ BASE_SCRIPTS = [
     'feature_loadblock.py',
     'wallet_assumeutxo.py',
     'p2p_add_connections.py',
+    'p2p_addnode_ibd_stall.py',
     'feature_bind_port_discover.py',
     'p2p_unrequested_blocks.py',
     'p2p_message_capture.py',


### PR DESCRIPTION
If the selected initial headers-sync peer responds with an empty HEADERS message, keep fSyncStarted from blocking selection of another peer, which can otherwise stall IBD (e.g. when connected via -addnode to a peer still syncing).

Reset the per-peer headers-sync state on empty HEADERS responses and add a functional regression test.

Fixes #34096