### PR TITLE
coins: add cache size reservation to `CCoinsViewCache`

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -42,6 +42,24 @@ CCoinsViewCache::CCoinsViewCache(CCoinsView* baseIn, bool deterministic) :
     CCoinsViewBacked(baseIn), m_deterministic(deterministic),
     cacheCoins(0, SaltedOutpointHasher(/*deterministic=*/deterministic), CCoinsMap::key_equal{}, &m_cache_coins_memory_resource)
 {
+    Reset();
+}
+
+void CCoinsViewCache::Start()
+{
+    Assert(cacheCoins.empty());
+    Assert(cachedCoinsUsage == 0);
+    Assert(hashBlock.IsNull());
+    Assert(m_sentinel.second.Next() == &m_sentinel);
+    Assert(m_sentinel.second.Prev() == &m_sentinel);
+    (void)GetBestBlock(); // lazy init
+}
+
+void CCoinsViewCache::Reset() noexcept
+{
+    cacheCoins.clear();
+    cachedCoinsUsage = 0;
+    hashBlock.SetNull();
     m_sentinel.second.SelfRef(m_sentinel);
 }
 

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -72,8 +72,16 @@ void CCoinsViewCache::Reset() noexcept
     m_sentinel.second.SelfRef(m_sentinel);
 }
 
-size_t CCoinsViewCache::DynamicMemoryUsage() const {
+size_t CCoinsViewCache::DynamicMemoryUsage() const
+{
     return memusage::DynamicUsage(cacheCoins) + cachedCoinsUsage;
+}
+
+size_t CCoinsViewCache::ActiveMemoryUsage() const
+{
+    const size_t node_pool_bytes{cacheCoins.get_allocator().resource()->BytesInUse()};
+    const size_t bucket_array_bytes{memusage::MallocUsage(sizeof(void*) * cacheCoins.bucket_count())};
+    return cachedCoinsUsage + node_pool_bytes + bucket_array_bytes;
 }
 
 CCoinsMap::iterator CCoinsViewCache::FetchCoin(const COutPoint &outpoint) const {

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -321,15 +321,13 @@ void CCoinsViewCache::BatchWrite(CoinsViewCacheCursor& cursor, const uint256& ha
     hashBlock = hashBlockIn;
 }
 
-void CCoinsViewCache::Flush(bool will_reuse_cache)
+void CCoinsViewCache::Flush()
 {
     auto cursor{CoinsViewCacheCursor(m_sentinel, cacheCoins, /*will_erase=*/true)};
     base->BatchWrite(cursor, hashBlock);
-    cacheCoins.clear();
-    if (will_reuse_cache) {
-        ReallocateCache();
-    }
-    cachedCoinsUsage = 0;
+        cacheCoins.clear();
+        cachedCoinsUsage = 0;
+
 }
 
 void CCoinsViewCache::Sync()

--- a/src/coins.h
+++ b/src/coins.h
@@ -448,8 +448,6 @@ public:
      * Push the modifications applied to this cache to its base and wipe local state.
      * Failure to call this method or Sync() before destruction will cause the changes
      * to be forgotten.
-     * If will_reuse_cache is false, the cache will retain the same memory footprint
-     * after flushing and should be destroyed to deallocate.
      */
     void Flush();
 

--- a/src/coins.h
+++ b/src/coins.h
@@ -467,6 +467,9 @@ public:
     //! Calculate the size of the cache (in bytes)
     size_t DynamicMemoryUsage() const;
 
+    //! Calculate the active memory usage of the cache (in bytes)
+    size_t ActiveMemoryUsage() const;
+
     //! Check whether all prevouts of the transaction are present in the UTXO set represented by this view
     bool HaveInputs(const CTransaction& tx) const;
 

--- a/src/coins.h
+++ b/src/coins.h
@@ -377,7 +377,13 @@ protected:
     mutable size_t cachedCoinsUsage{0};
 
 public:
-    CCoinsViewCache(CCoinsView *baseIn, bool deterministic = false);
+    static constexpr float DEFAULT_MAX_LOAD_FACTOR{1.0f};
+
+    static size_t ReservedEntries(size_t max_coins_cache_size_bytes, float max_load_factor) noexcept;
+    static const size_t CONNECT_BLOCK_VIEW_RESERVE_ENTRIES;
+    float GetMaxLoadFactor() const noexcept { return cacheCoins.max_load_factor(); }
+
+    CCoinsViewCache(CCoinsView* baseIn, bool deterministic = false, size_t reserve_entries = 0, float max_load_factor = DEFAULT_MAX_LOAD_FACTOR);
 
     /**
      * By deleting the copy constructor, we prevent accidentally using it when one intends to create a cache on top of a base cache.
@@ -479,6 +485,10 @@ public:
     //!
     //! See: https://stackoverflow.com/questions/42114044/how-to-release-unordered-map-memory
     void ReallocateCache();
+
+    //! Preallocate the cache map bucket count based on the expected maximum cache size.
+    //! This avoids expensive rehashing during cache growth.
+    void ReserveCache(size_t max_coins_cache_size_bytes, float max_load_factor);
 
     //! Run an internal sanity check on the cache data structure. */
     void SanityCheck() const;

--- a/src/coins.h
+++ b/src/coins.h
@@ -384,6 +384,9 @@ public:
      */
     CCoinsViewCache(const CCoinsViewCache &) = delete;
 
+    void Start();
+    void Reset() noexcept;
+
     // Standard CCoinsView methods
     std::optional<Coin> GetCoin(const COutPoint& outpoint) const override;
     bool HaveCoin(const COutPoint &outpoint) const override;

--- a/src/coins.h
+++ b/src/coins.h
@@ -451,7 +451,7 @@ public:
      * If will_reuse_cache is false, the cache will retain the same memory footprint
      * after flushing and should be destroyed to deallocate.
      */
-    void Flush(bool will_reuse_cache = true);
+    void Flush();
 
     /**
      * Push the modifications applied to this cache to its base while retaining

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -114,7 +114,8 @@ static ChainstateLoadResult CompleteChainstateInitialization(
         }
 
         // The on-disk coinsdb is now in a good state, create the cache
-        chainstate->InitCoinsCache(chainman.m_total_coinstip_cache * init_cache_fraction);
+        chainstate->InitCoinsCache(chainman.m_total_coinstip_cache * init_cache_fraction,
+                                   CCoinsViewCache::CONNECT_BLOCK_VIEW_RESERVE_ENTRIES);
         assert(chainstate->CanFlushToDisk());
 
         if (!is_coinsview_empty(*chainstate)) {

--- a/src/support/allocators/pool.h
+++ b/src/support/allocators/pool.h
@@ -157,11 +157,13 @@ class PoolResource final
     void AllocateChunk()
     {
         // if there is still any available memory left, put it into the freelist.
-        size_t remaining_available_bytes = std::distance(m_available_memory_it, m_available_memory_end);
-        if (0 != remaining_available_bytes) {
-            ASAN_UNPOISON_MEMORY_REGION(m_available_memory_it, sizeof(ListNode));
-            PlacementAddToList(m_available_memory_it, m_free_lists[remaining_available_bytes / ELEM_ALIGN_BYTES]);
-            ASAN_POISON_MEMORY_REGION(m_available_memory_it, sizeof(ListNode));
+        if (m_available_memory_it != nullptr && m_available_memory_end != nullptr) {
+            size_t remaining_available_bytes = std::distance(m_available_memory_it, m_available_memory_end);
+            if (0 != remaining_available_bytes) {
+                ASAN_UNPOISON_MEMORY_REGION(m_available_memory_it, sizeof(ListNode));
+                PlacementAddToList(m_available_memory_it, m_free_lists[remaining_available_bytes / ELEM_ALIGN_BYTES]);
+                ASAN_POISON_MEMORY_REGION(m_available_memory_it, sizeof(ListNode));
+            }
         }
 
         void* storage = ::operator new (m_chunk_size_bytes, std::align_val_t{ELEM_ALIGN_BYTES});

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -86,6 +86,11 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsView& backend
                 coins_view_cache.SetBestBlock(best_block);
             },
             [&] {
+                coins_view_cache.Reset();
+                // Set best block hash to non-null to satisfy the assertion in CCoinsViewDB::BatchWrite().
+                if (is_db) coins_view_cache.SetBestBlock(uint256::ONE);
+            },
+            [&] {
                 Coin move_to;
                 (void)coins_view_cache.SpendCoin(random_out_point, fuzzed_data_provider.ConsumeBool() ? &move_to : nullptr);
             },

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -74,7 +74,7 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsView& backend
                 }
             },
             [&] {
-                coins_view_cache.Flush(/*will_reuse_cache=*/fuzzed_data_provider.ConsumeBool());
+                coins_view_cache.Flush();
             },
             [&] {
                 coins_view_cache.Sync();

--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -401,6 +401,12 @@ FUZZ_TARGET(coinscache_sim)
                 caches.back()->Sync();
             },
 
+            [&]() { // Reset.
+                sim_caches[caches.size()].Wipe();
+                // Apply to real caches.
+                caches.back()->Reset();
+            },
+
             [&]() { // GetCacheSize
                 (void)caches.back()->GetCacheSize();
             },

--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -391,7 +391,7 @@ FUZZ_TARGET(coinscache_sim)
                 // Apply to simulation data.
                 flush();
                 // Apply to real caches.
-                caches.back()->Flush(/*will_reuse_cache=*/provider.ConsumeBool());
+                caches.back()->Flush();
             },
 
             [&]() { // Sync.

--- a/src/test/pool_tests.cpp
+++ b/src/test/pool_tests.cpp
@@ -186,6 +186,12 @@ BOOST_AUTO_TEST_CASE(memusage_test)
         auto max_nodes_per_chunk = resource.ChunkSizeBytes() / sizeof(Map::value_type);
         auto min_num_allocated_chunks = resource_map.size() / max_nodes_per_chunk + 1;
         BOOST_TEST(resource.NumAllocatedChunks() >= min_num_allocated_chunks);
+
+        size_t chunks_before_clear = resource.NumAllocatedChunks();
+        BOOST_CHECK(chunks_before_clear > 0);
+        resource_map.clear();
+        BOOST_CHECK_EQUAL(resource.NumAllocatedChunks(), chunks_before_clear);
+        BOOST_CHECK_EQUAL(resource.BytesInUse(), 0);
     }
 
     PoolResourceTester::CheckAllDataAccountedFor(resource);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2790,8 +2790,10 @@ bool Chainstate::FlushStateToDisk(
         bool fCacheCritical = mode == FlushStateMode::IF_NEEDED && cache_state >= CoinsCacheSizeState::CRITICAL;
         // It's been a while since we wrote the block index and chain state to disk. Do this frequently, so we don't need to redownload or reindex after a crash.
         bool fPeriodicWrite = mode == FlushStateMode::PERIODIC && nNow >= m_next_write;
+        // Flush the chainstate (which may refer to block index entries).
+        bool should_empty{(mode == FlushStateMode::ALWAYS) || fCacheLarge || fCacheCritical};
         // Combine all conditions that result in a write to disk.
-        bool should_write = (mode == FlushStateMode::ALWAYS) || fCacheLarge || fCacheCritical || fPeriodicWrite || fFlushForPrune;
+        bool should_write{should_empty || fPeriodicWrite || fFlushForPrune};
         // Write blocks, block index and best chain related state to disk.
         if (should_write) {
             LogDebug(BCLog::COINDB, "Writing chainstate to disk: flush mode=%s, prune=%d, large=%d, critical=%d, periodic=%d",
@@ -2838,9 +2840,11 @@ bool Chainstate::FlushStateToDisk(
                 if (!CheckDiskSpace(m_chainman.m_options.datadir, 48 * 2 * 2 * CoinsTip().GetCacheSize())) {
                     return FatalError(m_chainman.GetNotifications(), state, _("Disk space is too low!"));
                 }
-                // Flush the chainstate (which may refer to block index entries).
-                const auto empty_cache{(mode == FlushStateMode::ALWAYS) || fCacheLarge || fCacheCritical};
-                empty_cache ? CoinsTip().Flush() : CoinsTip().Sync();
+                if (should_empty) {
+                    CoinsTip().Flush();
+                } else {
+                    CoinsTip().Sync();
+                }
                 full_flush_completed = true;
                 TRACEPOINT(utxocache, flush,
                     int64_t{Ticks<std::chrono::microseconds>(NodeClock::now() - nNow)},

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2984,7 +2984,7 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
             view.Reset();
             return false;
         }
-        view.Flush(/*will_reuse_cache=*/false);
+        view.Flush();
         view.Reset();
     }
     LogDebug(BCLog::BENCH, "- Disconnect block: %.2fms\n",
@@ -3122,7 +3122,7 @@ bool Chainstate::ConnectTip(
                  Ticks<MillisecondsDouble>(time_3 - time_2),
                  Ticks<SecondsDouble>(m_chainman.time_connect_total),
                  Ticks<MillisecondsDouble>(m_chainman.time_connect_total) / m_chainman.num_blocks_total);
-        view.Flush(/*will_reuse_cache=*/false);
+        view.Flush();
         view.Reset();
     }
     const auto time_4{SteadyClock::now()};
@@ -4929,7 +4929,7 @@ bool Chainstate::ReplayBlocks()
     }
 
     cache.SetBestBlock(pindexNew->GetBlockHash());
-    cache.Flush(/*will_reuse_cache=*/false); // local CCoinsViewCache goes out of scope
+    cache.Flush(); // local CCoinsViewCache goes out of scope
     m_chainman.GetNotifications().progress(bilingual_str{}, 100, false);
     return true;
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1855,7 +1855,10 @@ CoinsViews::CoinsViews(DBParams db_params, CoinsViewOptions options)
 void CoinsViews::InitCache(size_t cache_size_bytes, float max_load_factor, size_t connect_block_view_reserve_entries)
 {
     AssertLockHeld(::cs_main);
-    m_cacheview = std::make_unique<CCoinsViewCache>(&m_catcherview, /*deterministic=*/false, CCoinsViewCache::ReservedEntries(cache_size_bytes, max_load_factor), max_load_factor);
+
+    const size_t reserved_entries{CCoinsViewCache::ReservedEntries(cache_size_bytes, max_load_factor)};
+    m_cacheview = std::make_unique<CCoinsViewCache>(&m_catcherview, /*deterministic=*/false, reserved_entries, max_load_factor);
+
     m_connect_block_view = std::make_unique<CCoinsViewCache>(&*m_cacheview, /*deterministic=*/false, connect_block_view_reserve_entries, max_load_factor);
 }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1856,6 +1856,7 @@ void CoinsViews::InitCache()
 {
     AssertLockHeld(::cs_main);
     m_cacheview = std::make_unique<CCoinsViewCache>(&m_catcherview);
+    m_connect_block_view = std::make_unique<CCoinsViewCache>(&*m_cacheview);
 }
 
 Chainstate::Chainstate(
@@ -2975,13 +2976,16 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
     // Apply the block atomically to the chain state.
     const auto time_start{SteadyClock::now()};
     {
-        CCoinsViewCache view(&CoinsTip());
+        auto& view{ConnectBlockView()};
+        view.Start();
         assert(view.GetBestBlock() == pindexDelete->GetBlockHash());
         if (DisconnectBlock(block, pindexDelete, view) != DISCONNECT_OK) {
             LogError("DisconnectTip(): DisconnectBlock %s failed\n", pindexDelete->GetBlockHash().ToString());
+            view.Reset();
             return false;
         }
-        view.Flush(/*will_reuse_cache=*/false); // local CCoinsViewCache goes out of scope
+        view.Flush(/*will_reuse_cache=*/false);
+        view.Reset();
     }
     LogDebug(BCLog::BENCH, "- Disconnect block: %.2fms\n",
              Ticks<MillisecondsDouble>(SteadyClock::now() - time_start));
@@ -3097,7 +3101,9 @@ bool Chainstate::ConnectTip(
     LogDebug(BCLog::BENCH, "  - Load block from disk: %.2fms\n",
              Ticks<MillisecondsDouble>(time_2 - time_1));
     {
-        CCoinsViewCache view(&CoinsTip());
+        auto& view{ConnectBlockView()};
+        view.Start();
+        assert(view.GetBestBlock() == (pindexNew->pprev ? pindexNew->pprev->GetBlockHash() : uint256::ZERO));
         bool rv = ConnectBlock(*block_to_connect, state, pindexNew, view);
         if (m_chainman.m_options.signals) {
             m_chainman.m_options.signals->BlockChecked(block_to_connect, state);
@@ -3106,6 +3112,7 @@ bool Chainstate::ConnectTip(
             if (state.IsInvalid())
                 InvalidBlockFound(pindexNew, state);
             LogError("%s: ConnectBlock %s failed, %s\n", __func__, pindexNew->GetBlockHash().ToString(), state.ToString());
+            view.Reset();
             return false;
         }
         time_3 = SteadyClock::now();
@@ -3115,7 +3122,8 @@ bool Chainstate::ConnectTip(
                  Ticks<MillisecondsDouble>(time_3 - time_2),
                  Ticks<SecondsDouble>(m_chainman.time_connect_total),
                  Ticks<MillisecondsDouble>(m_chainman.time_connect_total) / m_chainman.num_blocks_total);
-        view.Flush(/*will_reuse_cache=*/false); // local CCoinsViewCache goes out of scope
+        view.Flush(/*will_reuse_cache=*/false);
+        view.Reset();
     }
     const auto time_4{SteadyClock::now()};
     m_chainman.time_flush += time_4 - time_3;
@@ -4584,13 +4592,17 @@ BlockValidationState TestBlockValidity(
     index_dummy.pprev = tip;
     index_dummy.nHeight = tip->nHeight + 1;
     index_dummy.phashBlock = &block_hash;
-    CCoinsViewCache view_dummy(&chainstate.CoinsTip());
+    auto& view_dummy{chainstate.ConnectBlockView()};
+    view_dummy.Start();
+    assert(view_dummy.GetBestBlock() == tip->GetBlockHash());
 
     // Set fJustCheck to true in order to update, and not clear, validation caches.
     if(!chainstate.ConnectBlock(block, state, &index_dummy, view_dummy, /*fJustCheck=*/true)) {
         if (state.IsValid()) NONFATAL_UNREACHABLE();
+        view_dummy.Reset();
         return state;
     }
+    view_dummy.Reset();
 
     // Ensure no check returned successfully while also setting an invalid state.
     if (!state.IsValid()) NONFATAL_UNREACHABLE();

--- a/src/validation.h
+++ b/src/validation.h
@@ -500,7 +500,7 @@ public:
     CoinsViews(DBParams db_params, CoinsViewOptions options);
 
     //! Initialize the CCoinsViewCache member.
-    void InitCache() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    void InitCache(size_t cache_size_bytes, float max_load_factor, size_t connect_block_view_reserve_entries) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 };
 
 enum class CoinsCacheSizeState
@@ -607,7 +607,7 @@ public:
 
     //! Initialize the in-memory coins cache (to be done after the health of the on-disk database
     //! is verified).
-    void InitCoinsCache(size_t cache_size_bytes) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    void InitCoinsCache(size_t cache_size_bytes, size_t connect_block_view_reserve_entries = 0, float max_load_factor = CCoinsViewCache::DEFAULT_MAX_LOAD_FACTOR) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     //! @returns whether or not the CoinsViews object has been fully initialized and we can
     //!          safely flush this object to disk.

--- a/src/validation.h
+++ b/src/validation.h
@@ -488,6 +488,9 @@ public:
     //! can fit per the dbcache setting.
     std::unique_ptr<CCoinsViewCache> m_cacheview GUARDED_BY(cs_main);
 
+    //! A per-block cache used for ConnectBlock to not pollute the underlying cache with newly created coins in case the block is invalid.
+    std::unique_ptr<CCoinsViewCache> m_connect_block_view GUARDED_BY(cs_main);
+
     //! This constructor initializes CCoinsViewDB and CCoinsViewErrorCatcher instances, but it
     //! *does not* create a CCoinsViewCache instance by default. This is done separately because the
     //! presence of the cache has implications on whether or not we're allowed to flush the cache's
@@ -682,6 +685,13 @@ public:
         AssertLockHeld(::cs_main);
         Assert(m_coins_views);
         return *Assert(m_coins_views->m_cacheview);
+    }
+
+    CCoinsViewCache& ConnectBlockView() EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
+    {
+        AssertLockHeld(::cs_main);
+        Assert(m_coins_views);
+        return *Assert(m_coins_views->m_connect_block_view);
     }
 
     //! @returns A reference to the on-disk UTXO set database.


### PR DESCRIPTION
```patch
diff --git a/src/coins.cpp b/src/coins.cpp
--- a/src/coins.cpp	(revision 150fbddecea9b351ec5c0f85cc2662c64c3eadcc)
+++ b/src/coins.cpp	(revision 78e5f8af56ee32b3eec60ef58fb20dd81b9822a0)
@@ -250,6 +250,8 @@
 }
 
 bool CCoinsViewCache::Flush(bool will_reuse_cache) {
+    LogInfo("cachedCoinsUsage: %s, buckets: %s, size: %s, load: %.2f", cachedCoinsUsage, cacheCoins.bucket_count(), cacheCoins.size(), cacheCoins.load_factor());
+
     auto cursor{CoinsViewCacheCursor(m_sentinel, cacheCoins, /*will_erase=*/true)};
     bool fOk = base->BatchWrite(cursor, hashBlock);
     if (fOk) {

```


-------


https://github.com/bitcoin/bitcoin/pull/33602

```
COMMITS="091cae6fdf895da8f77c5c3e724a62b3fc55b00e 475110f9c22724d1a2649ccca4c137f9878f1162"; STOP=923319; DBCACHE=450; CC=gcc; CXX=g++; BASE_DIR="/mnt/my_storage"; DATA_DIR="$BASE_DIR/BitcoinData"; LOG_DIR="$BASE_DIR/logs"; (echo ""; for c in $COMMITS; do git fetch -q origin $c && git log -1 --pretty='%h %s' $c || exit 1; done) && (echo "" && echo "reindex-chainstate | ${STOP} blocks | dbcache ${DBCACHE} | $(hostname) | $(uname -m) | $(lscpu | grep 'Model name' | head -1 | cut -d: -f2 | xargs) | $(nproc) cores | $(free -h | awk '/^Mem:/{print $2}') RAM | $(df -T $BASE_DIR | awk 'NR==2{print $2}') | $(lsblk -no ROTA $(df --output=source $BASE_DIR | tail -1) | grep -q 0 && echo SSD || echo HDD)"; echo "") &&hyperfine   --sort command   --runs 1   --export-json "$BASE_DIR/rdx-$(sed -E 's/(\w{8})\w+ ?/\1-/g;s/-$//'<<<"$COMMITS")-$STOP-$DBCACHE-$CC.json"   --parameter-list COMMIT ${COMMITS// /,}   --prepare "killall -9 bitcoind 2>/dev/null; rm -f $DATA_DIR/debug.log; git checkout {COMMIT}; git clean -fxd; git reset --hard && \
    cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_IPC=OFF && ninja -C build bitcoind -j2 && \
    ./build/bin/bitcoind -datadir=$DATA_DIR -stopatheight=$STOP -dbcache=1000 -printtoconsole=0; sleep 20"   --conclude "killall bitcoind || true; sleep 5; grep -q 'height=0' $DATA_DIR/debug.log && grep -q 'Disabling script verification at block #1' $DATA_DIR/debug.log && grep -q 'height=$STOP' $DATA_DIR/debug.log; \
              cp $DATA_DIR/debug.log $LOG_DIR/debug-{COMMIT}-$(date +%s).log"   "COMPILER=$CC ./build/bin/bitcoind -datadir=$DATA_DIR -stopatheight=$STOP -dbcache=$DBCACHE -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0";

091cae6fdf Merge bitcoin/bitcoin#33939: contrib: Count entry differences in asmap-tool diff summary
475110f9c2 flush by ActiveMemoryUsage

reindex-chainstate | 923319 blocks | dbcache 450 | i9-ssd | x86_64 | Intel(R) Core(TM) i9-9900K CPU @ 3.60GHz | 16 cores | 62Gi RAM | xfs | SSD

Benchmark 1: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=923319 -dbcache=450 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 091cae6fdf895da8f77c5c3e724a62b3fc55b00e)
  Time (abs ≡):        21044.151 s               [User: 42599.523 s, System: 2794.149 s]
 
Benchmark 2: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=923319 -dbcache=450 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 475110f9c22724d1a2649ccca4c137f9878f1162)
  Time (abs ≡):        20308.383 s               [User: 41090.047 s, System: 2644.751 s]
 
Relative speed comparison
        1.04          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=923319 -dbcache=450 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 091cae6fdf895da8f77c5c3e724a62b3fc55b00e)
        1.00          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=923319 -dbcache=450 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 475110f9c22724d1a2649ccca4c137f9878f1162)
```

```
COMMITS="091cae6fdf895da8f77c5c3e724a62b3fc55b00e 475110f9c22724d1a2649ccca4c137f9878f1162"; \
STOP=923319; DBCACHE=450; \
CC=gcc; CXX=g++; \
BASE_DIR="/mnt/my_storage"; DATA_DIR="$BASE_DIR/BitcoinData"; LOG_DIR="$BASE_DIR/logs"; \
(echo ""; for c in $COMMITS; do git fetch -q origin $c && git log -1 --pretty='%h %s' $c || exit 1; done) && \
(echo "" && echo "reindex-chainstate | ${STOP} blocks | dbcache ${DBCACHE} | $(hostname) | $(uname -m) | $(lscpu | grep 'Model name' | head -1 | cut -d: -f2 | xargs) | $(nproc) cores | $(free -h | awk '/^Mem:/{print $2}') RAM | $(df -T $BASE_DIR | awk 'NR==2{print $2}') | $(lsblk -no ROTA $(df --output=source $BASE_DIR | tail -1) | grep -q 0 && echo SSD || echo HDD)"; echo "") &&\
hyperfine \
  --sort command \
  --runs 1 \
  --export-json "$BASE_DIR/rdx-$(sed -E 's/(\w{8})\w+ ?/\1-/g;s/-$//'<<<"$COMMITS")-$STOP-$DBCACHE-$CC.json" \
  --parameter-list COMMIT ${COMMITS// /,} \
  --prepare "killall -9 bitcoind 2>/dev/null; rm -f $DATA_DIR/debug.log; git checkout {COMMIT}; git clean -fxd; git reset --hard && \
    cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_IPC=OFF && ninja -C build bitcoind -j2 && \
    ./build/bin/bitcoind -datadir=$DATA_DIR -stopatheight=$STOP -dbcache=1000 -printtoconsole=0; sleep 20" \
  --conclude "killall bitcoind || true; sleep 5; grep -q 'height=0' $DATA_DIR/debug.log && grep -q 'Disabling script verification at block #1' $DATA_DIR/debug.log && grep -q 'height=$STOP' $DATA_DIR/debug.log; \
              cp $DATA_DIR/debug.log $LOG_DIR/debug-{COMMIT}-$(date +%s).log" \
  "COMPILER=$CC ./build/bin/bitcoind -datadir=$DATA_DIR -stopatheight=$STOP -dbcache=$DBCACHE -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0";

091cae6fdf Merge bitcoin/bitcoin#33939: contrib: Count entry differences in asmap-tool diff summary
475110f9c2 flush by ActiveMemoryUsage

reindex-chainstate | 923319 blocks | dbcache 450 | i7-hdd | x86_64 | Intel(R) Core(TM) i7-7700 CPU @ 3.60GHz | 8 cores | 62Gi RAM | ext4 | HDD

Benchmark 1: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=923319 -dbcache=450 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 091cae6fdf895da8f77c5c3e724a62b3fc55b00e)
  Time (abs ≡):        43196.715 s               [User: 42709.277 s, System: 3091.060 s]

Benchmark 2: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=923319 -dbcache=450 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 475110f9c22724d1a2649ccca4c137f9878f1162)
  Time (abs ≡):        41678.736 s               [User: 41532.750 s, System: 2995.303 s]
 
Relative speed comparison
        1.04          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=923319 -dbcache=450 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 091cae6fdf895da8f77c5c3e724a62b3fc55b00e)
        1.00          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=923319 -dbcache=450 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 475110f9c22724d1a2649ccca4c137f9878f1162)
```

```
COMMITS="091cae6fdf895da8f77c5c3e724a62b3fc55b00e 475110f9c22724d1a2649ccca4c137f9878f1162"; \
STOP=923319; DBCACHE=450; \
DATA_DIR="$HOME/Library/Application Support/Bitcoin"; LOG_DIR="$HOME/bitcoin-reindex-logs"; \
mkdir -p "$LOG_DIR"; \
COMMA_COMMITS=${COMMITS// /,}; \
(echo ""; for c in $(echo $COMMITS); do git fetch -q origin $c && git log -1 --pretty='%h %s' $c || exit 1; done) && \
(echo "" && echo "reindex-chainstate | ${STOP} blocks | dbcache ${DBCACHE} | $(hostname) | $(uname -m) | $(sysctl -n machdep.cpu.brand_string) | $(nproc) cores | $(printf '%.1fGiB' "$(( $(sysctl -n hw.memsize)/1024/1024/1024 ))") RAM | SSD | $(sw_vers -productName) $(sw_vers -productVersion) $(sw_vers -buildVersion) | $(xcrun clang --version | head -1)"; echo "") && \
hyperfine \
  --sort command \
  --runs 1 \
  --export-json "$LOG_DIR/rdx-$(echo "$COMMITS" | sed -E 's/([a-f0-9]{8})[a-f0-9]+ ?/\1-/g;s/-$//')-$STOP-$DBCACHE-appleclang.json" \
  --parameter-list COMMIT "$COMMA_COMMITS" \
  --prepare "killall -9 bitcoind 2>/dev/null || true; rm -f \"$DATA_DIR\"/debug.log; git checkout {COMMIT}; git clean -fxd; git reset --hard && \
    cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_IPC=OFF && ninja -C build bitcoind -j2 && \
    ./build/bin/bitcoind -datadir=\"$DATA_DIR\" -stopatheight=$STOP -dbcache=1000 -printtoconsole=0; sleep 20" \
  --conclude "killall bitcoind 2>/dev/null || true; sleep 5; grep -q 'height=0' \"$DATA_DIR\"/debug.log && grep -q 'Disabling script verification at block #1' \"$DATA_DIR\"/debug.log && grep -q \"height=$STOP\" \"$DATA_DIR\"/debug.log || { echo 'debug.log assertions failed'; exit 1; }; \
              cp \"$DATA_DIR\"/debug.log \"$LOG_DIR\"/debug-{COMMIT}-\$(date +%s).log 2>/dev/null || true" \
  "./build/bin/bitcoind -datadir=\"$DATA_DIR\" -stopatheight=$STOP -dbcache=$DBCACHE -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0"

091cae6fdf Merge bitcoin/bitcoin#33939: contrib: Count entry differences in asmap-tool diff summary
475110f9c2 flush by ActiveMemoryUsage

reindex-chainstate | 923319 blocks | dbcache 450 | M4-Max.local | arm64 | Apple M4 Max | 16 cores | 64.0GiB RAM | SSD | macOS 26.1 25B78 | Apple clang version 17.0.0 (clang-1700.4.4.1)

Benchmark 1: ./build/bin/bitcoind -datadir="/Users/lorinc/Library/Application Support/Bitcoin" -stopatheight=923319 -dbcache=450 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 091cae6fdf895da8f77c5c3e724a62b3fc55b00e)
  Time (abs ≡):        22591.933 s               [User: 22346.018 s, System: 5728.474 s]
Benchmark 1b: ? 

Benchmark 2: ./build/bin/bitcoind -datadir="/Users/lorinc/Library/Application Support/Bitcoin" -stopatheight=923319 -dbcache=450 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 475110f9c22724d1a2649ccca4c137f9878f1162)
  Time (abs ≡):        20936.847 s               [User: 21514.821 s, System: 5422.377 s]
Benchmark 2b: ./build/bin/bitcoind -datadir="/Users/lorinc/Library/Application Support/Bitcoin" -stopatheight=923319 -dbcache=450 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 475110f9c22724d1a2649ccca4c137f9878f1162)
  Time (abs ≡):        22288.343 s               [User: 24618.137 s, System: 6125.298 s]
 
Relative speed comparison
        1.08          ./build/bin/bitcoind -datadir="/Users/lorinc/Library/Application Support/Bitcoin" -stopatheight=923319 -dbcache=450 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 091cae6fdf895da8f77c5c3e724a62b3fc55b00e)
        1.00          ./build/bin/bitcoind -datadir="/Users/lorinc/Library/Application Support/Bitcoin" -stopatheight=923319 -dbcache=450 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 475110f9c22724d1a2649ccca4c137f9878f1162)
```


----------

```
for DBCACHE in 450 4500; do   COMMITS="c5cea2a4f859c58b8c5dfd6583d7e3c7ea5b7d3d d4b3fd8dacae5716f8721ef2df8a8e2dbff314d2 ea3deecdc9eeefcd03733e955ad8e28a225d8d4f 4637602ef3c1746d3bc5e30106f2f207dd9602d7";   STOP=931139; CC=gcc; CXX=g++;   BASE_DIR="/mnt/my_storage"; DATA_DIR="$BASE_DIR/BitcoinData"; LOG_DIR="$BASE_DIR/logs";   (echo ""; for c in $COMMITS; do git fetch -q origin $c && git log -1 --pretty='%h %s' $c || exit 1; done) &&   (echo "" && echo "$(date -I) | reindex-chainstate | ${STOP} blocks | dbcache ${DBCACHE} | $(hostname) | $(uname -m) | $(lscpu | grep 'Model name' | head -1 | cut -d: -f2 | xargs) | $(nproc) cores | $(free -h | awk '/^Mem:/{print $2}') RAM | SSD"; echo "") &&  hyperfine     --sort command     --runs 1     --export-json "$BASE_DIR/rdx-$(sed -E 's/(\w{8})\w+ ?/\1-/g;s/-$//'<<<"$COMMITS")-$STOP-$DBCACHE-$CC.json"     --parameter-list COMMIT ${COMMITS// /,}     --prepare "killall -9 bitcoind 2>/dev/null; rm -f $DATA_DIR/debug.log; git clean -fxd; git reset --hard {COMMIT} && \
      cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_IPC=OFF && ninja -C build bitcoind -j1 && \
      ./build/bin/bitcoind -datadir=$DATA_DIR -stopatheight=$STOP -dbcache=1000 -printtoconsole=0; sleep 20; rm -f $DATA_DIR/debug.log"     --conclude "killall bitcoind || true; sleep 5; grep -q 'height=0' $DATA_DIR/debug.log && grep -q 'Disabling script verification at block #1' $DATA_DIR/debug.log && grep -q 'height=$STOP' $DATA_DIR/debug.log; \
                cp $DATA_DIR/debug.log $LOG_DIR/debug-{COMMIT}-$(date +%s).log"     "COMPILER=$CC ./build/bin/bitcoind -datadir=$DATA_DIR -stopatheight=$STOP -dbcache=$DBCACHE -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0"; done

c5cea2a4f8 refactor: reuse `should_empty` for chainstate flush condition
d4b3fd8dac coins: reserve coins cache based on dbcache
ea3deecdc9 coins: drop will_reuse_cache from Flush
4637602ef3 coins: log and preserve cache load factor on reallocate

2026-01-13 | reindex-chainstate | 931139 blocks | dbcache 450 | rpi5-16-3 | aarch64 | Cortex-A76 | 4 cores | 15Gi RAM | SSD

Benchmark 1: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=931139 -dbcache=450 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = c5cea2a4f859c58b8c5dfd6583d7e3c7ea5b7d3d)
  Time (abs ≡):        45086.578 s               [User: 84381.338 s, System: 7567.990 s]
 
Benchmark 2: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=931139 -dbcache=450 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = d4b3fd8dacae5716f8721ef2df8a8e2dbff314d2)
  Time (abs ≡):        47202.490 s               [User: 86382.637 s, System: 7885.777 s]
 
Benchmark 3: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=931139 -dbcache=450 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = ea3deecdc9eeefcd03733e955ad8e28a225d8d4f)
  Time (abs ≡):        46287.141 s               [User: 85249.871 s, System: 7677.796 s]
 
Benchmark 4: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=931139 -dbcache=450 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 4637602ef3c1746d3bc5e30106f2f207dd9602d7)
  Time (abs ≡):        46785.429 s               [User: 85493.689 s, System: 7762.561 s]
 
Relative speed comparison
        1.00          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=931139 -dbcache=450 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = c5cea2a4f859c58b8c5dfd6583d7e3c7ea5b7d3d)
        1.05          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=931139 -dbcache=450 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = d4b3fd8dacae5716f8721ef2df8a8e2dbff314d2)
        1.03          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=931139 -dbcache=450 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = ea3deecdc9eeefcd03733e955ad8e28a225d8d4f)
        1.04          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=931139 -dbcache=450 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 4637602ef3c1746d3bc5e30106f2f207dd9602d7)
```

```
c5cea2a4f8 refactor: reuse `should_empty` for chainstate flush condition
d4b3fd8dac coins: reserve coins cache based on dbcache
ea3deecdc9 coins: drop will_reuse_cache from Flush
4637602ef3 coins: log and preserve cache load factor on reallocate

2026-01-15 | reindex-chainstate | 931139 blocks | dbcache 4500 | rpi5-16-3 | aarch64 | Cortex-A76 | 4 cores | 15Gi RAM | SSD

Benchmark 1: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=931139 -dbcache=4500 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = c5cea2a4f859c58b8
  Time (abs ≡):        39407.538 s               [User: 55646.719 s, System: 3442.633 s]
 
Benchmark 2: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=931139 -dbcache=4500 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = d4b3fd8dacae5716f8721ef2df8a8e2dbff314d2)
  Time (abs ≡):        40615.044 s               [User: 56579.987 s, System: 3378.544 s]
 
Benchmark 3: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=931139 -dbcache=4500 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = ea3deecdc9eeefcd03733e955ad8e28a225d8d4f)
  Time (abs ≡):        41289.803 s               [User: 57410.137 s, System: 3592.495 s]
 
Benchmark 4: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=931139 -dbcache=4500 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 4637602ef3c1746d3bc5e30106f2f207dd9602d7)
  Time (abs ≡):        41359.612 s               [User: 57662.495 s, System: 3552.278 s]
 
Relative speed comparison
        1.00          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=931139 -dbcache=4500 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = c5cea2a4f859c58b8c5dfd6583d7e3c7ea5b7d3d)
        1.03          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=931139 -dbcache=4500 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = d4b3fd8dacae5716f8721ef2df8a8e2dbff314d2)
        1.05          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=931139 -dbcache=4500 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = ea3deecdc9eeefcd03733e955ad8e28a225d8d4f)
        1.05          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=931139 -dbcache=4500 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 4637602ef3c1746d3bc5e30106f2f207dd9602d7)
```


----------


for DBCACHE in 450 4500; do   COMMITS="2c2ec6aebc13d9af6c52925cf8c832d2b90d3b19 188b7d13145fbe340d94d7e82cc955ba06d30134";   STOP=932239; CC=gcc; CXX=g++;   BASE_DIR="/mnt/my_storage"; DATA_DIR="$BASE_DIR/BitcoinData"; LOG_DIR="$BASE_DIR/logs";   (echo ""; for c in $COMMITS; do git fetch -q origin $c && git log -1 --pretty='%h %s' $c || exit 1; done) &&   (echo "" && echo "$(date -I) | reindex-chainstate | ${STOP} blocks | dbcache ${DBCACHE} | $(hostname) | $(uname -m) | $(lscpu | grep 'Model name' | head -1 | cut -d: -f2 | xargs) | $(nproc) cores | $(free -h | awk '/^Mem:/{print $2}') RAM | $(lsblk -no ROTA $(df --output=source $BASE_DIR | tail -1) | grep -q 0 && echo SSD || echo HDD)"; echo "") &&  hyperfine     --sort command     --runs 1     --export-json "$BASE_DIR/rdx-$(sed -E 's/(\w{8})\w+ ?/\1-/g;s/-$//'<<<"$COMMITS")-$STOP-$DBCACHE-$CC.json"     --parameter-list COMMIT ${COMMITS// /,}     --prepare "killall -9 bitcoind 2>/dev/null; rm -f ./build/bin/bitcoind; git clean -fxd; git reset --hard {COMMIT} && \                                                                                                                               
      cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_IPC=OFF && ninja -C build bitcoind -j1 && \                                                                                                ./build/bin/bitcoind -datadir=$DATA_DIR -stopatheight=$STOP -dbcache=1000 -printtoconsole=0; sleep 20; rm -f $DATA_DIR/debug.log"     --conclude "killall bitcoind || true; sleep 5; grep -q 'height=0' $DATA_DIR/debug.log && grep -q 'Disabling script verification at block #1' $DATA_DIR/debug.log && grep -q 'height=$STOP' $DATA_DIR/debug.log && grep 'Bitcoin Core version' $DATA_DIR/debug.log | grep -q "$(printf %.12s {COMMIT})"; \                                                                                                                                                                                cp $DATA_DIR/debug.log $LOG_DIR/debug-{COMMIT}-$(date +%s).log"     "COMPILER=$CC ./build/bin/bitcoind -datadir=$DATA_DIR -stopatheight=$STOP -dbcache=$DBCACHE -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0"; done
root@umbrel:/data/my_storage/bitcoin# for DBCACHE in 450 4500; do   COMMITS="2c2ec6aebc13d9af6c52925cf8c832d2b90d3b19 188b7d13145fbe340d94d7e82cc955ba06d30134";   STOP=932239; CC=gcc; CXX=g++;   BASE_DIR="/mnt/my_storage"; DATA_DIR="$BASE_DIR/BitcoinData"; LOG_DIR="$BASE_DIR/logs";   (echo ""; for c in $COMMITS; do git fetch -q origin $c && git log -1 --pretty='%h %s' $c || exit 1; done) &&   (echo "" && echo "$(date -I) | reindex-chainstate | ${STOP} blocks | dbcache ${DBCACHE} | $(hostname) | $(uname -m) | $(lscpu | grep 'Model name' | head -1 | cut -d: -f2 | xargs) | $(nproc) cores | $(free -h | awk '/^Mem:/{print $2}') RAM | $(lsblk -no ROTA $(df --output=source $BASE_DIR | tail -1) | grep -q 0 && echo SSD || echo HDD)"; echo "") &&  hyperfine     --sort command     --runs 1     --export-json "$BASE_DIR/rdx-$(sed -E 's/(\w{8})\w+ ?/\1-/g;s/-$//'<<<"$COMMITS")-$STOP-$DBCACHE-$CC.json"     --parameter-list COMMIT ${COMMITS// /,}     --prepare "killall -9 bitcoind 2>/dev/null; rm -f ./build/bin/bitcoind; git clean -fxd; git reset --hard {COMMIT} && \
      cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_IPC=OFF && ninja -C build bitcoind -j1 && \
      ./build/bin/bitcoind -datadir=$DATA_DIR -stopatheight=$STOP -dbcache=1000 -printtoconsole=0; sleep 20; rm -f $DATA_DIR/debug.log"     --conclude "killall bitcoind || true; sleep 5; grep -q 'height=0' $DATA_DIR/debug.log && grep -q 'Disabling script verification at block #1' $DATA_DIR/debug.log && grep -q 'height=$STOP' $DATA_DIR/debug.log && grep 'Bitcoin Core version' $DATA_DIR/debug.log | grep -q "$(printf %.12s {COMMIT})"; \
                cp $DATA_DIR/debug.log $LOG_DIR/debug-{COMMIT}-$(date +%s).log"     "COMPILER=$CC ./build/bin/bitcoind -datadir=$DATA_DIR -stopatheight=$STOP -dbcache=$DBCACHE -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0"; done

2c2ec6aebc refactor: reuse `should_empty` for chainstate flush condition
188b7d1314 coins: reserve coins cache based on dbcache

2026-01-19 | reindex-chainstate | 932239 blocks | dbcache 450 | umbrel | x86_64 | Intel(R) N150 | 4 cores | 15Gi RAM | SSD

Benchmark 1: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=932239 -dbcache=450 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 2c2ec6aebc13d9af6c52925cf8c832d2b90d3b19)
  Time (abs ≡):        31497.275 s               [User: 54483.290 s, System: 5245.336 s]
 
Benchmark 2: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=932239 -dbcache=450 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 188b7d13145fbe340d94d7e82cc955ba06d30134)
  Time (abs ≡):        32648.636 s               [User: 55765.893 s, System: 5380.497 s]
 
Relative speed comparison
        1.00          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=932239 -dbcache=450 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 2c2ec6aebc13d9af6c52925cf8c832d2b90d3b19)
        1.04          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=932239 -dbcache=450 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 188b7d13145fbe340d94d7e82cc955ba06d30134)

2c2ec6aebc refactor: reuse `should_empty` for chainstate flush condition
188b7d1314 coins: reserve coins cache based on dbcache

2026-01-20 | reindex-chainstate | 932239 blocks | dbcache 4500 | umbrel | x86_64 | Intel(R) N150 | 4 cores | 15Gi RAM | SSD

Benchmark 1: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=932239 -dbcache=4500 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 2c2ec6aebc13d9af6c52925cf8c832d2b90d3b19)
  Time (abs ≡):        30053.999 s               [User: 39306.163 s, System: 2765.169 s]
 
Benchmark 2: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=932239 -dbcache=4500 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 188b7d13145fbe340d94d7e82cc955ba06d30134)
  Time (abs ≡):        31630.416 s               [User: 40760.507 s, System: 2796.359 s]
 
Relative speed comparison
        1.00          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=932239 -dbcache=4500 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 2c2ec6aebc13d9af6c52925cf8c832d2b90d3b19)
        1.05          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=932239 -dbcache=4500 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 188b7d13145fbe340d94d7e82cc955ba06d30134)

--------

for DBCACHE in 450 4500; do   COMMITS="2c2ec6aebc13d9af6c52925cf8c832d2b90d3b19 188b7d13145fbe340d94d7e82cc955ba06d30134";   STOP=931139; CC=gcc; CXX=g++;   BASE_DIR="/mnt/my_storage"; DATA_DIR="$BASE_DIR/BitcoinData"; LOG_DIR="$BASE_DIR/logs";   (echo ""; for c in $COMMITS; do git fetch -q origin $c && git log -1 --pretty='%h %s' $c || exit 1; done) &&   (echo "" && echo "$(date -I) | reindex-chainstate | ${STOP} blocks | dbcache ${DBCACHE} | $(hostname) | $(uname -m) | $(lscpu | grep 'Model name' | head -1 | cut -d: -f2 | xargs) | $(nproc) cores | $(free -h | awk '/^Mem:/{print $2}') RAM | SSD"; echo "") &&  hyperfine     --sort command     --runs 1     --export-json "$BASE_DIR/rdx-$(sed -E 's/(\w{8})\w+ ?/\1-/g;s/-$//'<<<"$COMMITS")-$STOP-$DBCACHE-$CC.json"     --parameter-list COMMIT ${COMMITS// /,}     --prepare "killall -9 bitcoind 2>/dev/null; rm -f $DATA_DIR/debug.log; git clean -fxd; git reset --hard {COMMIT} && \                          cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_IPC=OFF && ninja -C build bitcoind -j1 && \                                                                                          
      ./build/bin/bitcoind -datadir=$DATA_DIR -stopatheight=$STOP -dbcache=1000 -printtoconsole=0; sleep 20; rm -f $DATA_DIR/debug.log"     --conclude "killall bitcoind || true; sleep 5; grep -q 'height=0' $DATA_DIR/debug.log && grep -q 'Disabling script verification at block #1' $DATA_DIR/debug.log && grep -q 'height=$STOP' $DATA_DIR/debug.log; \                                                                 cp $DATA_DIR/debug.log $LOG_DIR/debug-{COMMIT}-$(date +%s).log"     "COMPILER=$CC ./build/bin/bitcoind -datadir=$DATA_DIR -stopatheight=$STOP -dbcache=$DBCACHE -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0"; done                                                                                                                                                           

2c2ec6aebc refactor: reuse `should_empty` for chainstate flush condition
188b7d1314 coins: reserve coins cache based on dbcache

2026-01-18 | reindex-chainstate | 931139 blocks | dbcache 450 | rpi5-16-3 | aarch64 | Cortex-A76 | 4 cores | 15Gi RAM | SSD

Benchmark 1: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=931139 -dbcache=450 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 2c2ec6aebc13d9af6c52925cf8c832d2b90d3b19)
  Time (abs ≡):        45235.608 s               [User: 84980.946 s, System: 7435.777 s]
 
Benchmark 2: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=931139 -dbcache=450 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 188b7d13145fbe340d94d7e82cc955ba06d30134)
  Time (abs ≡):        46222.619 s               [User: 85865.729 s, System: 7650.212 s]
 
Relative speed comparison
        1.00          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=931139 -dbcache=450 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 2c2ec6aebc13d9af6c52925cf8c832d2b90d3b19)
        1.02          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=931139 -dbcache=450 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 188b7d13145fbe340d94d7e82cc955ba06d30134)

2c2ec6aebc refactor: reuse `should_empty` for chainstate flush condition
188b7d1314 coins: reserve coins cache based on dbcache

2026-01-20 | reindex-chainstate | 931139 blocks | dbcache 4500 | rpi5-16-3 | aarch64 | Cortex-A76 | 4 cores | 15Gi RAM | SSD

Benchmark 1: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=931139 -dbcache=4500 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 2c2ec6aebc13d9af6c52925cf8c832d2b90d3b19)
  Time (abs ≡):        39133.673 s               [User: 55920.383 s, System: 3395.885 s]
 
Benchmark 2: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=931139 -dbcache=4500 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 188b7d13145fbe340d94d7e82cc955ba06d30134)
  Time (abs ≡):        42472.661 s               [User: 56474.346 s, System: 3758.376 s]
 
Relative speed comparison
        1.00          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=931139 -dbcache=4500 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 2c2ec6aebc13d9af6c52925cf8c832d2b90d3b19)
        1.09          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=931139 -dbcache=4500 -reindex-chainstate -blocksonly -connect=0 -printtoconsole=0 (COMMIT = 188b7d13145fbe340d94d7e82cc955ba06d30134)