### PR TITLE
fix: handle negative block depth in `ApproximateBestBlockDepth` and add tests

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1317,7 +1317,9 @@ bool PeerManagerImpl::TipMayBeStale()
 
 int64_t PeerManagerImpl::ApproximateBestBlockDepth() const
 {
-    return (GetTime<std::chrono::seconds>() - m_best_block_time.load()).count() / m_chainparams.GetConsensus().nPowTargetSpacing;
+    const auto depth{GetTime<std::chrono::seconds>() - m_best_block_time.load()};
+    if (depth < 0s) return 0;
+    return depth.count() / m_chainparams.GetConsensus().nPowTargetSpacing;
 }
 
 bool PeerManagerImpl::CanDirectFetch()

--- a/src/test/peerman_tests.cpp
+++ b/src/test/peerman_tests.cpp
@@ -73,4 +73,25 @@ BOOST_AUTO_TEST_CASE(connections_desirable_service_flags)
     BOOST_CHECK(peerman->GetDesirableServiceFlags(peer_flags) == ServiceFlags(NODE_NETWORK | NODE_WITNESS));
 }
 
+BOOST_AUTO_TEST_CASE(approximate_best_block_depth_test)
+{
+    std::unique_ptr<PeerManager> peerman = PeerManager::make(*m_node.connman, *m_node.addrman, nullptr, *m_node.chainman, *m_node.mempool, *m_node.warnings, {});
+    auto consensus = m_node.chainman->GetParams().GetConsensus();
+    ServiceFlags peer_flags{NODE_WITNESS | NODE_NETWORK_LIMITED};
+
+    // Set best block time in the future (e.g., 100 blocks ahead)
+    int64_t future_time = GetTime<std::chrono::seconds>().count() + 100 * consensus.nPowTargetSpacing;
+    peerman->SetBestBlock(1000, std::chrono::seconds{future_time});
+
+    // We should return limited peers as desirable (depth 0 or negative)
+    BOOST_CHECK(peerman->GetDesirableServiceFlags(peer_flags) == ServiceFlags(NODE_NETWORK_LIMITED | NODE_WITNESS));
+
+    // Set best block time in the past (e.g., 200 blocks behind)
+    int64_t past_time = GetTime<std::chrono::seconds>().count() - 200 * consensus.nPowTargetSpacing;
+    peerman->SetBestBlock(1000, std::chrono::seconds{past_time});
+
+    // We should NOT return limited peers as desirable (depth 200 > 144)
+    BOOST_CHECK(peerman->GetDesirableServiceFlags(peer_flags) == ServiceFlags(NODE_NETWORK | NODE_WITNESS));
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Prevent negative depth values by returning 0 when `m_best_block_time` is in the future. Added unit tests to validate behavior with future and past block times.