### PR TITLE
chacha20

### DIFF
--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -5,6 +5,7 @@
 add_library(bitcoin_crypto STATIC EXCLUDE_FROM_ALL
   aes.cpp
   chacha20.cpp
+  chacha20_vec_base.cpp
   chacha20poly1305.cpp
   hex_base.cpp
   hkdf_sha256_32.cpp

--- a/src/crypto/chacha20.cpp
+++ b/src/crypto/chacha20.cpp
@@ -7,11 +7,15 @@
 
 #include <crypto/common.h>
 #include <crypto/chacha20.h>
+#include <crypto/chacha20_vec.h>
 #include <support/cleanse.h>
 
 #include <algorithm>
 #include <bit>
 #include <cassert>
+#include <limits>
+
+static_assert(ChaCha20Aligned::BLOCKLEN == CHACHA20_VEC_BLOCKLEN);
 
 #define QUARTERROUND(a,b,c,d) \
   a += b; d = std::rotl(d ^ a, 16); \
@@ -282,7 +286,22 @@ static inline void chacha20_crypt(std::span<const std::byte> in_bytes, std::span
 
 inline void ChaCha20Aligned::Crypt(std::span<const std::byte> in_bytes, std::span<std::byte> out_bytes) noexcept
 {
-    chacha20_crypt(in_bytes, out_bytes, input);
+    assert(in_bytes.size() == out_bytes.size());
+    size_t blocks = out_bytes.size() / ChaCha20Aligned::BLOCKLEN;
+    assert(blocks * ChaCha20Aligned::BLOCKLEN == out_bytes.size());
+#ifdef ENABLE_CHACHA20_VEC
+    // Only use the vectorized implementations if the counter will not overflow.
+    const bool overflow = static_cast<uint64_t>(input[8]) + blocks > std::numeric_limits<uint32_t>::max();
+    if (blocks > 1 && !overflow) {
+        const auto state = std::to_array(input);
+        chacha20_vec_base::chacha20_crypt_vectorized(in_bytes, out_bytes, state);
+        const size_t blocks_written = blocks - (out_bytes.size() / ChaCha20Aligned::BLOCKLEN);
+        input[8] += blocks_written;
+    }
+#endif
+    if (in_bytes.size()) {
+        chacha20_crypt(in_bytes, out_bytes, input);
+    }
 }
 
 void ChaCha20::Keystream(std::span<std::byte> out) noexcept

--- a/src/crypto/chacha20.cpp
+++ b/src/crypto/chacha20.cpp
@@ -157,13 +157,14 @@ inline void ChaCha20Aligned::Keystream(std::span<std::byte> output) noexcept
     }
 }
 
-inline void ChaCha20Aligned::Crypt(std::span<const std::byte> in_bytes, std::span<std::byte> out_bytes) noexcept
+static inline void chacha20_crypt(std::span<const std::byte> in_bytes, std::span<std::byte> out_bytes, uint32_t input[12]) noexcept
 {
     assert(in_bytes.size() == out_bytes.size());
     const std::byte* m = in_bytes.data();
     std::byte* c = out_bytes.data();
-    size_t blocks = out_bytes.size() / BLOCKLEN;
-    assert(blocks * BLOCKLEN == out_bytes.size());
+    size_t blocks = out_bytes.size() / ChaCha20Aligned::BLOCKLEN;
+    assert(blocks * ChaCha20Aligned::BLOCKLEN == out_bytes.size());
+
 
     uint32_t x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15;
     uint32_t j4, j5, j6, j7, j8, j9, j10, j11, j12, j13, j14, j15;
@@ -273,9 +274,15 @@ inline void ChaCha20Aligned::Crypt(std::span<const std::byte> in_bytes, std::spa
             return;
         }
         blocks -= 1;
-        c += BLOCKLEN;
-        m += BLOCKLEN;
+        c += ChaCha20Aligned::BLOCKLEN;
+        m += ChaCha20Aligned::BLOCKLEN;
     }
+}
+
+
+inline void ChaCha20Aligned::Crypt(std::span<const std::byte> in_bytes, std::span<std::byte> out_bytes) noexcept
+{
+    chacha20_crypt(in_bytes, out_bytes, input);
 }
 
 void ChaCha20::Keystream(std::span<std::byte> out) noexcept

--- a/src/crypto/chacha20.cpp
+++ b/src/crypto/chacha20.cpp
@@ -291,10 +291,9 @@ inline void ChaCha20Aligned::Crypt(std::span<const std::byte> in_bytes, std::spa
     assert(blocks * ChaCha20Aligned::BLOCKLEN == out_bytes.size());
 #ifdef ENABLE_CHACHA20_VEC
     // Only use the vectorized implementations if the counter will not overflow.
-    const bool overflow = static_cast<uint64_t>(input[8]) + blocks > std::numeric_limits<uint32_t>::max();
+    const bool overflow = blocks > std::numeric_limits<uint32_t>::max() - input[8];
     if (blocks > 1 && !overflow) {
-        const auto state = std::to_array(input);
-        chacha20_vec_base::chacha20_crypt_vectorized(in_bytes, out_bytes, state);
+        chacha20_vec_base::chacha20_crypt_vectorized(in_bytes, out_bytes, std::span<const uint32_t, 12>{input});
         const size_t blocks_written = blocks - (out_bytes.size() / ChaCha20Aligned::BLOCKLEN);
         input[8] += blocks_written;
     }

--- a/src/crypto/chacha20_vec.h
+++ b/src/crypto/chacha20_vec.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2025-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CRYPTO_CHACHA20_VEC_H
+#define BITCOIN_CRYPTO_CHACHA20_VEC_H
+
+#include <array>
+#include <cstdint>
+#include <cstddef>
+#include <span>
+
+static constexpr size_t CHACHA20_VEC_BLOCKLEN = 64;
+
+#ifdef __has_builtin
+  #if __has_builtin(__builtin_shufflevector)
+    #define ENABLE_CHACHA20_VEC 1
+  #endif
+#endif
+
+#ifdef ENABLE_CHACHA20_VEC
+
+namespace chacha20_vec_base
+{
+    void chacha20_crypt_vectorized(std::span<const std::byte>& in_bytes, std::span<std::byte>& out_bytes, const std::array<uint32_t, 12>& input) noexcept;
+}
+
+#endif // ENABLE_CHACHA20_VEC
+
+#endif // BITCOIN_CRYPTO_CHACHA20_VEC_H

--- a/src/crypto/chacha20_vec.h
+++ b/src/crypto/chacha20_vec.h
@@ -5,7 +5,6 @@
 #ifndef BITCOIN_CRYPTO_CHACHA20_VEC_H
 #define BITCOIN_CRYPTO_CHACHA20_VEC_H
 
-#include <array>
 #include <cstdint>
 #include <cstddef>
 #include <span>
@@ -22,7 +21,7 @@ static constexpr size_t CHACHA20_VEC_BLOCKLEN = 64;
 
 namespace chacha20_vec_base
 {
-    void chacha20_crypt_vectorized(std::span<const std::byte>& in_bytes, std::span<std::byte>& out_bytes, const std::array<uint32_t, 12>& input) noexcept;
+    void chacha20_crypt_vectorized(std::span<const std::byte>& in_bytes, std::span<std::byte>& out_bytes, std::span<const uint32_t, 12> input) noexcept;
 }
 
 #endif // ENABLE_CHACHA20_VEC

--- a/src/crypto/chacha20_vec.ipp
+++ b/src/crypto/chacha20_vec.ipp
@@ -174,8 +174,9 @@ ALWAYS_INLINE void vec_read_xor_write(std::span<const std::byte, 32> in_bytes, s
 {
     std::array<uint32_t, 8> temparr;
     memcpy(temparr.data(), in_bytes.data(), in_bytes.size());
-    vec256 tempvec = vec ^ (vec256){temparr[0], temparr[1], temparr[2], temparr[3], temparr[4], temparr[5], temparr[6], temparr[7]};
+    vec256 tempvec = vec;
     vec_byteswap(tempvec);
+    tempvec ^= (vec256){temparr[0], temparr[1], temparr[2], temparr[3], temparr[4], temparr[5], temparr[6], temparr[7]};
     temparr = {tempvec[0], tempvec[1], tempvec[2], tempvec[3], tempvec[4], tempvec[5], tempvec[6], tempvec[7]};
     memcpy(out_bytes.data(), temparr.data(), out_bytes.size());
 }

--- a/src/crypto/chacha20_vec.ipp
+++ b/src/crypto/chacha20_vec.ipp
@@ -1,0 +1,342 @@
+// Copyright (c) 2025-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <crypto/chacha20_vec.h>
+
+#include <bit>
+#include <cassert>
+#include <cstring>
+#include <limits>
+
+#if defined(ENABLE_CHACHA20_VEC)
+
+#if defined(CHACHA20_VEC_DISABLE_STATES_16) && \
+    defined(CHACHA20_VEC_DISABLE_STATES_8) && \
+    defined(CHACHA20_VEC_DISABLE_STATES_6) && \
+    defined(CHACHA20_VEC_DISABLE_STATES_4) && \
+    defined(CHACHA20_VEC_DISABLE_STATES_2)
+#define CHACHA20_VEC_ALL_MULTI_STATES_DISABLED
+#endif
+
+
+#if !defined(CHACHA20_VEC_ALL_MULTI_STATES_DISABLED)
+
+#if defined(__has_attribute)
+#  if __has_attribute(always_inline)
+#    define ALWAYS_INLINE __attribute__ ((always_inline)) inline
+#  endif
+#endif
+
+#if !defined(ALWAYS_INLINE)
+#  define ALWAYS_INLINE inline
+#endif
+
+
+namespace {
+
+using vec256 = uint32_t __attribute__((__vector_size__(32)));
+
+/** Endian-conversion for big-endian */
+ALWAYS_INLINE void vec_byteswap(vec256& vec)
+{
+    if constexpr (std::endian::native == std::endian::big)
+    {
+        vec256 ret;
+        ret[0] = __builtin_bswap32(vec[0]);
+        ret[1] = __builtin_bswap32(vec[1]);
+        ret[2] = __builtin_bswap32(vec[2]);
+        ret[3] = __builtin_bswap32(vec[3]);
+        ret[4] = __builtin_bswap32(vec[4]);
+        ret[5] = __builtin_bswap32(vec[5]);
+        ret[6] = __builtin_bswap32(vec[6]);
+        ret[7] = __builtin_bswap32(vec[7]);
+        vec = ret;
+    }
+}
+
+/** Left-rotate vector */
+template <size_t BITS>
+ALWAYS_INLINE void vec_rotl(vec256& vec)
+{
+    vec = (vec << BITS) | (vec >> (32 - BITS));
+}
+
+/** Store a vector in all array elements */
+template <size_t I, size_t ITER = 0>
+ALWAYS_INLINE void arr_set_vec256(std::array<vec256, I>& arr, const vec256& vec)
+{
+    std::get<ITER>(arr) = vec;
+    if constexpr(ITER + 1 < I ) arr_set_vec256<I, ITER + 1>(arr, vec);
+}
+
+/** Add a vector to all array elements */
+template <size_t I, size_t ITER = 0>
+ALWAYS_INLINE void arr_add_vec256(std::array<vec256, I>& arr, const vec256& vec)
+{
+    std::get<ITER>(arr) += vec;
+    if constexpr(ITER + 1 < I ) arr_add_vec256<I, ITER + 1>(arr, vec);
+}
+
+/** Add corresponding vectors in arr1 to arr0 */
+template <size_t I, size_t ITER = 0>
+ALWAYS_INLINE void arr_add_arr(std::array<vec256, I>& arr0, const std::array<vec256, I>& arr1)
+{
+    std::get<ITER>(arr0) += std::get<ITER>(arr1);
+    if constexpr(ITER + 1 < I ) arr_add_arr<I, ITER + 1>(arr0, arr1);
+}
+
+/** Perform add/xor/rotate for the round function */
+template <size_t BITS, size_t I, size_t ITER = 0>
+ALWAYS_INLINE void arr_add_xor_rot(std::array<vec256, I>& arr0, const std::array<vec256, I>& arr1, std::array<vec256, I>& arr2)
+{
+    vec256& x = std::get<ITER>(arr0);
+    const vec256& y = std::get<ITER>(arr1);
+    vec256& z = std::get<ITER>(arr2);
+
+    x += y;
+    z ^= x;
+    vec_rotl<BITS>(z);
+
+    if constexpr(ITER + 1 < I ) arr_add_xor_rot<BITS, I, ITER + 1>(arr0, arr1, arr2);
+}
+
+/*
+The first round:
+            QUARTERROUND( x0, x4, x8,x12);
+            QUARTERROUND( x1, x5, x9,x13);
+            QUARTERROUND( x2, x6,x10,x14);
+            QUARTERROUND( x3, x7,x11,x15);
+
+The second round:
+            QUARTERROUND( x0, x5,x10,x15);
+            QUARTERROUND( x1, x6,x11,x12);
+            QUARTERROUND( x2, x7, x8,x13);
+            QUARTERROUND( x3, x4, x9,x14);
+
+After the first round, arr_shuf0, arr_shuf1, and arr_shuf2 are used to shuffle
+the layout to prepare for the second round.
+
+After the second round, they are used (in reverse) to restore the original
+layout.
+
+*/
+template <size_t I, size_t ITER = 0>
+ALWAYS_INLINE void arr_shuf0(std::array<vec256, I>& arr)
+{
+    vec256& x = std::get<ITER>(arr);
+    x = __builtin_shufflevector(x, x, 1, 2, 3, 0, 5, 6, 7, 4);
+    if constexpr(ITER + 1 < I ) arr_shuf0<I, ITER + 1>(arr);
+}
+
+template <size_t I, size_t ITER = 0>
+ALWAYS_INLINE void arr_shuf1(std::array<vec256, I>& arr)
+{
+    vec256& x = std::get<ITER>(arr);
+    x = __builtin_shufflevector(x, x, 2, 3, 0, 1, 6, 7, 4, 5);
+    if constexpr(ITER + 1 < I ) arr_shuf1<I, ITER + 1>(arr);
+}
+
+template <size_t I, size_t ITER = 0>
+ALWAYS_INLINE void arr_shuf2(std::array<vec256, I>& arr)
+{
+    vec256& x = std::get<ITER>(arr);
+    x = __builtin_shufflevector(x, x, 3, 0, 1, 2, 7, 4, 5, 6);
+    if constexpr(ITER + 1 < I ) arr_shuf2<I, ITER + 1>(arr);
+}
+
+/* Main round function. */
+template <size_t I, size_t ITER = 0>
+ALWAYS_INLINE void doubleround(std::array<vec256, I>& arr0, std::array<vec256, I>& arr1, std::array<vec256, I>&arr2, std::array<vec256, I>&arr3)
+{
+    arr_add_xor_rot<16>(arr0, arr1, arr3);
+    arr_add_xor_rot<12>(arr2, arr3, arr1);
+    arr_add_xor_rot<8>(arr0, arr1, arr3);
+    arr_add_xor_rot<7>(arr2, arr3, arr1);
+    arr_shuf0(arr1);
+    arr_shuf1(arr2);
+    arr_shuf2(arr3);
+    arr_add_xor_rot<16>(arr0, arr1, arr3);
+    arr_add_xor_rot<12>(arr2, arr3, arr1);
+    arr_add_xor_rot<8>(arr0, arr1, arr3);
+    arr_add_xor_rot<7>(arr2, arr3, arr1);
+    arr_shuf2(arr1);
+    arr_shuf1(arr2);
+    arr_shuf0(arr3);
+    if constexpr (ITER + 1 < 10) doubleround<I, ITER + 1>(arr0, arr1, arr2, arr3);
+}
+
+/* Read 32bytes of input, xor with calculated state, write to output. Assumes
+   that input and output are unaligned, and makes no assumptions about the
+   internal layout of vec256;
+*/
+ALWAYS_INLINE void vec_read_xor_write(std::span<const std::byte, 32> in_bytes, std::span<std::byte, 32> out_bytes, const vec256& vec)
+{
+    std::array<uint32_t, 8> temparr;
+    memcpy(temparr.data(), in_bytes.data(), in_bytes.size());
+    vec256 tempvec = vec ^ (vec256){temparr[0], temparr[1], temparr[2], temparr[3], temparr[4], temparr[5], temparr[6], temparr[7]};
+    vec_byteswap(tempvec);
+    temparr = {tempvec[0], tempvec[1], tempvec[2], tempvec[3], tempvec[4], tempvec[5], tempvec[6], tempvec[7]};
+    memcpy(out_bytes.data(), temparr.data(), out_bytes.size());
+}
+
+/* Merge the 128 bit lanes from 2 states to the proper order, then pass each vec_read_xor_write */
+template <size_t I, size_t ITER = 0>
+ALWAYS_INLINE void arr_read_xor_write(std::span<const std::byte> in_bytes, std::span<std::byte> out_bytes, const std::array<vec256, I>& arr0, const std::array<vec256, I>& arr1, const std::array<vec256, I>& arr2, const std::array<vec256, I>& arr3)
+{
+    const vec256& w = std::get<ITER>(arr0);
+    const vec256& x = std::get<ITER>(arr1);
+    const vec256& y = std::get<ITER>(arr2);
+    const vec256& z = std::get<ITER>(arr3);
+
+    vec_read_xor_write(in_bytes.first<32>(), out_bytes.first<32>(), __builtin_shufflevector(w, x, 4, 5, 6, 7, 12, 13, 14, 15));
+    vec_read_xor_write(in_bytes.subspan<32, 32>(), out_bytes.subspan<32, 32>(), __builtin_shufflevector(y, z, 4, 5, 6, 7, 12, 13, 14, 15));
+    vec_read_xor_write(in_bytes.subspan<64, 32>(), out_bytes.subspan<64, 32>(), __builtin_shufflevector(w, x, 0, 1, 2, 3, 8, 9, 10, 11));
+    vec_read_xor_write(in_bytes.subspan<96, 32>(), out_bytes.subspan<96, 32>(), __builtin_shufflevector(y, z, 0, 1, 2, 3, 8, 9, 10, 11));
+
+    if constexpr(ITER + 1 < I ) arr_read_xor_write<I, ITER + 1>(in_bytes.subspan<128>(), out_bytes.subspan<128>(), arr0, arr1, arr2, arr3);
+}
+
+/* Compile-time helper to create addend vectors which used to increment the states
+
+    Generates vectors of the pattern:
+    1 0 0 0 0 0 0 0
+    3 0 0 0 2 0 0 0
+    5 0 0 0 4 0 0 0
+    ...
+*/
+template <size_t SIZE>
+consteval std::array<vec256, SIZE> generate_increments()
+{
+    std::array<vec256, SIZE> rows;
+    for (uint32_t i = 0; i < SIZE; i ++)
+    {
+        rows[i] = (i * (vec256){2, 0, 0, 0, 2, 0, 0, 0}) + (vec256){1, 0, 0, 0, 0, 0, 0, 0};
+    }
+    return rows;
+}
+
+/* Main crypt function. Calculates up to 16 states.
+
+    Each array contains one or more vectors, with each array representing a
+    quarter of a state. Initially, the high and low parts of each vector are
+    duplicated. They each contain a portion of the current and next state.
+
+    arr0[0]    arr1[0]    arr2[0]    arr3[0]   increment
+    ----------|---------|----------|----------|---------
+    0x61707865 input[0]   input[4]   input[8]   [1]
+    0x3320646e input[1]   input[5]   input[9]   [0]
+    0x79622d32 input[2]   input[6]   input[10]  [0]
+    0x6b206574 input[3]   input[7]   input[11]  [0]
+
+    0x61707865 input[0]   input[4]   input[8]   [0]
+    0x3320646e input[1]   input[5]   input[9]   [0]
+    0x79622d32 input[2]   input[6]   input[10]  [0]
+    0x6b206574 input[3]   input[7]   input[11]  [0]
+
+    After loading the states, arr3's vectors are incremented as-necessary to
+    contain the correct counter values.
+
+    This way, operations like "arr0[0] += arr1[0]" can perform all 8 operations
+    in parallel, taking advantage of 256bit registers where available.
+
+    arrX[0] represents states 0 and 1.
+    arrX[1] represents states 2 and 3 (if present)
+    etc.
+
+    After the doublerounds have been run and the initial state has been mixed
+    back in, the high and low portions of the vectors in each array are
+    shuffled in order to prepare them for mixing with the input bytes. Finally,
+    each state is xor'd with its corresponding input, byteswapped if necessary,
+    and written to its output.
+*/
+template <size_t STATES>
+ALWAYS_INLINE void multi_block_crypt(std::span<const std::byte> in_bytes, std::span<std::byte> out_bytes, const vec256& state0, const vec256& state1, const vec256& state2)
+{
+    static constexpr size_t HALF_STATES = STATES / 2;
+    static constexpr vec256 nums256 = (vec256){0x61707865, 0x3320646e, 0x79622d32, 0x6b206574, 0x61707865, 0x3320646e, 0x79622d32, 0x6b206574};
+    static constinit std::array<vec256, HALF_STATES> increments = generate_increments<HALF_STATES>();
+
+    std::array<vec256, HALF_STATES> arr0, arr1, arr2, arr3;
+
+    arr_set_vec256(arr0, nums256);
+    arr_set_vec256(arr1, state0);
+    arr_set_vec256(arr2, state1);
+    arr_set_vec256(arr3, state2);
+
+    arr_add_arr(arr3, increments);
+
+    doubleround(arr0, arr1, arr2, arr3);
+
+    arr_add_vec256(arr0, nums256);
+    arr_add_vec256(arr1, state0);
+    arr_add_vec256(arr2, state1);
+    arr_add_vec256(arr3, state2);
+
+    arr_add_arr(arr3, increments);
+
+    arr_read_xor_write(in_bytes, out_bytes, arr0, arr1, arr2, arr3);
+}
+
+} // anonymous namespace
+#endif // CHACHA20_VEC_ALL_MULTI_STATES_DISABLED
+
+#if defined(CHACHA20_NAMESPACE)
+namespace CHACHA20_NAMESPACE {
+#endif
+
+void chacha20_crypt_vectorized(std::span<const std::byte>& in_bytes, std::span<std::byte>& out_bytes, const std::array<uint32_t, 12>& input) noexcept
+{
+#if !defined(CHACHA20_VEC_ALL_MULTI_STATES_DISABLED)
+    assert(in_bytes.size() == out_bytes.size());
+    const vec256 state0 =  (vec256){input[0], input[1], input[2], input[3], input[0], input[1], input[2], input[3]};
+    const vec256 state1 =  (vec256){input[4], input[5], input[6], input[7], input[4], input[5], input[6], input[7]};
+    vec256 state2 =  (vec256){input[8], input[9], input[10], input[11], input[8], input[9], input[10], input[11]};
+#if !defined(CHACHA20_VEC_DISABLE_STATES_16)
+    while(in_bytes.size() >= CHACHA20_VEC_BLOCKLEN * 16) {
+        multi_block_crypt<16>(in_bytes, out_bytes, state0, state1, state2);
+        state2 += (vec256){16, 0, 0, 0, 16, 0, 0, 0};
+        in_bytes = in_bytes.subspan(CHACHA20_VEC_BLOCKLEN * 16);
+        out_bytes = out_bytes.subspan(CHACHA20_VEC_BLOCKLEN * 16);
+    }
+#endif
+#if !defined(CHACHA20_VEC_DISABLE_STATES_8)
+    while(in_bytes.size() >= CHACHA20_VEC_BLOCKLEN * 8) {
+        multi_block_crypt<8>(in_bytes, out_bytes, state0, state1, state2);
+        state2 += (vec256){8, 0, 0, 0, 8, 0, 0, 0};
+        in_bytes = in_bytes.subspan(CHACHA20_VEC_BLOCKLEN * 8);
+        out_bytes = out_bytes.subspan(CHACHA20_VEC_BLOCKLEN * 8);
+    }
+#endif
+#if !defined(CHACHA20_VEC_DISABLE_STATES_6)
+    while(in_bytes.size() >= CHACHA20_VEC_BLOCKLEN * 6) {
+        multi_block_crypt<6>(in_bytes, out_bytes, state0, state1, state2);
+        state2 += (vec256){6, 0, 0, 0, 6, 0, 0, 0};
+        in_bytes = in_bytes.subspan(CHACHA20_VEC_BLOCKLEN * 6);
+        out_bytes = out_bytes.subspan(CHACHA20_VEC_BLOCKLEN * 6);
+    }
+#endif
+#if !defined(CHACHA20_VEC_DISABLE_STATES_4)
+    while(in_bytes.size() >= CHACHA20_VEC_BLOCKLEN * 4) {
+        multi_block_crypt<4>(in_bytes, out_bytes, state0, state1, state2);
+        state2 += (vec256){4, 0, 0, 0, 4, 0, 0, 0};
+        in_bytes = in_bytes.subspan(CHACHA20_VEC_BLOCKLEN * 4);
+        out_bytes = out_bytes.subspan(CHACHA20_VEC_BLOCKLEN * 4);
+    }
+#endif
+#if !defined(CHACHA20_VEC_DISABLE_STATES_2)
+    while(in_bytes.size() >= CHACHA20_VEC_BLOCKLEN * 2) {
+        multi_block_crypt<2>(in_bytes, out_bytes, state0, state1, state2);
+        state2 += (vec256){2, 0, 0, 0, 2, 0, 0, 0};
+        in_bytes = in_bytes.subspan(CHACHA20_VEC_BLOCKLEN * 2);
+        out_bytes = out_bytes.subspan(CHACHA20_VEC_BLOCKLEN * 2);
+    }
+#endif
+#endif // CHACHA20_VEC_ALL_MULTI_STATES_DISABLED
+}
+
+#if defined(CHACHA20_NAMESPACE)
+}
+#endif
+
+#endif // ENABLE_CHACHA20_VEC

--- a/src/crypto/chacha20_vec.ipp
+++ b/src/crypto/chacha20_vec.ipp
@@ -125,7 +125,8 @@ template <size_t I, size_t ITER = 0>
 ALWAYS_INLINE void arr_shuf0(std::array<vec256, I>& arr)
 {
     vec256& x = std::get<ITER>(arr);
-    x = __builtin_shufflevector(x, x, 1, 2, 3, 0, 5, 6, 7, 4);
+    x = vec256{x[1], x[2], x[3], x[0], x[5], x[6], x[7], x[4]};
+
     if constexpr(ITER + 1 < I ) arr_shuf0<I, ITER + 1>(arr);
 }
 
@@ -133,7 +134,8 @@ template <size_t I, size_t ITER = 0>
 ALWAYS_INLINE void arr_shuf1(std::array<vec256, I>& arr)
 {
     vec256& x = std::get<ITER>(arr);
-    x = __builtin_shufflevector(x, x, 2, 3, 0, 1, 6, 7, 4, 5);
+    x = vec256{x[2], x[3], x[0], x[1], x[6], x[7], x[4], x[5]};
+
     if constexpr(ITER + 1 < I ) arr_shuf1<I, ITER + 1>(arr);
 }
 
@@ -141,7 +143,8 @@ template <size_t I, size_t ITER = 0>
 ALWAYS_INLINE void arr_shuf2(std::array<vec256, I>& arr)
 {
     vec256& x = std::get<ITER>(arr);
-    x = __builtin_shufflevector(x, x, 3, 0, 1, 2, 7, 4, 5, 6);
+    x = vec256{x[3], x[0], x[1], x[2], x[7], x[4], x[5], x[6]};
+
     if constexpr(ITER + 1 < I ) arr_shuf2<I, ITER + 1>(arr);
 }
 

--- a/src/crypto/chacha20_vec.ipp
+++ b/src/crypto/chacha20_vec.ipp
@@ -163,13 +163,12 @@ ALWAYS_INLINE void doubleround(std::array<vec256, N>& arr0, std::array<vec256, N
 */
 ALWAYS_INLINE void vec_read_xor_write(std::span<const std::byte, 32> in_bytes, std::span<std::byte, 32> out_bytes, const vec256& vec)
 {
-    std::array<uint32_t, 8> temparr;
-    memcpy(temparr.data(), in_bytes.data(), in_bytes.size());
-    vec256 tempvec = vec;
+    vec256 tempvec;
+    memcpy(&tempvec, in_bytes.data(), sizeof(tempvec));
     vec_byteswap(tempvec);
-    tempvec ^= (vec256){temparr[0], temparr[1], temparr[2], temparr[3], temparr[4], temparr[5], temparr[6], temparr[7]};
-    temparr = {tempvec[0], tempvec[1], tempvec[2], tempvec[3], tempvec[4], tempvec[5], tempvec[6], tempvec[7]};
-    memcpy(out_bytes.data(), temparr.data(), out_bytes.size());
+    tempvec ^= vec;
+    vec_byteswap(tempvec);
+    memcpy(out_bytes.data(), &tempvec, sizeof(tempvec));
 }
 
 /* Merge the 128-bit lanes from 2 states to the proper order, then pass each vec_read_xor_write */

--- a/src/crypto/chacha20_vec.ipp
+++ b/src/crypto/chacha20_vec.ipp
@@ -289,7 +289,7 @@ ALWAYS_INLINE void multi_block_crypt(std::span<const std::byte> in_bytes, std::s
 namespace CHACHA20_NAMESPACE {
 #endif
 
-void chacha20_crypt_vectorized(std::span<const std::byte>& in_bytes, std::span<std::byte>& out_bytes, const std::array<uint32_t, 12>& input) noexcept
+void chacha20_crypt_vectorized(std::span<const std::byte>& in_bytes, std::span<std::byte>& out_bytes, std::span<const uint32_t, 12> input) noexcept
 {
 #if !defined(CHACHA20_VEC_ALL_MULTI_STATES_DISABLED)
     assert(in_bytes.size() == out_bytes.size());

--- a/src/crypto/chacha20_vec.ipp
+++ b/src/crypto/chacha20_vec.ipp
@@ -282,6 +282,18 @@ ALWAYS_INLINE void multi_block_crypt(std::span<const std::byte> in_bytes, std::s
     arr_read_xor_write(in_bytes, out_bytes, arr0, arr1, arr2, arr3);
 }
 
+template <size_t STATES>
+ALWAYS_INLINE void process_blocks(std::span<const std::byte>& in_bytes, std::span<std::byte>& out_bytes, const vec256& state0, const vec256& state1, vec256& state2)
+{
+    static constexpr vec256 increment = (vec256){STATES, 0, 0, 0, STATES, 0, 0, 0};
+    while (in_bytes.size() >= CHACHA20_VEC_BLOCKLEN * STATES) {
+        multi_block_crypt<STATES>(in_bytes, out_bytes, state0, state1, state2);
+        state2 += increment;
+        in_bytes = in_bytes.subspan(CHACHA20_VEC_BLOCKLEN * STATES);
+        out_bytes = out_bytes.subspan(CHACHA20_VEC_BLOCKLEN * STATES);
+    }
+}
+
 } // anonymous namespace
 #endif // CHACHA20_VEC_ALL_MULTI_STATES_DISABLED
 
@@ -297,44 +309,19 @@ void chacha20_crypt_vectorized(std::span<const std::byte>& in_bytes, std::span<s
     const vec256 state1 =  (vec256){input[4], input[5], input[6], input[7], input[4], input[5], input[6], input[7]};
     vec256 state2 =  (vec256){input[8], input[9], input[10], input[11], input[8], input[9], input[10], input[11]};
 #if !defined(CHACHA20_VEC_DISABLE_STATES_16)
-    while(in_bytes.size() >= CHACHA20_VEC_BLOCKLEN * 16) {
-        multi_block_crypt<16>(in_bytes, out_bytes, state0, state1, state2);
-        state2 += (vec256){16, 0, 0, 0, 16, 0, 0, 0};
-        in_bytes = in_bytes.subspan(CHACHA20_VEC_BLOCKLEN * 16);
-        out_bytes = out_bytes.subspan(CHACHA20_VEC_BLOCKLEN * 16);
-    }
+    process_blocks<16>(in_bytes, out_bytes, state0, state1, state2);
 #endif
 #if !defined(CHACHA20_VEC_DISABLE_STATES_8)
-    while(in_bytes.size() >= CHACHA20_VEC_BLOCKLEN * 8) {
-        multi_block_crypt<8>(in_bytes, out_bytes, state0, state1, state2);
-        state2 += (vec256){8, 0, 0, 0, 8, 0, 0, 0};
-        in_bytes = in_bytes.subspan(CHACHA20_VEC_BLOCKLEN * 8);
-        out_bytes = out_bytes.subspan(CHACHA20_VEC_BLOCKLEN * 8);
-    }
+    process_blocks<8>(in_bytes, out_bytes, state0, state1, state2);
 #endif
 #if !defined(CHACHA20_VEC_DISABLE_STATES_6)
-    while(in_bytes.size() >= CHACHA20_VEC_BLOCKLEN * 6) {
-        multi_block_crypt<6>(in_bytes, out_bytes, state0, state1, state2);
-        state2 += (vec256){6, 0, 0, 0, 6, 0, 0, 0};
-        in_bytes = in_bytes.subspan(CHACHA20_VEC_BLOCKLEN * 6);
-        out_bytes = out_bytes.subspan(CHACHA20_VEC_BLOCKLEN * 6);
-    }
+    process_blocks<6>(in_bytes, out_bytes, state0, state1, state2);
 #endif
 #if !defined(CHACHA20_VEC_DISABLE_STATES_4)
-    while(in_bytes.size() >= CHACHA20_VEC_BLOCKLEN * 4) {
-        multi_block_crypt<4>(in_bytes, out_bytes, state0, state1, state2);
-        state2 += (vec256){4, 0, 0, 0, 4, 0, 0, 0};
-        in_bytes = in_bytes.subspan(CHACHA20_VEC_BLOCKLEN * 4);
-        out_bytes = out_bytes.subspan(CHACHA20_VEC_BLOCKLEN * 4);
-    }
+    process_blocks<4>(in_bytes, out_bytes, state0, state1, state2);
 #endif
 #if !defined(CHACHA20_VEC_DISABLE_STATES_2)
-    while(in_bytes.size() >= CHACHA20_VEC_BLOCKLEN * 2) {
-        multi_block_crypt<2>(in_bytes, out_bytes, state0, state1, state2);
-        state2 += (vec256){2, 0, 0, 0, 2, 0, 0, 0};
-        in_bytes = in_bytes.subspan(CHACHA20_VEC_BLOCKLEN * 2);
-        out_bytes = out_bytes.subspan(CHACHA20_VEC_BLOCKLEN * 2);
-    }
+    process_blocks<2>(in_bytes, out_bytes, state0, state1, state2);
 #endif
 #endif // CHACHA20_VEC_ALL_MULTI_STATES_DISABLED
 }

--- a/src/crypto/chacha20_vec.ipp
+++ b/src/crypto/chacha20_vec.ipp
@@ -14,16 +14,12 @@
 
 #if defined(ENABLE_CHACHA20_VEC)
 
-#if defined(CHACHA20_VEC_DISABLE_STATES_16) && \
-    defined(CHACHA20_VEC_DISABLE_STATES_8) && \
-    defined(CHACHA20_VEC_DISABLE_STATES_6) && \
-    defined(CHACHA20_VEC_DISABLE_STATES_4) && \
-    defined(CHACHA20_VEC_DISABLE_STATES_2)
-#define CHACHA20_VEC_ALL_MULTI_STATES_DISABLED
-#endif
-
-
-#if !defined(CHACHA20_VEC_ALL_MULTI_STATES_DISABLED)
+static constexpr bool CHACHA20_VEC_ALL_MULTI_STATES_DISABLED{
+    CHACHA20_VEC_DISABLE_STATES_16 &&
+    CHACHA20_VEC_DISABLE_STATES_8 &&
+    CHACHA20_VEC_DISABLE_STATES_6 &&
+    CHACHA20_VEC_DISABLE_STATES_4 &&
+    CHACHA20_VEC_DISABLE_STATES_2};
 
 namespace {
 
@@ -287,7 +283,6 @@ ALWAYS_INLINE void process_blocks(std::span<const std::byte>& in_bytes, std::spa
 }
 
 } // anonymous namespace
-#endif // CHACHA20_VEC_ALL_MULTI_STATES_DISABLED
 
 #if defined(CHACHA20_NAMESPACE)
 namespace CHACHA20_NAMESPACE {
@@ -295,27 +290,17 @@ namespace CHACHA20_NAMESPACE {
 
 void chacha20_crypt_vectorized(std::span<const std::byte>& in_bytes, std::span<std::byte>& out_bytes, std::span<const uint32_t, 12> input) noexcept
 {
-#if !defined(CHACHA20_VEC_ALL_MULTI_STATES_DISABLED)
-    assert(in_bytes.size() == out_bytes.size());
-    const vec256 state0 =  (vec256){input[0], input[1], input[2], input[3], input[0], input[1], input[2], input[3]};
-    const vec256 state1 =  (vec256){input[4], input[5], input[6], input[7], input[4], input[5], input[6], input[7]};
-    vec256 state2 =  (vec256){input[8], input[9], input[10], input[11], input[8], input[9], input[10], input[11]};
-#if !defined(CHACHA20_VEC_DISABLE_STATES_16)
-    process_blocks<16>(in_bytes, out_bytes, state0, state1, state2);
-#endif
-#if !defined(CHACHA20_VEC_DISABLE_STATES_8)
-    process_blocks<8>(in_bytes, out_bytes, state0, state1, state2);
-#endif
-#if !defined(CHACHA20_VEC_DISABLE_STATES_6)
-    process_blocks<6>(in_bytes, out_bytes, state0, state1, state2);
-#endif
-#if !defined(CHACHA20_VEC_DISABLE_STATES_4)
-    process_blocks<4>(in_bytes, out_bytes, state0, state1, state2);
-#endif
-#if !defined(CHACHA20_VEC_DISABLE_STATES_2)
-    process_blocks<2>(in_bytes, out_bytes, state0, state1, state2);
-#endif
-#endif // CHACHA20_VEC_ALL_MULTI_STATES_DISABLED
+    if constexpr (!CHACHA20_VEC_ALL_MULTI_STATES_DISABLED) {
+        assert(in_bytes.size() == out_bytes.size());
+        const vec256 state0 = (vec256){input[0], input[1], input[2], input[3], input[0], input[1], input[2], input[3]};
+        const vec256 state1 = (vec256){input[4], input[5], input[6], input[7], input[4], input[5], input[6], input[7]};
+        vec256 state2 = (vec256){input[8], input[9], input[10], input[11], input[8], input[9], input[10], input[11]};
+        if constexpr (!CHACHA20_VEC_DISABLE_STATES_16) process_blocks<16>(in_bytes, out_bytes, state0, state1, state2);
+        if constexpr (!CHACHA20_VEC_DISABLE_STATES_8) process_blocks<8>(in_bytes, out_bytes, state0, state1, state2);
+        if constexpr (!CHACHA20_VEC_DISABLE_STATES_6) process_blocks<6>(in_bytes, out_bytes, state0, state1, state2);
+        if constexpr (!CHACHA20_VEC_DISABLE_STATES_4) process_blocks<4>(in_bytes, out_bytes, state0, state1, state2);
+        if constexpr (!CHACHA20_VEC_DISABLE_STATES_2) process_blocks<2>(in_bytes, out_bytes, state0, state1, state2);
+    }
 }
 
 #if defined(CHACHA20_NAMESPACE)

--- a/src/crypto/chacha20_vec.ipp
+++ b/src/crypto/chacha20_vec.ipp
@@ -9,8 +9,10 @@
 #include <array>
 #include <bit>
 #include <cassert>
+#include <cstdint>
 #include <cstring>
 #include <limits>
+#include <memory>
 
 #if defined(ENABLE_CHACHA20_VEC)
 
@@ -24,6 +26,8 @@ static constexpr bool CHACHA20_VEC_ALL_MULTI_STATES_DISABLED{
 namespace {
 
 using vec256 = uint32_t __attribute__((__vector_size__(32)));
+
+static constexpr size_t CHACHA20_VEC_MEM_ALIGN{16};
 
 /** Endian-conversion for big-endian */
 ALWAYS_INLINE void vec_byteswap(vec256& vec)
@@ -161,31 +165,52 @@ ALWAYS_INLINE void doubleround(std::array<vec256, N>& arr0, std::array<vec256, N
    that input and output are unaligned, and makes no assumptions about the
    internal layout of vec256;
 */
-ALWAYS_INLINE void vec_read_xor_write(std::span<const std::byte, 32> in_bytes, std::span<std::byte, 32> out_bytes, const vec256& vec)
+template <bool AssumeAligned>
+ALWAYS_INLINE void vec_read_xor_write(const std::byte* in_bytes, std::byte* out_bytes, const vec256& vec)
 {
+    if constexpr (AssumeAligned) {
+        in_bytes = std::assume_aligned<CHACHA20_VEC_MEM_ALIGN>(in_bytes);
+        out_bytes = std::assume_aligned<CHACHA20_VEC_MEM_ALIGN>(out_bytes);
+    }
+
     vec256 tempvec;
-    memcpy(&tempvec, in_bytes.data(), sizeof(tempvec));
+    memcpy(&tempvec, in_bytes, sizeof(tempvec));
     vec_byteswap(tempvec);
     tempvec ^= vec;
     vec_byteswap(tempvec);
-    memcpy(out_bytes.data(), &tempvec, sizeof(tempvec));
+    memcpy(out_bytes, &tempvec, sizeof(tempvec));
 }
 
 /* Merge the 128-bit lanes from 2 states to the proper order, then pass each vec_read_xor_write */
-template <size_t N, size_t INDEX = 0>
-ALWAYS_INLINE void arr_read_xor_write(std::span<const std::byte> in_bytes, std::span<std::byte> out_bytes, const std::array<vec256, N>& arr0, const std::array<vec256, N>& arr1, const std::array<vec256, N>& arr2, const std::array<vec256, N>& arr3)
+template <bool AssumeAligned, size_t N, size_t INDEX = 0>
+ALWAYS_INLINE void arr_read_xor_write_impl(const std::byte* in_bytes, std::byte* out_bytes, const std::array<vec256, N>& arr0, const std::array<vec256, N>& arr1, const std::array<vec256, N>& arr2, const std::array<vec256, N>& arr3)
 {
     const vec256& w = std::get<INDEX>(arr0);
     const vec256& x = std::get<INDEX>(arr1);
     const vec256& y = std::get<INDEX>(arr2);
     const vec256& z = std::get<INDEX>(arr3);
+    const std::byte* in_slice{in_bytes + INDEX * 128};
+    std::byte* out_slice{out_bytes + INDEX * 128};
 
-    vec_read_xor_write(in_bytes.first<32>(), out_bytes.first<32>(), __builtin_shufflevector(w, x, 4, 5, 6, 7, 12, 13, 14, 15));
-    vec_read_xor_write(in_bytes.subspan<32, 32>(), out_bytes.subspan<32, 32>(), __builtin_shufflevector(y, z, 4, 5, 6, 7, 12, 13, 14, 15));
-    vec_read_xor_write(in_bytes.subspan<64, 32>(), out_bytes.subspan<64, 32>(), __builtin_shufflevector(w, x, 0, 1, 2, 3, 8, 9, 10, 11));
-    vec_read_xor_write(in_bytes.subspan<96, 32>(), out_bytes.subspan<96, 32>(), __builtin_shufflevector(y, z, 0, 1, 2, 3, 8, 9, 10, 11));
+    vec_read_xor_write<AssumeAligned>(in_slice, out_slice, __builtin_shufflevector(w, x, 4, 5, 6, 7, 12, 13, 14, 15));
+    vec_read_xor_write<AssumeAligned>(in_slice + 32, out_slice + 32, __builtin_shufflevector(y, z, 4, 5, 6, 7, 12, 13, 14, 15));
+    vec_read_xor_write<AssumeAligned>(in_slice + 64, out_slice + 64, __builtin_shufflevector(w, x, 0, 1, 2, 3, 8, 9, 10, 11));
+    vec_read_xor_write<AssumeAligned>(in_slice + 96, out_slice + 96, __builtin_shufflevector(y, z, 0, 1, 2, 3, 8, 9, 10, 11));
 
-    if constexpr (INDEX + 1 < N) arr_read_xor_write<N, INDEX + 1>(in_bytes.subspan<128>(), out_bytes.subspan<128>(), arr0, arr1, arr2, arr3);
+    if constexpr (INDEX + 1 < N) arr_read_xor_write_impl<AssumeAligned, N, INDEX + 1>(in_bytes, out_bytes, arr0, arr1, arr2, arr3);
+}
+
+template <size_t N>
+ALWAYS_INLINE void arr_read_xor_write(std::span<const std::byte> in_bytes, std::span<std::byte> out_bytes, const std::array<vec256, N>& arr0, const std::array<vec256, N>& arr1, const std::array<vec256, N>& arr2, const std::array<vec256, N>& arr3)
+{
+    constexpr uintptr_t mask{CHACHA20_VEC_MEM_ALIGN - 1};
+    const bool aligned{((reinterpret_cast<uintptr_t>(in_bytes.data()) | reinterpret_cast<uintptr_t>(out_bytes.data())) & mask) == 0};
+
+    if (aligned) [[likely]] {
+        arr_read_xor_write_impl<true>(in_bytes.data(), out_bytes.data(), arr0, arr1, arr2, arr3);
+    } else {
+        arr_read_xor_write_impl<false>(in_bytes.data(), out_bytes.data(), arr0, arr1, arr2, arr3);
+    }
 }
 
 /* Compile-time helper to create addend vectors which used to increment the states

--- a/src/crypto/chacha20_vec.ipp
+++ b/src/crypto/chacha20_vec.ipp
@@ -4,6 +4,9 @@
 
 #include <crypto/chacha20_vec.h>
 
+#include <attributes.h>
+
+#include <array>
 #include <bit>
 #include <cassert>
 #include <cstring>
@@ -21,17 +24,6 @@
 
 
 #if !defined(CHACHA20_VEC_ALL_MULTI_STATES_DISABLED)
-
-#if defined(__has_attribute)
-#  if __has_attribute(always_inline)
-#    define ALWAYS_INLINE __attribute__ ((always_inline)) inline
-#  endif
-#endif
-
-#if !defined(ALWAYS_INLINE)
-#  define ALWAYS_INLINE inline
-#endif
-
 
 namespace {
 
@@ -63,42 +55,42 @@ ALWAYS_INLINE void vec_rotl(vec256& vec)
 }
 
 /** Store a vector in all array elements */
-template <size_t I, size_t ITER = 0>
-ALWAYS_INLINE void arr_set_vec256(std::array<vec256, I>& arr, const vec256& vec)
+template <size_t N, size_t INDEX = 0>
+ALWAYS_INLINE void arr_set_vec256(std::array<vec256, N>& arr, const vec256& vec)
 {
-    std::get<ITER>(arr) = vec;
-    if constexpr(ITER + 1 < I ) arr_set_vec256<I, ITER + 1>(arr, vec);
+    std::get<INDEX>(arr) = vec;
+    if constexpr (INDEX + 1 < N) arr_set_vec256<N, INDEX + 1>(arr, vec);
 }
 
 /** Add a vector to all array elements */
-template <size_t I, size_t ITER = 0>
-ALWAYS_INLINE void arr_add_vec256(std::array<vec256, I>& arr, const vec256& vec)
+template <size_t N, size_t INDEX = 0>
+ALWAYS_INLINE void arr_add_vec256(std::array<vec256, N>& arr, const vec256& vec)
 {
-    std::get<ITER>(arr) += vec;
-    if constexpr(ITER + 1 < I ) arr_add_vec256<I, ITER + 1>(arr, vec);
+    std::get<INDEX>(arr) += vec;
+    if constexpr (INDEX + 1 < N) arr_add_vec256<N, INDEX + 1>(arr, vec);
 }
 
 /** Add corresponding vectors in arr1 to arr0 */
-template <size_t I, size_t ITER = 0>
-ALWAYS_INLINE void arr_add_arr(std::array<vec256, I>& arr0, const std::array<vec256, I>& arr1)
+template <size_t N, size_t INDEX = 0>
+ALWAYS_INLINE void arr_add_arr(std::array<vec256, N>& arr0, const std::array<vec256, N>& arr1)
 {
-    std::get<ITER>(arr0) += std::get<ITER>(arr1);
-    if constexpr(ITER + 1 < I ) arr_add_arr<I, ITER + 1>(arr0, arr1);
+    std::get<INDEX>(arr0) += std::get<INDEX>(arr1);
+    if constexpr (INDEX + 1 < N) arr_add_arr<N, INDEX + 1>(arr0, arr1);
 }
 
 /** Perform add/xor/rotate for the round function */
-template <size_t BITS, size_t I, size_t ITER = 0>
-ALWAYS_INLINE void arr_add_xor_rot(std::array<vec256, I>& arr0, const std::array<vec256, I>& arr1, std::array<vec256, I>& arr2)
+template <size_t BITS, size_t N, size_t INDEX = 0>
+ALWAYS_INLINE void arr_add_xor_rot(std::array<vec256, N>& arr0, const std::array<vec256, N>& arr1, std::array<vec256, N>& arr2)
 {
-    vec256& x = std::get<ITER>(arr0);
-    const vec256& y = std::get<ITER>(arr1);
-    vec256& z = std::get<ITER>(arr2);
+    vec256& x = std::get<INDEX>(arr0);
+    const vec256& y = std::get<INDEX>(arr1);
+    vec256& z = std::get<INDEX>(arr2);
 
     x += y;
     z ^= x;
     vec_rotl<BITS>(z);
 
-    if constexpr(ITER + 1 < I ) arr_add_xor_rot<BITS, I, ITER + 1>(arr0, arr1, arr2);
+    if constexpr (INDEX + 1 < N) arr_add_xor_rot<BITS, N, INDEX + 1>(arr0, arr1, arr2);
 }
 
 /*
@@ -121,36 +113,36 @@ After the second round, they are used (in reverse) to restore the original
 layout.
 
 */
-template <size_t I, size_t ITER = 0>
-ALWAYS_INLINE void arr_shuf0(std::array<vec256, I>& arr)
+template <size_t N, size_t INDEX = 0>
+ALWAYS_INLINE void arr_shuf0(std::array<vec256, N>& arr)
 {
-    vec256& x = std::get<ITER>(arr);
+    vec256& x = std::get<INDEX>(arr);
     x = vec256{x[1], x[2], x[3], x[0], x[5], x[6], x[7], x[4]};
 
-    if constexpr(ITER + 1 < I ) arr_shuf0<I, ITER + 1>(arr);
+    if constexpr (INDEX + 1 < N) arr_shuf0<N, INDEX + 1>(arr);
 }
 
-template <size_t I, size_t ITER = 0>
-ALWAYS_INLINE void arr_shuf1(std::array<vec256, I>& arr)
+template <size_t N, size_t INDEX = 0>
+ALWAYS_INLINE void arr_shuf1(std::array<vec256, N>& arr)
 {
-    vec256& x = std::get<ITER>(arr);
+    vec256& x = std::get<INDEX>(arr);
     x = vec256{x[2], x[3], x[0], x[1], x[6], x[7], x[4], x[5]};
 
-    if constexpr(ITER + 1 < I ) arr_shuf1<I, ITER + 1>(arr);
+    if constexpr (INDEX + 1 < N) arr_shuf1<N, INDEX + 1>(arr);
 }
 
-template <size_t I, size_t ITER = 0>
-ALWAYS_INLINE void arr_shuf2(std::array<vec256, I>& arr)
+template <size_t N, size_t INDEX = 0>
+ALWAYS_INLINE void arr_shuf2(std::array<vec256, N>& arr)
 {
-    vec256& x = std::get<ITER>(arr);
+    vec256& x = std::get<INDEX>(arr);
     x = vec256{x[3], x[0], x[1], x[2], x[7], x[4], x[5], x[6]};
 
-    if constexpr(ITER + 1 < I ) arr_shuf2<I, ITER + 1>(arr);
+    if constexpr (INDEX + 1 < N) arr_shuf2<N, INDEX + 1>(arr);
 }
 
 /* Main round function. */
-template <size_t I, size_t ITER = 0>
-ALWAYS_INLINE void doubleround(std::array<vec256, I>& arr0, std::array<vec256, I>& arr1, std::array<vec256, I>&arr2, std::array<vec256, I>&arr3)
+template <size_t N, size_t INDEX = 0>
+ALWAYS_INLINE void doubleround(std::array<vec256, N>& arr0, std::array<vec256, N>& arr1, std::array<vec256, N>&arr2, std::array<vec256, N>&arr3)
 {
     arr_add_xor_rot<16>(arr0, arr1, arr3);
     arr_add_xor_rot<12>(arr2, arr3, arr1);
@@ -166,10 +158,10 @@ ALWAYS_INLINE void doubleround(std::array<vec256, I>& arr0, std::array<vec256, I
     arr_shuf2(arr1);
     arr_shuf1(arr2);
     arr_shuf0(arr3);
-    if constexpr (ITER + 1 < 10) doubleround<I, ITER + 1>(arr0, arr1, arr2, arr3);
+    if constexpr (INDEX + 1 < 10) doubleround<N, INDEX + 1>(arr0, arr1, arr2, arr3);
 }
 
-/* Read 32bytes of input, xor with calculated state, write to output. Assumes
+/* Read 32 bytes of input, xor with calculated state, write to output. Assumes
    that input and output are unaligned, and makes no assumptions about the
    internal layout of vec256;
 */
@@ -184,21 +176,21 @@ ALWAYS_INLINE void vec_read_xor_write(std::span<const std::byte, 32> in_bytes, s
     memcpy(out_bytes.data(), temparr.data(), out_bytes.size());
 }
 
-/* Merge the 128 bit lanes from 2 states to the proper order, then pass each vec_read_xor_write */
-template <size_t I, size_t ITER = 0>
-ALWAYS_INLINE void arr_read_xor_write(std::span<const std::byte> in_bytes, std::span<std::byte> out_bytes, const std::array<vec256, I>& arr0, const std::array<vec256, I>& arr1, const std::array<vec256, I>& arr2, const std::array<vec256, I>& arr3)
+/* Merge the 128-bit lanes from 2 states to the proper order, then pass each vec_read_xor_write */
+template <size_t N, size_t INDEX = 0>
+ALWAYS_INLINE void arr_read_xor_write(std::span<const std::byte> in_bytes, std::span<std::byte> out_bytes, const std::array<vec256, N>& arr0, const std::array<vec256, N>& arr1, const std::array<vec256, N>& arr2, const std::array<vec256, N>& arr3)
 {
-    const vec256& w = std::get<ITER>(arr0);
-    const vec256& x = std::get<ITER>(arr1);
-    const vec256& y = std::get<ITER>(arr2);
-    const vec256& z = std::get<ITER>(arr3);
+    const vec256& w = std::get<INDEX>(arr0);
+    const vec256& x = std::get<INDEX>(arr1);
+    const vec256& y = std::get<INDEX>(arr2);
+    const vec256& z = std::get<INDEX>(arr3);
 
     vec_read_xor_write(in_bytes.first<32>(), out_bytes.first<32>(), __builtin_shufflevector(w, x, 4, 5, 6, 7, 12, 13, 14, 15));
     vec_read_xor_write(in_bytes.subspan<32, 32>(), out_bytes.subspan<32, 32>(), __builtin_shufflevector(y, z, 4, 5, 6, 7, 12, 13, 14, 15));
     vec_read_xor_write(in_bytes.subspan<64, 32>(), out_bytes.subspan<64, 32>(), __builtin_shufflevector(w, x, 0, 1, 2, 3, 8, 9, 10, 11));
     vec_read_xor_write(in_bytes.subspan<96, 32>(), out_bytes.subspan<96, 32>(), __builtin_shufflevector(y, z, 0, 1, 2, 3, 8, 9, 10, 11));
 
-    if constexpr(ITER + 1 < I ) arr_read_xor_write<I, ITER + 1>(in_bytes.subspan<128>(), out_bytes.subspan<128>(), arr0, arr1, arr2, arr3);
+    if constexpr (INDEX + 1 < N) arr_read_xor_write<N, INDEX + 1>(in_bytes.subspan<128>(), out_bytes.subspan<128>(), arr0, arr1, arr2, arr3);
 }
 
 /* Compile-time helper to create addend vectors which used to increment the states

--- a/src/crypto/chacha20_vec_base.cpp
+++ b/src/crypto/chacha20_vec_base.cpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2025-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#define CHACHA20_NAMESPACE chacha20_vec_base
+
+// This file should define which states should be en/disabled for all
+// supported architectures. For some, like x86-64 and armv8, simd features
+// (sse2 and neon respectively) are safe to use without runtime detection.
+
+#if defined(__x86_64__) || defined(__amd64__)
+#  define CHACHA20_VEC_DISABLE_STATES_16
+#  define CHACHA20_VEC_DISABLE_STATES_8
+#  define CHACHA20_VEC_DISABLE_STATES_6
+#elif defined(__ARM_NEON)
+#  define CHACHA20_VEC_DISABLE_STATES_2
+#else
+// Be conservative and require platforms to opt-in
+#  define CHACHA20_VEC_DISABLE_STATES_16
+#  define CHACHA20_VEC_DISABLE_STATES_8
+#  define CHACHA20_VEC_DISABLE_STATES_6
+#  define CHACHA20_VEC_DISABLE_STATES_4
+#  define CHACHA20_VEC_DISABLE_STATES_2
+#endif
+
+#include <crypto/chacha20_vec.ipp>

--- a/src/crypto/chacha20_vec_base.cpp
+++ b/src/crypto/chacha20_vec_base.cpp
@@ -9,18 +9,24 @@
 // (sse2 and neon respectively) are safe to use without runtime detection.
 
 #if defined(__x86_64__) || defined(__amd64__)
-#  define CHACHA20_VEC_DISABLE_STATES_16
-#  define CHACHA20_VEC_DISABLE_STATES_8
-#  define CHACHA20_VEC_DISABLE_STATES_6
+static constexpr bool CHACHA20_VEC_DISABLE_STATES_16{true};
+static constexpr bool CHACHA20_VEC_DISABLE_STATES_8{true};
+static constexpr bool CHACHA20_VEC_DISABLE_STATES_6{true};
+static constexpr bool CHACHA20_VEC_DISABLE_STATES_4{false};
+static constexpr bool CHACHA20_VEC_DISABLE_STATES_2{false};
 #elif defined(__ARM_NEON)
-#  define CHACHA20_VEC_DISABLE_STATES_2
+static constexpr bool CHACHA20_VEC_DISABLE_STATES_16{false};
+static constexpr bool CHACHA20_VEC_DISABLE_STATES_8{false};
+static constexpr bool CHACHA20_VEC_DISABLE_STATES_6{false};
+static constexpr bool CHACHA20_VEC_DISABLE_STATES_4{false};
+static constexpr bool CHACHA20_VEC_DISABLE_STATES_2{true};
 #else
-// Be conservative and require platforms to opt-in
-#  define CHACHA20_VEC_DISABLE_STATES_16
-#  define CHACHA20_VEC_DISABLE_STATES_8
-#  define CHACHA20_VEC_DISABLE_STATES_6
-#  define CHACHA20_VEC_DISABLE_STATES_4
-#  define CHACHA20_VEC_DISABLE_STATES_2
+// Be conservative and require platforms to opt in.
+static constexpr bool CHACHA20_VEC_DISABLE_STATES_16{true};
+static constexpr bool CHACHA20_VEC_DISABLE_STATES_8{true};
+static constexpr bool CHACHA20_VEC_DISABLE_STATES_6{true};
+static constexpr bool CHACHA20_VEC_DISABLE_STATES_4{true};
+static constexpr bool CHACHA20_VEC_DISABLE_STATES_2{true};
 #endif
 
 #include <crypto/chacha20_vec.ipp>


### PR DESCRIPTION
```
for compiler in gcc clang; do   if [ "$compiler" = "gcc" ]; then CC=gcc; CXX=g++; COMP_VER=$(gcc -dumpfullversion);   else CC=clang; CXX=clang++; COMP_VER=$(clang -dumpversion); fi &&   echo "> Compiler: $compiler $COMP_VER" &&   for commit in 781876e277373ba777458b9f74a4107edf777fe5 36604f9c310b773ee71268d037637cc8b7471f35; do     git fetch origin $commit >/dev/null 2>&1 && git checkout $commit >/dev/null 2>&1 && echo "" && git log -1 --pretty='%h %s' &&     rm -rf build >/dev/null 2>&1 && cmake -B build -DBUILD_BENCH=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX >/dev/null 2>&1 &&     cmake --build build -j$(nproc) >/dev/null 2>&1 &&     for i in $(seq 0 1); do       build/bin/bench_bitcoin -filter='CHACHA20_.*' -min-time=10000;     done;   done; done                                                                                                                                                                
> Compiler: gcc 15.0.1

781876e277 chacha20: Add generic vectorized chacha20 implementation

|             ns/byte |              byte/s |    err% |        ins/byte |        cyc/byte |    IPC |       bra/byte |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|                4.83 |      206,958,878.47 |    0.0% |           23.35 |           11.56 |  2.020 |           0.00 |    0.2% |     11.00 | `CHACHA20_1MB`
|                4.80 |      208,137,730.48 |    0.0% |           20.59 |           11.50 |  1.790 |           0.07 |    0.0% |     11.00 | `CHACHA20_256BYTES`
|                2.69 |      372,003,472.99 |    0.1% |           17.84 |            6.44 |  2.773 |           0.19 |    0.0% |     11.00 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |        ins/byte |        cyc/byte |    IPC |       bra/byte |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|                4.83 |      207,069,975.88 |    0.0% |           23.35 |           11.56 |  2.021 |           0.00 |    0.1% |     11.00 | `CHACHA20_1MB`
|                4.81 |      208,067,368.76 |    0.0% |           20.59 |           11.51 |  1.789 |           0.07 |    0.0% |     11.00 | `CHACHA20_256BYTES`
|                2.67 |      374,590,193.11 |    0.1% |           17.84 |            6.39 |  2.791 |           0.19 |    0.0% |     11.00 | `CHACHA20_64BYTES`

36604f9c31 refactor: improve GCC handling for NEON/AArch64 in ChaCha20 vectorized paths
> Compiler: clang 22.0.0

781876e277 chacha20: Add generic vectorized chacha20 implementation

|             ns/byte |              byte/s |    err% |        ins/byte |        cyc/byte |    IPC |       bra/byte |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|                1.79 |      557,959,494.89 |    0.0% |            9.60 |            4.29 |  2.240 |           0.00 |    0.1% |     11.01 | `CHACHA20_1MB`
|                1.64 |      610,307,932.25 |    0.1% |            6.55 |            3.92 |  1.670 |           0.10 |    0.0% |     11.00 | `CHACHA20_256BYTES`
|                2.60 |      384,698,439.18 |    0.0% |           18.44 |            6.23 |  2.962 |           0.31 |    0.0% |     11.00 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |        ins/byte |        cyc/byte |    IPC |       bra/byte |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|                1.79 |      559,005,536.76 |    0.0% |            9.60 |            4.28 |  2.244 |           0.00 |    0.1% |     11.00 | `CHACHA20_1MB`
|                1.64 |      610,786,505.54 |    0.1% |            6.55 |            3.92 |  1.672 |           0.10 |    0.0% |     11.00 | `CHACHA20_256BYTES`
|                2.61 |      383,769,985.63 |    0.0% |           18.44 |            6.24 |  2.954 |           0.31 |    0.0% |     11.00 | `CHACHA20_64BYTES`

36604f9c31 refactor: improve GCC handling for NEON/AArch64 in ChaCha20 vectorized paths

|             ns/byte |              byte/s |    err% |        ins/byte |        cyc/byte |    IPC |       bra/byte |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|                1.85 |      539,703,724.67 |    0.1% |            9.69 |            4.43 |  2.187 |           0.00 |    0.1% |     11.00 | `CHACHA20_1MB`
|                1.73 |      577,268,413.16 |    0.3% |            6.76 |            4.15 |  1.629 |           0.11 |    0.0% |     10.98 | `CHACHA20_256BYTES`
|                2.61 |      383,738,420.85 |    0.0% |           18.44 |            6.24 |  2.954 |           0.31 |    0.0% |     11.00 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |        ins/byte |        cyc/byte |    IPC |       bra/byte |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|                1.84 |      542,736,861.01 |    0.0% |            9.69 |            4.41 |  2.198 |           0.00 |    0.1% |     11.00 | `CHACHA20_1MB`
|                1.73 |      577,511,857.60 |    0.1% |            6.76 |            4.15 |  1.629 |           0.11 |    0.0% |     11.00 | `CHACHA20_256BYTES`
|                2.58 |      388,189,914.99 |    0.0% |           18.44 |            6.17 |  2.988 |           0.31 |    0.0% |     11.00 | `CHACHA20_64BYTES`
```

-----------

lorinc@M4-Max bitcoin % for commit in ab233255d444ccf6ffe4a45cb02bfc3e5fb71bdb 1cf4ca6e909599a5d5a6b9c7c92765870ee31875 781876e277373ba777458b9f74a4107edf777fe5 e81ad4fe175521704875e8af671b6ca45cab6918 684c6b8e30ad6f307a170f4004b799bd8112b211; do \
    git fetch origin $commit >/dev/null 2>&1 && git checkout $commit >/dev/null 2>&1 && echo "" && git log -1 --pretty='%h %s' && \
    rm -rf build >/dev/null 2>&1 && cmake -B build -DBUILD_BENCH=ON -DCMAKE_BUILD_TYPE=Release >/dev/null 2>&1 && \
    cmake --build build -j$(nproc) >/dev/null 2>&1 && \
    for _ in $(seq 5); do \
      sleep 5; \
      sudo taskpolicy -t 5 -l 5 nice -n -20 ./build/bin/bench_bitcoin -filter='CHACHA20_.*' -min-time=1000; \
    done; \
done

ab233255d4 Merge bitcoin/bitcoin#33866: refactor: Let CCoinsViewCache::BatchWrite return void

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.94 |    1,058,268,894.46 |    0.1% |      1.10 | `CHACHA20_1MB`
|                0.95 |    1,048,416,152.60 |    0.0% |      1.10 | `CHACHA20_256BYTES`
|                1.02 |      984,038,960.26 |    0.1% |      1.06 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.94 |    1,060,040,366.28 |    0.1% |      1.10 | `CHACHA20_1MB`
|                0.96 |    1,047,073,717.58 |    0.1% |      1.10 | `CHACHA20_256BYTES`
|                1.01 |      988,687,480.14 |    0.1% |      1.06 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.94 |    1,058,577,350.59 |    0.1% |      1.10 | `CHACHA20_1MB`
|                0.95 |    1,048,430,547.51 |    0.1% |      1.10 | `CHACHA20_256BYTES`
|                1.01 |      988,243,103.68 |    0.1% |      1.06 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.94 |    1,062,574,399.41 |    0.1% |      1.10 | `CHACHA20_1MB`
|                0.95 |    1,049,985,619.12 |    0.1% |      1.10 | `CHACHA20_256BYTES`
|                1.01 |      994,965,993.01 |    0.9% |      1.07 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.94 |    1,061,505,032.08 |    0.4% |      1.10 | `CHACHA20_1MB`
|                0.96 |    1,045,737,313.10 |    0.2% |      1.10 | `CHACHA20_256BYTES`
|                0.99 |    1,008,315,324.40 |    0.5% |      1.06 | `CHACHA20_64BYTES`

1cf4ca6e90 chacha20: move single-block crypt to inline helper function

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.95 |    1,057,645,664.12 |    0.6% |      1.11 | `CHACHA20_1MB`
|                0.95 |    1,054,704,109.21 |    0.2% |      1.10 | `CHACHA20_256BYTES`
|                1.00 |      999,328,767.58 |    0.4% |      1.06 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.94 |    1,067,467,363.20 |    0.6% |      1.09 | `CHACHA20_1MB`
|                0.95 |    1,049,898,455.45 |    0.3% |      1.10 | `CHACHA20_256BYTES`
|                1.00 |      998,002,850.63 |    0.3% |      1.06 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.94 |    1,061,319,270.40 |    0.3% |      1.10 | `CHACHA20_1MB`
|                0.95 |    1,049,840,423.60 |    0.3% |      1.11 | `CHACHA20_256BYTES`
|                0.98 |    1,018,308,605.16 |    0.6% |      1.06 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.92 |    1,089,061,018.31 |    0.7% |      1.10 | `CHACHA20_1MB`
|                0.94 |    1,069,084,780.31 |    0.8% |      1.10 | `CHACHA20_256BYTES`
|                0.97 |    1,026,499,631.32 |    0.2% |      1.06 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.92 |    1,082,938,842.72 |    0.6% |      1.10 | `CHACHA20_1MB`
|                0.92 |    1,084,811,196.80 |    0.5% |      1.10 | `CHACHA20_256BYTES`
|                0.97 |    1,029,920,328.74 |    0.4% |      1.06 | `CHACHA20_64BYTES`

781876e277 chacha20: Add generic vectorized chacha20 implementation

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.47 |    2,125,353,221.24 |    0.3% |      1.10 | `CHACHA20_1MB`
|                0.70 |    1,429,018,109.32 |    0.2% |      1.10 | `CHACHA20_256BYTES`
|                0.96 |    1,040,329,069.62 |    0.5% |      1.05 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.47 |    2,119,953,176.39 |    0.1% |      1.10 | `CHACHA20_1MB`
|                0.69 |    1,458,624,203.47 |    0.8% |      1.10 | `CHACHA20_256BYTES`
|                0.96 |    1,045,066,539.72 |    0.3% |      1.05 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.47 |    2,130,234,806.57 |    0.3% |      1.10 | `CHACHA20_1MB`
|                0.68 |    1,460,207,386.67 |    0.5% |      1.10 | `CHACHA20_256BYTES`
|                0.95 |    1,052,170,850.45 |    0.3% |      1.05 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.47 |    2,136,197,849.41 |    0.3% |      1.10 | `CHACHA20_1MB`
|                0.68 |    1,472,577,603.43 |    0.5% |      1.10 | `CHACHA20_256BYTES`
|                0.95 |    1,049,933,878.00 |    0.4% |      1.06 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.47 |    2,127,184,778.91 |    0.1% |      1.10 | `CHACHA20_1MB`
|                0.68 |    1,481,420,351.81 |    0.6% |      1.09 | `CHACHA20_256BYTES`
|                0.95 |    1,050,776,578.07 |    0.3% |      1.05 | `CHACHA20_64BYTES`

e81ad4fe17 refactor: replace recursive templates in ChaCha20 implementation with `static_for` loops

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.47 |    2,114,253,720.25 |    0.2% |      1.10 | `CHACHA20_1MB`
|                0.71 |    1,417,796,186.07 |    0.5% |      1.09 | `CHACHA20_256BYTES`
|                0.97 |    1,028,289,610.80 |    1.0% |      1.05 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.47 |    2,117,216,904.18 |    0.2% |      1.10 | `CHACHA20_1MB`
|                0.69 |    1,445,997,595.12 |    0.4% |      1.10 | `CHACHA20_256BYTES`
|                0.97 |    1,032,485,796.21 |    0.2% |      1.05 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.47 |    2,116,239,613.66 |    0.4% |      1.10 | `CHACHA20_1MB`
|                0.69 |    1,445,589,055.85 |    1.1% |      1.10 | `CHACHA20_256BYTES`
|                0.97 |    1,033,384,684.85 |    0.4% |      1.06 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.47 |    2,123,535,080.30 |    0.2% |      1.10 | `CHACHA20_1MB`
|                0.68 |    1,461,407,516.49 |    0.4% |      1.10 | `CHACHA20_256BYTES`
|                0.96 |    1,041,673,508.08 |    0.3% |      1.06 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.47 |    2,109,132,889.91 |    1.1% |      1.11 | `CHACHA20_1MB`
|                0.69 |    1,458,662,628.90 |    0.6% |      1.10 | `CHACHA20_256BYTES`
|                0.96 |    1,046,068,940.07 |    0.2% |      1.10 | `CHACHA20_64BYTES`

684c6b8e30 refactor: replace template-based static_for use in ChaCha20 with runtime iteration

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.60 |    1,659,589,463.76 |    0.1% |      1.06 | `CHACHA20_1MB`
|                0.97 |    1,031,143,486.52 |    0.5% |      1.10 | `CHACHA20_256BYTES`
|                0.97 |    1,026,590,256.31 |    0.3% |      1.06 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.60 |    1,656,108,069.32 |    0.2% |      1.06 | `CHACHA20_1MB`
|                0.96 |    1,042,447,290.91 |    0.6% |      1.09 | `CHACHA20_256BYTES`
|                0.97 |    1,025,706,259.48 |    0.5% |      1.06 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.60 |    1,664,479,265.88 |    0.2% |      1.06 | `CHACHA20_1MB`
|                0.96 |    1,037,608,553.47 |    0.6% |      1.10 | `CHACHA20_256BYTES`
|                0.97 |    1,029,755,444.87 |    0.6% |      1.05 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.60 |    1,667,859,284.70 |    0.4% |      1.06 | `CHACHA20_1MB`
|                0.95 |    1,048,295,704.45 |    0.2% |      1.10 | `CHACHA20_256BYTES`
|                0.96 |    1,040,519,808.92 |    0.3% |      1.06 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.60 |    1,670,046,100.32 |    0.3% |      1.06 | `CHACHA20_1MB`
|                0.95 |    1,055,358,439.82 |    0.2% |      1.10 | `CHACHA20_256BYTES`
|                0.97 |    1,035,578,740.44 |    0.3% |      1.06 | `CHACHA20_64BYTES`


3b47fec2cc refactor: unroll ChaCha20 vector operations for improved clarity and efficiency

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.45 |    2,199,678,091.89 |    0.3% |      1.11 | `CHACHA20_1MB`
|                0.66 |    1,507,291,665.04 |    0.1% |      1.10 | `CHACHA20_256BYTES`
|                0.90 |    1,112,959,504.77 |    0.7% |      1.10 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.46 |    2,195,684,136.65 |    0.4% |      1.10 | `CHACHA20_1MB`
|                0.66 |    1,506,660,295.78 |    0.4% |      1.10 | `CHACHA20_256BYTES`
|                0.92 |    1,087,933,892.78 |    2.5% |      1.13 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.45 |    2,203,401,712.10 |    0.2% |      1.10 | `CHACHA20_1MB`
|                0.66 |    1,507,625,039.08 |    0.2% |      1.10 | `CHACHA20_256BYTES`
|                0.90 |    1,108,996,437.73 |    0.3% |      1.10 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.46 |    2,183,490,417.79 |    0.5% |      1.11 | `CHACHA20_1MB`
|                0.66 |    1,507,655,302.52 |    0.1% |      1.10 | `CHACHA20_256BYTES`
|                0.90 |    1,115,916,915.48 |    0.2% |      1.10 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.45 |    2,202,195,041.84 |    0.3% |      1.10 | `CHACHA20_1MB`
|                0.66 |    1,507,910,301.61 |    0.4% |      1.10 | `CHACHA20_256BYTES`
|                0.89 |    1,119,904,705.18 |    0.5% |      1.10 | `CHACHA20_64BYTES`

3e6fcae65d refactor: unify loop unrolling macros and refactor ChaCha20 vector operations for clarity

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.46 |    2,159,748,881.74 |    0.1% |      1.10 | `CHACHA20_1MB`
|                0.65 |    1,549,391,853.78 |    0.0% |      1.10 | `CHACHA20_256BYTES`
|                0.91 |    1,097,296,385.46 |    0.4% |      1.10 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.46 |    2,175,945,129.30 |    0.0% |      1.10 | `CHACHA20_1MB`
|                0.65 |    1,548,893,301.86 |    0.1% |      1.10 | `CHACHA20_256BYTES`
|                0.90 |    1,113,094,172.35 |    0.4% |      1.10 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.46 |    2,192,142,331.94 |    0.3% |      1.10 | `CHACHA20_1MB`
|                0.65 |    1,532,186,313.62 |    0.5% |      1.10 | `CHACHA20_256BYTES`
|                0.88 |    1,132,883,209.14 |    0.3% |      1.10 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.46 |    2,194,963,166.87 |    0.6% |      1.11 | `CHACHA20_1MB`
|                0.65 |    1,548,631,622.21 |    0.1% |      1.11 | `CHACHA20_256BYTES`
|                0.89 |    1,128,422,075.21 |    0.6% |      1.07 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.45 |    2,220,489,171.03 |    0.3% |      1.10 | `CHACHA20_1MB`
|                0.65 |    1,548,464,997.06 |    0.1% |      1.10 | `CHACHA20_256BYTES`
|                0.88 |    1,135,806,636.22 |    0.2% |      1.10 | `CHACHA20_64BYTES`

64471e2a64 refactor: modularize ChaCha20 vector operations and consolidate common patterns

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.48 |    2,081,892,000.27 |    0.6% |      1.11 | `CHACHA20_1MB`
|                0.68 |    1,473,786,338.04 |    0.4% |      1.10 | `CHACHA20_256BYTES`
|                0.96 |    1,042,868,052.36 |    0.3% |      1.06 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.48 |    2,075,353,491.83 |    0.5% |      1.10 | `CHACHA20_1MB`
|                0.67 |    1,483,727,345.67 |    0.3% |      1.10 | `CHACHA20_256BYTES`
|                0.95 |    1,049,641,969.66 |    0.5% |      1.06 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.48 |    2,078,360,609.28 |    0.5% |      1.10 | `CHACHA20_1MB`
|                0.68 |    1,475,035,491.76 |    0.4% |      1.10 | `CHACHA20_256BYTES`
|                0.96 |    1,046,741,829.89 |    0.2% |      1.06 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.48 |    2,080,665,985.65 |    0.2% |      1.10 | `CHACHA20_1MB`
|                0.67 |    1,487,879,644.40 |    0.3% |      1.10 | `CHACHA20_256BYTES`
|                0.96 |    1,047,080,450.94 |    0.5% |      1.06 | `CHACHA20_64BYTES`

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.48 |    2,073,967,519.81 |    0.6% |      1.10 | `CHACHA20_1MB`
|                0.68 |    1,475,708,659.69 |    0.4% |      1.09 | `CHACHA20_256BYTES`
|                0.95 |    1,048,601,229.29 |    0.2% |      1.06 | `CHACHA20_64BYTES`
