### PR TITLE
util: add Utf8ToWide helper

### DIFF
--- a/src/common/system.cpp
+++ b/src/common/system.cpp
@@ -13,7 +13,6 @@
 
 #ifdef WIN32
 #include <cassert>
-#include <codecvt>
 #include <compat/compat.h>
 #include <windows.h>
 #else
@@ -56,7 +55,8 @@ void runCommand(const std::string& strCommand)
 #ifndef WIN32
     int nErr = ::system(strCommand.c_str());
 #else
-    int nErr = ::_wsystem(std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>,wchar_t>().from_bytes(strCommand).c_str());
+    const std::wstring wide_command{util::Utf8ToWide(strCommand)};
+    int nErr = ::_wsystem(wide_command.c_str());
 #endif
     if (nErr) {
         LogWarning("runCommand error: system(%s) returned %d", strCommand, nErr);

--- a/src/leveldb/util/env_windows.cc
+++ b/src/leveldb/util/env_windows.cc
@@ -81,11 +81,6 @@ class ScopedHandle {
 
   ScopedHandle& operator=(const ScopedHandle&) = delete;
 
-  ScopedHandle& operator=(ScopedHandle&& rhs) noexcept {
-    if (this != &rhs) handle_ = rhs.Release();
-    return *this;
-  }
-
   bool Close() {
     if (!is_valid()) {
       return true;

--- a/src/util/exec.cpp
+++ b/src/util/exec.cpp
@@ -5,6 +5,7 @@
 #include <util/exec.h>
 
 #include <util/fs.h>
+#include <util/string.h>
 #include <util/subprocess.h>
 
 #include <string>
@@ -24,16 +25,16 @@ int ExecVp(const char* file, char* const argv[])
     return execvp(file, argv);
 #else
     std::vector<std::wstring> escaped_args;
-    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
     for (char* const* arg_ptr{argv}; *arg_ptr; ++arg_ptr) {
-        subprocess::util::quote_argument(converter.from_bytes(*arg_ptr), escaped_args.emplace_back(), false);
+        subprocess::util::quote_argument(util::Utf8ToWide(*arg_ptr), escaped_args.emplace_back(), false);
     }
 
     std::vector<const wchar_t*> new_argv;
     new_argv.reserve(escaped_args.size() + 1);
     for (const auto& s : escaped_args) new_argv.push_back(s.c_str());
     new_argv.push_back(nullptr);
-    return _wexecvp(converter.from_bytes(file).c_str(), new_argv.data());
+    const std::wstring wide_file{util::Utf8ToWide(file)};
+    return _wexecvp(wide_file.c_str(), new_argv.data());
 #endif
 }
 

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -4,6 +4,18 @@
 
 #include <util/string.h>
 
+#ifdef WIN32
+#include <util/syserror.h>
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+
+#include <limits>
+#include <stdexcept>
+#endif
+
 #include <regex>
 #include <string>
 
@@ -13,4 +25,30 @@ void ReplaceAll(std::string& in_out, const std::string& search, const std::strin
     if (search.empty()) return;
     in_out = std::regex_replace(in_out, std::regex(search), substitute);
 }
+
+#ifdef WIN32
+std::wstring Utf8ToWide(std::string_view utf8)
+{
+    if (utf8.empty()) return {};
+    if (utf8.size() > static_cast<size_t>(std::numeric_limits<int>::max())) {
+        throw std::runtime_error("UTF-8 string is too long to convert");
+    }
+
+    const int src_size{static_cast<int>(utf8.size())};
+    const int dst_size{MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, utf8.data(), src_size, nullptr, 0)};
+    if (dst_size == 0) {
+        const auto err{GetLastError()};
+        throw std::runtime_error("MultiByteToWideChar failed: " + Win32ErrorString(err));
+    }
+
+    std::wstring wide(dst_size, 0);
+    const int result{MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, utf8.data(), src_size, wide.data(), dst_size)};
+    if (result != dst_size) {
+        const auto err{GetLastError()};
+        throw std::runtime_error("MultiByteToWideChar failed: " + Win32ErrorString(err));
+    }
+
+    return wide;
+}
+#endif
 } // namespace util

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -260,6 +260,10 @@ template <typename T1, size_t PREFIX_LEN>
     return obj.size() >= PREFIX_LEN &&
            std::equal(std::begin(prefix), std::end(prefix), std::begin(obj));
 }
+
+#ifdef WIN32
+std::wstring Utf8ToWide(std::string_view utf8);
+#endif
 } // namespace util
 
 #endif // BITCOIN_UTIL_STRING_H

--- a/src/util/subprocess.h
+++ b/src/util/subprocess.h
@@ -37,6 +37,7 @@ Documentation for C++ subprocessing library.
 #define BITCOIN_UTIL_SUBPROCESS_H
 
 #include <util/syserror.h>
+#include <util/string.h>
 
 #include <algorithm>
 #include <cassert>
@@ -57,10 +58,6 @@ Documentation for C++ subprocessing library.
 
 #if (defined _MSC_VER) || (defined __MINGW32__)
   #define __USING_WINDOWS__
-#endif
-
-#ifdef __USING_WINDOWS__
-  #include <codecvt>
 #endif
 
 extern "C" {
@@ -1102,7 +1099,6 @@ inline void Popen::execute_process() noexcept(false)
   }
   this->exe_name_ = vargs_[0];
 
-  std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
   std::wstring argument;
   std::wstring command_line;
   bool first_arg = true;
@@ -1113,7 +1109,7 @@ inline void Popen::execute_process() noexcept(false)
     } else {
       first_arg = false;
     }
-    argument = converter.from_bytes(arg);
+    argument = ::util::Utf8ToWide(arg);
     util::quote_argument(argument, command_line, false);
   }
 

--- a/src/util/subprocess.h
+++ b/src/util/subprocess.h
@@ -740,6 +740,7 @@ private:
  * This takes care of all the fork-exec logic
  * in the execute_child API.
  */
+#ifndef __USING_WINDOWS__
 class Child
 {
 public:
@@ -756,6 +757,7 @@ private:
   Popen* parent_ = nullptr;
   int err_wr_pipe_ = -1;
 };
+#endif // !__USING_WINDOWS__
 
 // Fwd Decl.
 class Streams;
@@ -929,7 +931,9 @@ class Popen
 {
 public:
   friend struct detail::ArgumentDeducer;
+#ifndef __USING_WINDOWS__
   friend class detail::Child;
+#endif
 
   template <typename... Args>
   Popen(const std::string& cmd_args, Args&& ...args):
@@ -1032,7 +1036,9 @@ private:
   std::vector<char*> cargv_;
 
   // Pid of the child process
+#ifndef __USING_WINDOWS__
   int child_pid_ = -1;
+#endif
 
   int retcode_ = -1;
 };


### PR DESCRIPTION
```
Cross compiling ....................... TRUE, for Windows, x86_64
C++ compiler .......................... Clang 19.1.6, /home/win/llvm-mingw-20241217-ucrt-ubuntu-20.04-x86_64/bin/x86_64-w64-mingw32-clang++

gmake[1]: Warning: File 'CMakeFiles/Makefile2' has modification time 1 s in the future
gmake[2]: Warning: File 'src/CMakeFiles/generate_build_info.dir/progress.make' has modification time 0.63 s in the future
gmake[2]: Warning: File 'src/CMakeFiles/crc32c.dir/progress.make' has modification time 0.58 s in the future
gmake[2]: Warning: File 'src/CMakeFiles/leveldb.dir/progress.make' has modification time 0.63 s in the future
gmake[2]: Warning: File 'src/univalue/CMakeFiles/univalue.dir/progress.make' has modification time 0.77 s in the future
gmake[2]: Warning: File 'src/crypto/CMakeFiles/bitcoin_crypto.dir/progress.make' has modification time 0.45 s in the future
gmake[2]: Warning: File 'src/secp256k1/src/CMakeFiles/secp256k1_precomputed.dir/progress.make' has modification time 0.68 s in the future
gmake[2]: Warning: File 'src/CMakeFiles/minisketch.dir/progress.make' has modification time 0.59 s in the future
gmake[2]: Warning: File 'src/CMakeFiles/bitcoin_consensus.dir/progress.make' has modification time 0.41 s in the future
gmake[2]: warning:  Clock skew detected.  Your build may be incomplete.
gmake[2]: warning:  Clock skew detected.  Your build may be incomplete.
gmake[2]: Warning: File 'src/CMakeFiles/generate_build_info.dir/progress.make' has modification time 0.45 s in the future
gmake[2]: Warning: File 'src/CMakeFiles/crc32c.dir/progress.make' has modification time 0.41 s in the future
gmake[2]: warning:  Clock skew detected.  Your build may be incomplete.
gmake[2]: warning:  Clock skew detected.  Your build may be incomplete.
gmake[2]: warning:  Clock skew detected.  Your build may be incomplete.
gmake[2]: warning:  Clock skew detected.  Your build may be incomplete.
gmake[2]: warning:  Clock skew detected.  Your build may be incomplete.
gmake[2]: Warning: File 'src/univalue/CMakeFiles/univalue.dir/progress.make' has modification time 0.42 s in the future
gmake[2]: Warning: File 'src/CMakeFiles/bitcoin_consensus.dir/progress.make' has modification time 0.092 s in the future
gmake[2]: Warning: File 'src/secp256k1/src/CMakeFiles/secp256k1_precomputed.dir/progress.make' has modification time 0.29 s in the future
gmake[2]: Warning: File 'src/CMakeFiles/minisketch.dir/progress.make' has modification time 0.13 s in the future
gmake[2]: warning:  Clock skew detected.  Your build may be incomplete.
[  2%] Building C object src/secp256k1/src/CMakeFiles/secp256k1_precomputed.dir/precomputed_ecmult.c.obj
gmake[2]: warning:  Clock skew detected.  Your build may be incomplete.
[  4%] Building C object src/secp256k1/src/CMakeFiles/secp256k1_precomputed.dir/precomputed_ecmult_gen.c.obj
gmake[2]: warning:  Clock skew detected.  Your build may be incomplete.
[  8%] Building C object src/secp256k1/src/CMakeFiles/exhaustive_tests.dir/tests_exhaustive.c.obj
gmake[2]: warning:  Clock skew detected.  Your build may be incomplete.
[ 11%] Linking C executable ../bin/exhaustive_tests.exe
gmake[2]: warning:  Clock skew detected.  Your build may be incomplete.
[ 15%] Building C object src/secp256k1/src/CMakeFiles/secp256k1.dir/secp256k1.c.obj
gmake[2]: warning:  Clock skew detected.  Your build may be incomplete.
[ 27%] Linking C static library ../lib/libsecp256k1.a
[ 28%] Building C object src/secp256k1/src/CMakeFiles/noverify_tests.dir/tests.c.obj
gmake[2]: warning:  Clock skew detected.  Your build may be incomplete.
[ 29%] Building C object src/secp256k1/src/CMakeFiles/tests.dir/tests.c.obj
[ 32%] Linking C executable ../bin/tests.exe
[ 33%] Linking C executable ../bin/noverify_tests.exe
/mnt/my_storage/bitcoin/src/leveldb/util/env_windows.cc:84:17: warning: unused member function 'operator=' [-Wunused-member-function]
   84 |   ScopedHandle& operator=(ScopedHandle&& rhs) noexcept {
      |                 ^~~~~~~~
1 warning generated.
In file included from /mnt/my_storage/bitcoin/src/util/exec.cpp:8:
/mnt/my_storage/bitcoin/src/util/subprocess.h:1105:29: warning: 'codecvt_utf8_utf16<wchar_t>' is deprecated [-Wdeprecated-declarations]
 1105 |   std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
      |                             ^
/home/win/llvm-mingw-20241217-ucrt-ubuntu-20.04-x86_64/x86_64-w64-mingw32/include/c++/v1/codecvt:568:28: note: 'codecvt_utf8_utf16<wchar_t>' has been explicitly marked deprecated here
  568 | class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17 codecvt_utf8_utf16 : public __codecvt_utf8_utf16<_Elem> {
      |                            ^
/home/win/llvm-mingw-20241217-ucrt-ubuntu-20.04-x86_64/x86_64-w64-mingw32/include/c++/v1/__config:723:41: note: expanded from macro '_LIBCPP_DEPRECATED_IN_CXX17'
  723 | #    define _LIBCPP_DEPRECATED_IN_CXX17 _LIBCPP_DEPRECATED
      |                                         ^
/home/win/llvm-mingw-20241217-ucrt-ubuntu-20.04-x86_64/x86_64-w64-mingw32/include/c++/v1/__config:688:49: note: expanded from macro '_LIBCPP_DEPRECATED'
  688 | #      define _LIBCPP_DEPRECATED __attribute__((__deprecated__))
      |                                                 ^
In file included from /mnt/my_storage/bitcoin/src/util/exec.cpp:8:
/mnt/my_storage/bitcoin/src/util/subprocess.h:1105:8: warning: 'wstring_convert<std::codecvt_utf8_utf16<wchar_t>>' is deprecated [-Wdeprecated-declarations]
 1105 |   std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
      |        ^
/home/win/llvm-mingw-20241217-ucrt-ubuntu-20.04-x86_64/x86_64-w64-mingw32/include/c++/v1/locale:3145:28: note: 'wstring_convert<std::codecvt_utf8_utf16<wchar_t>>' has been explicitly marked deprecated here
 3145 | class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17 wstring_convert {
      |                            ^
/home/win/llvm-mingw-20241217-ucrt-ubuntu-20.04-x86_64/x86_64-w64-mingw32/include/c++/v1/__config:723:41: note: expanded from macro '_LIBCPP_DEPRECATED_IN_CXX17'
  723 | #    define _LIBCPP_DEPRECATED_IN_CXX17 _LIBCPP_DEPRECATED
      |                                         ^
/home/win/llvm-mingw-20241217-ucrt-ubuntu-20.04-x86_64/x86_64-w64-mingw32/include/c++/v1/__config:688:49: note: expanded from macro '_LIBCPP_DEPRECATED'
  688 | #      define _LIBCPP_DEPRECATED __attribute__((__deprecated__))
      |                                                 ^
/mnt/my_storage/bitcoin/src/util/exec.cpp:27:31: warning: 'codecvt_utf8_utf16<wchar_t>' is deprecated [-Wdeprecated-declarations]
   27 |     std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
      |                               ^
/home/win/llvm-mingw-20241217-ucrt-ubuntu-20.04-x86_64/x86_64-w64-mingw32/include/c++/v1/codecvt:568:28: note: 'codecvt_utf8_utf16<wchar_t>' has been explicitly marked deprecated here
  568 | class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17 codecvt_utf8_utf16 : public __codecvt_utf8_utf16<_Elem> {
      |                            ^
/home/win/llvm-mingw-20241217-ucrt-ubuntu-20.04-x86_64/x86_64-w64-mingw32/include/c++/v1/__config:723:41: note: expanded from macro '_LIBCPP_DEPRECATED_IN_CXX17'
  723 | #    define _LIBCPP_DEPRECATED_IN_CXX17 _LIBCPP_DEPRECATED
      |                                         ^
/home/win/llvm-mingw-20241217-ucrt-ubuntu-20.04-x86_64/x86_64-w64-mingw32/include/c++/v1/__config:688:49: note: expanded from macro '_LIBCPP_DEPRECATED'
  688 | #      define _LIBCPP_DEPRECATED __attribute__((__deprecated__))
      |                                                 ^
/mnt/my_storage/bitcoin/src/util/exec.cpp:27:10: warning: 'wstring_convert<std::codecvt_utf8_utf16<wchar_t>>' is deprecated [-Wdeprecated-declarations]
   27 |     std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
      |          ^
/home/win/llvm-mingw-20241217-ucrt-ubuntu-20.04-x86_64/x86_64-w64-mingw32/include/c++/v1/locale:3145:28: note: 'wstring_convert<std::codecvt_utf8_utf16<wchar_t>>' has been explicitly marked deprecated here
 3145 | class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17 wstring_convert {
      |                            ^
/home/win/llvm-mingw-20241217-ucrt-ubuntu-20.04-x86_64/x86_64-w64-mingw32/include/c++/v1/__config:723:41: note: expanded from macro '_LIBCPP_DEPRECATED_IN_CXX17'
  723 | #    define _LIBCPP_DEPRECATED_IN_CXX17 _LIBCPP_DEPRECATED
      |                                         ^
/home/win/llvm-mingw-20241217-ucrt-ubuntu-20.04-x86_64/x86_64-w64-mingw32/include/c++/v1/__config:688:49: note: expanded from macro '_LIBCPP_DEPRECATED'
  688 | #      define _LIBCPP_DEPRECATED __attribute__((__deprecated__))
      |                                                 ^
In file included from /mnt/my_storage/bitcoin/src/util/exec.cpp:8:
/mnt/my_storage/bitcoin/src/util/subprocess.h:759:10: warning: private field 'parent_' is not used [-Wunused-private-field]
  759 |   Popen* parent_ = nullptr;
      |          ^
/mnt/my_storage/bitcoin/src/util/subprocess.h:760:7: warning: private field 'err_wr_pipe_' is not used [-Wunused-private-field]
  760 |   int err_wr_pipe_ = -1;
      |       ^
/mnt/my_storage/bitcoin/src/util/subprocess.h:1038:7: warning: private field 'child_pid_' is not used [-Wunused-private-field]
 1038 |   int child_pid_ = -1;
      |       ^
7 warnings generated.
In file included from /mnt/my_storage/bitcoin/src/common/run_command.cpp:13:
/mnt/my_storage/bitcoin/src/util/subprocess.h:1105:29: warning: 'codecvt_utf8_utf16<wchar_t>' is deprecated [-Wdeprecated-declarations]
 1105 |   std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
      |                             ^
/home/win/llvm-mingw-20241217-ucrt-ubuntu-20.04-x86_64/x86_64-w64-mingw32/include/c++/v1/codecvt:568:28: note: 'codecvt_utf8_utf16<wchar_t>' has been explicitly marked deprecated here
  568 | class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17 codecvt_utf8_utf16 : public __codecvt_utf8_utf16<_Elem> {
      |                            ^
/home/win/llvm-mingw-20241217-ucrt-ubuntu-20.04-x86_64/x86_64-w64-mingw32/include/c++/v1/__config:723:41: note: expanded from macro '_LIBCPP_DEPRECATED_IN_CXX17'
  723 | #    define _LIBCPP_DEPRECATED_IN_CXX17 _LIBCPP_DEPRECATED
      |                                         ^
/home/win/llvm-mingw-20241217-ucrt-ubuntu-20.04-x86_64/x86_64-w64-mingw32/include/c++/v1/__config:688:49: note: expanded from macro '_LIBCPP_DEPRECATED'
  688 | #      define _LIBCPP_DEPRECATED __attribute__((__deprecated__))
      |                                                 ^
In file included from /mnt/my_storage/bitcoin/src/common/run_command.cpp:13:
/mnt/my_storage/bitcoin/src/util/subprocess.h:1105:8: warning: 'wstring_convert<std::codecvt_utf8_utf16<wchar_t>>' is deprecated [-Wdeprecated-declarations]
 1105 |   std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
      |        ^
/home/win/llvm-mingw-20241217-ucrt-ubuntu-20.04-x86_64/x86_64-w64-mingw32/include/c++/v1/locale:3145:28: note: 'wstring_convert<std::codecvt_utf8_utf16<wchar_t>>' has been explicitly marked deprecated here
 3145 | class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17 wstring_convert {
      |                            ^
/home/win/llvm-mingw-20241217-ucrt-ubuntu-20.04-x86_64/x86_64-w64-mingw32/include/c++/v1/__config:723:41: note: expanded from macro '_LIBCPP_DEPRECATED_IN_CXX17'
  723 | #    define _LIBCPP_DEPRECATED_IN_CXX17 _LIBCPP_DEPRECATED
      |                                         ^
/home/win/llvm-mingw-20241217-ucrt-ubuntu-20.04-x86_64/x86_64-w64-mingw32/include/c++/v1/__config:688:49: note: expanded from macro '_LIBCPP_DEPRECATED'
  688 | #      define _LIBCPP_DEPRECATED __attribute__((__deprecated__))
      |                                                 ^
In file included from /mnt/my_storage/bitcoin/src/common/run_command.cpp:13:
/mnt/my_storage/bitcoin/src/util/subprocess.h:759:10: warning: private field 'parent_' is not used [-Wunused-private-field]
  759 |   Popen* parent_ = nullptr;
      |          ^
/mnt/my_storage/bitcoin/src/util/subprocess.h:760:7: warning: private field 'err_wr_pipe_' is not used [-Wunused-private-field]
  760 |   int err_wr_pipe_ = -1;
      |       ^
/mnt/my_storage/bitcoin/src/util/subprocess.h:1038:7: warning: private field 'child_pid_' is not used [-Wunused-private-field]
 1038 |   int child_pid_ = -1;
      |       ^
5 warnings generated.
/mnt/my_storage/bitcoin/src/common/system.cpp:59:53: warning: 'codecvt_utf8_utf16<wchar_t>' is deprecated [-Wdeprecated-declarations]
   59 |     int nErr = ::_wsystem(std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>,wchar_t>().from_bytes(strCommand).c_str());
      |                                                     ^
/home/win/llvm-mingw-20241217-ucrt-ubuntu-20.04-x86_64/x86_64-w64-mingw32/include/c++/v1/codecvt:568:28: note: 'codecvt_utf8_utf16<wchar_t>' has been explicitly marked deprecated here
  568 | class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17 codecvt_utf8_utf16 : public __codecvt_utf8_utf16<_Elem> {
      |                            ^
/home/win/llvm-mingw-20241217-ucrt-ubuntu-20.04-x86_64/x86_64-w64-mingw32/include/c++/v1/__config:723:41: note: expanded from macro '_LIBCPP_DEPRECATED_IN_CXX17'
  723 | #    define _LIBCPP_DEPRECATED_IN_CXX17 _LIBCPP_DEPRECATED
      |                                         ^
/home/win/llvm-mingw-20241217-ucrt-ubuntu-20.04-x86_64/x86_64-w64-mingw32/include/c++/v1/__config:688:49: note: expanded from macro '_LIBCPP_DEPRECATED'
  688 | #      define _LIBCPP_DEPRECATED __attribute__((__deprecated__))
      |                                                 ^
/mnt/my_storage/bitcoin/src/common/system.cpp:59:32: warning: 'wstring_convert<std::codecvt_utf8_utf16<wchar_t>>' is deprecated [-Wdeprecated-declarations]
   59 |     int nErr = ::_wsystem(std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>,wchar_t>().from_bytes(strCommand).c_str());
      |                                ^
/home/win/llvm-mingw-20241217-ucrt-ubuntu-20.04-x86_64/x86_64-w64-mingw32/include/c++/v1/locale:3145:28: note: 'wstring_convert<std::codecvt_utf8_utf16<wchar_t>>' has been explicitly marked deprecated here
 3145 | class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17 wstring_convert {
      |                            ^
/home/win/llvm-mingw-20241217-ucrt-ubuntu-20.04-x86_64/x86_64-w64-mingw32/include/c++/v1/__config:723:41: note: expanded from macro '_LIBCPP_DEPRECATED_IN_CXX17'
  723 | #    define _LIBCPP_DEPRECATED_IN_CXX17 _LIBCPP_DEPRECATED
      |                                         ^
/home/win/llvm-mingw-20241217-ucrt-ubuntu-20.04-x86_64/x86_64-w64-mingw32/include/c++/v1/__config:688:49: note: expanded from macro '_LIBCPP_DEPRECATED'
  688 | #      define _LIBCPP_DEPRECATED __attribute__((__deprecated__))
      |                                                 ^
2 warnings generated.

Scanning dependencies of target bitcoin
gmake[2]: Warning: File 'src/CMakeFiles/bitcoin.dir/depend.make' has modification time 1.1 s in the future
[ 59%] Building RC object src/CMakeFiles/bitcoin.dir/bitcoin-res.rc.res
[ 59%] Building RC object src/CMakeFiles/bitcoin.dir/bitcoin-manifest.rc.res
Scanning dependencies of target bitcoin-cli
gmake[2]: Warning: File 'src/CMakeFiles/bitcoin-cli.dir/depend.make' has modification time 1.2 s in the future
[ 60%] Building RC object src/CMakeFiles/bitcoin-cli.dir/bitcoin-cli-res.rc.res
[ 60%] Building RC object src/CMakeFiles/bitcoin-cli.dir/bitcoin-cli-manifest.rc.res
gmake[2]: warning:  Clock skew detected.  Your build may be incomplete.
Scanning dependencies of target bitcoin-tx
gmake[2]: Warning: File 'src/CMakeFiles/bitcoin-tx.dir/depend.make' has modification time 1.2 s in the future
win@WIN-A2EHOAU4JET:/mnt/my_storage/bitcoin$
Scanning dependencies of target bitcoin-util
gmake[2]: Warning: File 'src/CMakeFiles/bitcoin-util.dir/depend.make' has modification time 1.2 s in the future
[ 61%] Building RC object src/CMakeFiles/bitcoin-util.dir/bitcoin-util-res.rc.res
[ 61%] Building RC object src/CMakeFiles/bitcoin-util.dir/bitcoin-util-manifest.rc.res
gmake[2]: warning:  Clock skew detected.  Your build may be incomplete.
[ 61%] Building RC object src/CMakeFiles/bitcoin-tx.dir/bitcoin-tx-res.rc.res
[ 61%] Building RC object src/CMakeFiles/bitcoin-tx.dir/bitcoin-tx-manifest.rc.res
gmake[2]: warning:  Clock skew detected.  Your build may be incomplete.
Scanning dependencies of target bitcoin-wallet
gmake[2]: Warning: File 'src/CMakeFiles/bitcoin-wallet.dir/depend.make' has modification time 1.1 s in the future
gmake[2]: warning:  Clock skew detected.  Your build may be incomplete.
[ 65%] Building RC object src/CMakeFiles/bitcoin-wallet.dir/bitcoin-wallet-res.rc.res
[ 65%] Building RC object src/CMakeFiles/bitcoin-wallet.dir/bitcoin-wallet-manifest.rc.res
gmake[2]: warning:  Clock skew detected.  Your build may be incomplete.
Scanning dependencies of target bitcoind
gmake[2]: Warning: File 'src/CMakeFiles/bitcoind.dir/depend.make' has modification time 1.1 s in the future
[ 75%] Building RC object src/CMakeFiles/bitcoind.dir/bitcoind-manifest.rc.res
[ 75%] Building RC object src/CMakeFiles/bitcoind.dir/bitcoind-res.rc.res
Scanning dependencies of target test_bitcoin
gmake[2]: Warning: File 'src/test/CMakeFiles/test_bitcoin.dir/depend.make' has modification time 0.96 s in the future
gmake[2]: warning:  Clock skew detected.  Your build may be incomplete.
In file included from /mnt/my_storage/bitcoin/src/test/system_tests.cpp:12:
/mnt/my_storage/bitcoin/src/util/subprocess.h:1105:29: warning: 'codecvt_utf8_utf16<wchar_t>' is deprecated [-Wdeprecated-declarations]
 1105 |   std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
      |                             ^
/home/win/llvm-mingw-20241217-ucrt-ubuntu-20.04-x86_64/x86_64-w64-mingw32/include/c++/v1/codecvt:568:28: note: 'codecvt_utf8_utf16<wchar_t>' has been explicitly marked deprecated here
  568 | class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17 codecvt_utf8_utf16 : public __codecvt_utf8_utf16<_Elem> {
      |                            ^
/home/win/llvm-mingw-20241217-ucrt-ubuntu-20.04-x86_64/x86_64-w64-mingw32/include/c++/v1/__config:723:41: note: expanded from macro '_LIBCPP_DEPRECATED_IN_CXX17'
  723 | #    define _LIBCPP_DEPRECATED_IN_CXX17 _LIBCPP_DEPRECATED
      |                                         ^
/home/win/llvm-mingw-20241217-ucrt-ubuntu-20.04-x86_64/x86_64-w64-mingw32/include/c++/v1/__config:688:49: note: expanded from macro '_LIBCPP_DEPRECATED'
  688 | #      define _LIBCPP_DEPRECATED __attribute__((__deprecated__))
      |                                                 ^
In file included from /mnt/my_storage/bitcoin/src/test/system_tests.cpp:12:
/mnt/my_storage/bitcoin/src/util/subprocess.h:1105:8: warning: 'wstring_convert<std::codecvt_utf8_utf16<wchar_t>>' is deprecated [-Wdeprecated-declarations]
 1105 |   std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
      |        ^
/home/win/llvm-mingw-20241217-ucrt-ubuntu-20.04-x86_64/x86_64-w64-mingw32/include/c++/v1/locale:3145:28: note: 'wstring_convert<std::codecvt_utf8_utf16<wchar_t>>' has been explicitly marked deprecated here
 3145 | class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17 wstring_convert {
      |                            ^
/home/win/llvm-mingw-20241217-ucrt-ubuntu-20.04-x86_64/x86_64-w64-mingw32/include/c++/v1/__config:723:41: note: expanded from macro '_LIBCPP_DEPRECATED_IN_CXX17'
  723 | #    define _LIBCPP_DEPRECATED_IN_CXX17 _LIBCPP_DEPRECATED
      |                                         ^
/home/win/llvm-mingw-20241217-ucrt-ubuntu-20.04-x86_64/x86_64-w64-mingw32/include/c++/v1/__config:688:49: note: expanded from macro '_LIBCPP_DEPRECATED'
  688 | #      define _LIBCPP_DEPRECATED __attribute__((__deprecated__))
      |                                                 ^
In file included from /mnt/my_storage/bitcoin/src/test/system_tests.cpp:12:
/mnt/my_storage/bitcoin/src/util/subprocess.h:759:10: warning: private field 'parent_' is not used [-Wunused-private-field]
  759 |   Popen* parent_ = nullptr;
      |          ^
/mnt/my_storage/bitcoin/src/util/subprocess.h:760:7: warning: private field 'err_wr_pipe_' is not used [-Wunused-private-field]
  760 |   int err_wr_pipe_ = -1;
      |       ^
/mnt/my_storage/bitcoin/src/util/subprocess.h:1038:7: warning: private field 'child_pid_' is not used [-Wunused-private-field]
 1038 |   int child_pid_ = -1;
      |       ^
5 warnings generated.
[ 96%] Building RC object src/test/CMakeFiles/test_bitcoin.dir/test_bitcoin-manifest.rc.res
gmake[2]: warning:  Clock skew detected.  Your build may be incomplete.
```