### PR TITLE
refactor: use time helper utilities for clearer duration conversions

### DIFF
--- a/src/mapport.cpp
+++ b/src/mapport.cpp
@@ -15,6 +15,7 @@
 #include <random.h>
 #include <util/thread.h>
 #include <util/threadinterrupt.h>
+#include <util/time.h>
 
 #include <atomic>
 #include <cassert>
@@ -40,7 +41,7 @@ static void ProcessPCP()
     bool no_resources = false;
     const uint16_t private_port = GetListenPort();
     // Multiply the reannounce period by two, as we'll try to renew approximately halfway.
-    const uint32_t requested_lifetime = std::chrono::seconds(PORT_MAPPING_REANNOUNCE_PERIOD * 2).count();
+    const uint32_t requested_lifetime = count_seconds(PORT_MAPPING_REANNOUNCE_PERIOD * 2);
     uint32_t actual_lifetime = 0;
     std::chrono::milliseconds sleep_time;
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2272,7 +2272,7 @@ void CConnman::ThreadDNSAddressSeed()
     if (!gArgs.GetArgs("-seednode").empty()) {
         auto start = NodeClock::now();
         constexpr std::chrono::seconds SEEDNODE_TIMEOUT = 30s;
-        LogInfo("-seednode enabled. Trying the provided seeds for %d seconds before defaulting to the dnsseeds.\n", SEEDNODE_TIMEOUT.count());
+        LogInfo("-seednode enabled. Trying the provided seeds for %d seconds before defaulting to the dnsseeds.\n", count_seconds(SEEDNODE_TIMEOUT));
         while (!m_interrupt_net->interrupted()) {
             if (!m_interrupt_net->sleep_for(500ms)) {
                 return;
@@ -2330,7 +2330,7 @@ void CConnman::ThreadDNSAddressSeed()
                 seeds_right_now += DNSSEEDS_TO_QUERY_AT_ONCE;
 
                 if (addrman.Size() > 0) {
-                    LogInfo("Waiting %d seconds before querying DNS seeds.\n", seeds_wait_time.count());
+                    LogInfo("Waiting %d seconds before querying DNS seeds.\n", count_seconds(seeds_wait_time));
                     std::chrono::seconds to_wait = seeds_wait_time;
                     while (to_wait.count() > 0) {
                         // if sleeping for the MANY_PEERS interval, wake up
@@ -2594,7 +2594,7 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect, std
             if (addrman.Size() == 0) {
                 LogInfo("Empty addrman, adding seednode (%s) to addrfetch\n", seed);
             } else {
-                LogInfo("Couldn't connect to peers from addrman after %d seconds. Adding seednode (%s) to addrfetch\n", ADD_NEXT_SEEDNODE.count(), seed);
+                LogInfo("Couldn't connect to peers from addrman after %d seconds. Adding seednode (%s) to addrfetch\n", count_seconds(ADD_NEXT_SEEDNODE), seed);
             }
         }
 
@@ -4215,7 +4215,7 @@ static void CaptureMessageToFile(const CAddress& addr,
     fs::path path = base_path / (is_incoming ? "msgs_recv.dat" : "msgs_sent.dat");
     AutoFile f{fsbridge::fopen(path, "ab")};
 
-    ser_writedata64(f, now.count());
+    ser_writedata64(f, count_microseconds(now));
     f << std::span{msg_type};
     for (auto i = msg_type.length(); i < CMessageHeader::MESSAGE_TYPE_SIZE; ++i) {
         f << uint8_t{'\0'};

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -5462,7 +5462,7 @@ void PeerManagerImpl::MaybeSendPing(CNode& node_to, Peer& peer, std::chrono::mic
     {
         // The ping timeout is using mocktime. To disable the check during
         // testing, increase -peertimeout.
-        LogDebug(BCLog::NET, "ping timeout: %fs, %s", 0.000001 * count_microseconds(now - peer.m_ping_start.load()), node_to.DisconnectMsg(fLogIPs));
+        LogDebug(BCLog::NET, "ping timeout: %fs, %s", Ticks<SecondsDouble>(now - peer.m_ping_start.load()), node_to.DisconnectMsg(fLogIPs));
         node_to.fDisconnect = true;
         return;
     }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1338,7 +1338,7 @@ bool PeerManagerImpl::TipMayBeStale()
 
 int64_t PeerManagerImpl::ApproximateBestBlockDepth() const
 {
-    return (GetTime<std::chrono::seconds>() - m_best_block_time.load()).count() / m_chainparams.GetConsensus().nPowTargetSpacing;
+    return count_seconds(GetTime<std::chrono::seconds>() - m_best_block_time.load()) / m_chainparams.GetConsensus().nPowTargetSpacing;
 }
 
 bool PeerManagerImpl::CanDirectFetch()

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -771,7 +771,7 @@ QString formatPingTime(std::chrono::microseconds ping_time)
 {
     return (ping_time == std::chrono::microseconds::max() || ping_time == 0us) ?
         QObject::tr("N/A") :
-        QObject::tr("%1 ms").arg(QString::number((int)(count_microseconds(ping_time) / 1000), 10));
+        QObject::tr("%1 ms").arg(QString::number(Ticks<std::chrono::milliseconds>(ping_time), 10));
 }
 
 QString formatTimeOffset(int64_t time_offset)

--- a/src/test/fuzz/p2p_handshake.cpp
+++ b/src/test/fuzz/p2p_handshake.cpp
@@ -82,8 +82,8 @@ FUZZ_TARGET(p2p_handshake, .init = ::initialize)
 
         SetMockTime(GetTime() +
                     fuzzed_data_provider.ConsumeIntegralInRange<int64_t>(
-                        -std::chrono::seconds{10min}.count(), // Allow mocktime to go backwards slightly
-                        std::chrono::seconds{TIMEOUT_INTERVAL}.count()));
+                        -count_seconds(10min), // Allow mocktime to go backwards slightly
+                        count_seconds(TIMEOUT_INTERVAL)));
 
         CSerializedNetMsg net_msg;
         net_msg.m_type = PickValue(fuzzed_data_provider, ALL_NET_MESSAGE_TYPES);

--- a/src/test/scheduler_tests.cpp
+++ b/src/test/scheduler_tests.cpp
@@ -207,7 +207,7 @@ BOOST_AUTO_TEST_CASE(mockforward)
 
     // check that the time of the remaining job has been updated
     auto now = std::chrono::steady_clock::now();
-    int delta = std::chrono::duration_cast<std::chrono::seconds>(first - now).count();
+    int delta = Ticks<std::chrono::seconds>(first - now);
     // should be between 2 & 3 minutes from now
     BOOST_CHECK(delta > 2*60 && delta < 3*60);
 }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -265,7 +265,7 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
         RemovalReasonToString(reason).c_str(),
         it->GetTxSize(),
         it->GetFee(),
-        std::chrono::duration_cast<std::chrono::duration<std::uint64_t>>(it->GetTime()).count()
+        Ticks<std::chrono::duration<std::uint64_t>>(it->GetTime())
     );
 
     for (const CTxIn& txin : it->GetTx().vin)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1226,7 +1226,7 @@ void MemPoolAccept::FinalizeSubpackage(const ATMPArgs& args)
                 it->GetTx().GetHash().data(),
                 it->GetTxSize(),
                 it->GetFee(),
-                std::chrono::duration_cast<std::chrono::duration<std::uint64_t>>(it->GetTime()).count(),
+                Ticks<std::chrono::duration<std::uint64_t>>(it->GetTime()),
                 tx_or_package_hash.data(),
                 feerate.size,
                 feerate.fee,


### PR DESCRIPTION
### Problem
While investigating https://github.com/bitcoin/bitcoin/pull/34328, I found a few remaining duration conversions that still used direct `.count()` or manual division.

### Fix
Switch them to the existing helpers for clarity using `count_seconds`,`count_microseconds` and `Ticks`.
