### PR TITLE
refactor: use span helpers for byte views

### DIFF
--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_HTTPSERVER_H
 #define BITCOIN_HTTPSERVER_H
 
+#include <span.h>
+
 #include <functional>
 #include <optional>
 #include <span>
@@ -140,7 +142,7 @@ public:
      */
     void WriteReply(int nStatus, std::string_view reply = "")
     {
-        WriteReply(nStatus, std::as_bytes(std::span{reply}));
+        WriteReply(nStatus, MakeByteSpan(reply));
     }
     void WriteReply(int nStatus, std::span<const std::byte> reply);
 };

--- a/src/kernel/bitcoinkernel_wrapper.h
+++ b/src/kernel/bitcoinkernel_wrapper.h
@@ -6,6 +6,7 @@
 #define BITCOIN_KERNEL_BITCOINKERNEL_WRAPPER_H
 
 #include <kernel/bitcoinkernel.h>
+#include <span.h>
 
 #include <array>
 #include <exception>
@@ -479,7 +480,7 @@ public:
     std::array<std::byte, 32> ToBytes() const
     {
         std::array<std::byte, 32> hash;
-        btck_txid_to_bytes(impl(), reinterpret_cast<unsigned char*>(hash.data()));
+        btck_txid_to_bytes(impl(), UCharCast(hash.data()));
         return hash;
     }
 };
@@ -680,7 +681,7 @@ public:
     std::array<std::byte, 32> ToBytes() const
     {
         std::array<std::byte, 32> hash;
-        btck_block_hash_to_bytes(impl(), reinterpret_cast<unsigned char*>(hash.data()));
+        btck_block_hash_to_bytes(impl(), UCharCast(hash.data()));
         return hash;
     }
 };
@@ -695,7 +696,7 @@ class BlockHash : public Handle<btck_BlockHash, btck_block_hash_copy, btck_block
 {
 public:
     explicit BlockHash(const std::array<std::byte, 32>& hash)
-        : Handle{btck_block_hash_create(reinterpret_cast<const unsigned char*>(hash.data()))} {}
+        : Handle{btck_block_hash_create(UCharCast(hash.data()))} {}
 
     explicit BlockHash(btck_BlockHash* hash)
         : Handle{hash} {}

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -16,6 +16,7 @@
 #include <primitives/transaction.h>
 #include <script/interpreter.h>
 #include <script/script.h>
+#include <span.h>
 #include <uint256.h>
 #include <util/chaintype.h>
 #include <util/strencodings.h>
@@ -23,7 +24,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdint>
-#include <cstring>
+#include <string_view>
 #include <type_traits>
 
 using namespace util::hex_literals;
@@ -43,7 +44,7 @@ static CBlock CreateGenesisBlock(const char* pszTimestamp, const CScript& genesi
     txNew.version = 1;
     txNew.vin.resize(1);
     txNew.vout.resize(1);
-    txNew.vin[0].scriptSig = CScript() << 486604799 << CScriptNum(4) << std::vector<unsigned char>((const unsigned char*)pszTimestamp, (const unsigned char*)pszTimestamp + strlen(pszTimestamp));
+    txNew.vin[0].scriptSig = CScript() << 486604799 << CScriptNum(4) << MakeUCharSpan(std::string_view{pszTimestamp});
     txNew.vout[0].nValue = genesisReward;
     txNew.vout[0].scriptPubKey = genesisOutputScript;
 

--- a/src/psbt.h
+++ b/src/psbt.h
@@ -205,7 +205,7 @@ template<typename Stream>
 void DeserializeMuSig2ParticipantPubkeys(Stream& s, SpanReader& skey, std::map<CPubKey, std::vector<CPubKey>>& out, std::string context)
 {
     std::array<unsigned char, CPubKey::COMPRESSED_SIZE> agg_pubkey_bytes;
-    skey >> std::as_writable_bytes(std::span{agg_pubkey_bytes});
+    skey >> MakeWritableByteSpan(agg_pubkey_bytes);
     CPubKey agg_pubkey(agg_pubkey_bytes);
     if (!agg_pubkey.IsFullyValid()) {
         throw std::ios_base::failure(context + " musig2 aggregate pubkey is invalid");
@@ -217,7 +217,7 @@ void DeserializeMuSig2ParticipantPubkeys(Stream& s, SpanReader& skey, std::map<C
     SpanReader s_val{val};
     while (s_val.size() >= CPubKey::COMPRESSED_SIZE) {
         std::array<unsigned char, CPubKey::COMPRESSED_SIZE> part_pubkey_bytes;
-        s_val >> std::as_writable_bytes(std::span{part_pubkey_bytes});
+        s_val >> MakeWritableByteSpan(part_pubkey_bytes);
         CPubKey participant(part_pubkey_bytes);
         if (!participant.IsFullyValid()) {
             throw std::ios_base::failure(context + " musig2 participant pubkey is invalid");
@@ -241,7 +241,7 @@ void DeserializeMuSig2ParticipantDataIdentifier(Stream& skey, CPubKey& agg_pub, 
     std::array<unsigned char, CPubKey::COMPRESSED_SIZE> part_pubkey_bytes;
     std::array<unsigned char, CPubKey::COMPRESSED_SIZE> agg_pubkey_bytes;
 
-    skey >> std::as_writable_bytes(std::span{part_pubkey_bytes}) >> std::as_writable_bytes(std::span{agg_pubkey_bytes});
+    skey >> MakeWritableByteSpan(part_pubkey_bytes) >> MakeWritableByteSpan(agg_pubkey_bytes);
     agg_pub.Set(agg_pubkey_bytes.begin(), agg_pubkey_bytes.end());
     part_pub.Set(part_pubkey_bytes.begin(), part_pubkey_bytes.end());
 

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -1657,7 +1657,7 @@ std::optional<uint32_t> ParseKeyPathNum(std::span<const char> elem, bool& apostr
     if (elem.size() > 0) {
         const char last = elem[elem.size() - 1];
         if (last == '\'' || last == 'h') {
-            elem = elem.first(elem.size() - 1);
+            SpanPopBack(elem);
             hardened = true;
             apostrophe = last == '\'';
         }

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -10,6 +10,7 @@
 #include <crypto/common.h>
 #include <prevector.h> // IWYU pragma: export
 #include <serialize.h>
+#include <span.h>
 #include <uint256.h>
 #include <util/hash_type.h>
 
@@ -483,7 +484,7 @@ public:
     CScript& operator<<(std::span<const std::byte> b) LIFETIMEBOUND
     {
         AppendDataSize(b.size());
-        AppendData({reinterpret_cast<const value_type*>(b.data()), b.size()});
+        AppendData(MakeUCharSpan(b));
         return *this;
     }
 

--- a/src/streams.h
+++ b/src/streams.h
@@ -88,7 +88,7 @@ public:
     /**
      * @param[in]  data Referenced byte vector to overwrite/append
      */
-    explicit SpanReader(std::span<const unsigned char> data) : m_data{std::as_bytes(data)} {}
+    explicit SpanReader(std::span<const unsigned char> data) : m_data{MakeByteSpan(data)} {}
     explicit SpanReader(std::span<const std::byte> data) : m_data{data} {}
 
     template<typename T>
@@ -145,7 +145,7 @@ public:
     typedef vector_type::reverse_iterator reverse_iterator;
 
     explicit DataStream() = default;
-    explicit DataStream(std::span<const uint8_t> sp) : DataStream{std::as_bytes(sp)} {}
+    explicit DataStream(std::span<const uint8_t> sp) : DataStream{MakeByteSpan(sp)} {}
     explicit DataStream(std::span<const value_type> sp) : vch(sp.data(), sp.data() + sp.size()) {}
 
     std::string str() const

--- a/src/test/descriptor_tests.cpp
+++ b/src/test/descriptor_tests.cpp
@@ -9,6 +9,7 @@
 #include <util/check.h>
 #include <util/strencodings.h>
 #include <util/string.h>
+#include <span.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -550,7 +551,7 @@ void CheckInferDescriptor(const std::string& script_hex, const std::string& expe
                 if (elem.size() > 0) {
                     const char last = elem[elem.size() - 1];
                     if (last == '\'' || last == 'h') {
-                        elem = elem.first(elem.size() - 1);
+                        SpanPopBack(elem);
                         hardened = true;
                     }
                 }

--- a/src/test/fuzz/hex.cpp
+++ b/src/test/fuzz/hex.cpp
@@ -11,6 +11,7 @@
 #include <uint256.h>
 #include <univalue.h>
 #include <util/strencodings.h>
+#include <span.h>
 
 #include <algorithm>
 #include <cassert>
@@ -23,7 +24,7 @@ FUZZ_TARGET(hex)
     const std::string random_hex_string(buffer.begin(), buffer.end());
     const std::vector<unsigned char> data = ParseHex(random_hex_string);
     const std::vector<std::byte> bytes{ParseHex<std::byte>(random_hex_string)};
-    assert(std::ranges::equal(std::as_bytes(std::span{data}), bytes));
+    assert(std::ranges::equal(MakeByteSpan(data), bytes));
     const std::string hex_data = HexStr(data);
     if (IsHex(random_hex_string)) {
         assert(ToLower(random_hex_string) == hex_data);

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -9,6 +9,7 @@
 #include <boost/test/included/unit_test.hpp>
 
 #include <test/kernel/block_data.h>
+#include <span.h>
 
 #include <charconv>
 #include <cstdint>
@@ -81,8 +82,8 @@ constexpr auto VERIFY_ALL_PRE_TAPROOT{VERIFY_ALL_PRE_SEGWIT | ScriptVerification
 
 void check_equal(std::span<const std::byte> _actual, std::span<const std::byte> _expected, bool equal = true)
 {
-    std::span<const uint8_t> actual{reinterpret_cast<const unsigned char*>(_actual.data()), _actual.size()};
-    std::span<const uint8_t> expected{reinterpret_cast<const unsigned char*>(_expected.data()), _expected.size()};
+    const auto actual = MakeUCharSpan(_actual);
+    const auto expected = MakeUCharSpan(_expected);
     BOOST_CHECK_EQUAL_COLLECTIONS(
         actual.begin(), actual.end(),
         expected.begin(), expected.end());

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -341,7 +341,7 @@ BOOST_AUTO_TEST_CASE(key_ellswift)
         BOOST_CHECK(key.IsValid());
 
         uint256 ent32 = m_rng.rand256();
-        auto ellswift = key.EllSwiftCreate(std::as_bytes(std::span{ent32}));
+        auto ellswift = key.EllSwiftCreate(MakeByteSpan(ent32));
 
         CPubKey decoded_pubkey = ellswift.Decode();
         if (!key.IsCompressed()) {

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -8,6 +8,7 @@
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <util/chaintype.h>
+#include <util/strencodings.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -196,6 +197,14 @@ BOOST_AUTO_TEST_CASE(ChainParams_REGTEST_sanity)
 BOOST_AUTO_TEST_CASE(ChainParams_TESTNET_sanity)
 {
     sanity_check_chainparams(*m_node.args, ChainType::TESTNET);
+}
+
+BOOST_AUTO_TEST_CASE(ChainParams_MAIN_genesis_scriptsig)
+{
+    const auto chainParams = CreateChainParams(*m_node.args, ChainType::MAIN);
+    const auto& genesis = chainParams->GenesisBlock();
+    const auto& script_sig = genesis.vtx[0]->vin[0].scriptSig;
+    BOOST_CHECK_EQUAL(HexStr(script_sig), "04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73");
 }
 
 BOOST_AUTO_TEST_CASE(ChainParams_TESTNET4_sanity)

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -278,6 +278,51 @@ BOOST_AUTO_TEST_CASE(span_write_bytes)
     BOOST_CHECK_EQUAL(mut_arr.at(1), 0x11);
 }
 
+BOOST_AUTO_TEST_CASE(span_make_byte_span)
+{
+    constexpr std::array<uint8_t, 3> input{0x01, 0x02, 0x03};
+    const auto expected = std::as_bytes(std::span{input});
+    const auto actual = MakeByteSpan(input);
+    BOOST_CHECK_EQUAL_COLLECTIONS(actual.begin(), actual.end(), expected.begin(), expected.end());
+}
+
+BOOST_AUTO_TEST_CASE(span_make_writable_byte_span)
+{
+    std::array<uint8_t, 2> input{0x0a, 0x0b};
+    const auto expected = std::as_writable_bytes(std::span{input});
+    const auto actual = MakeWritableByteSpan(input);
+    BOOST_CHECK_EQUAL(actual.data(), expected.data());
+    BOOST_CHECK_EQUAL(actual.size(), expected.size());
+}
+
+BOOST_AUTO_TEST_CASE(span_make_uchar_span)
+{
+    std::array<std::byte, 2> bytes{std::byte{0x12}, std::byte{0x34}};
+    const auto span = MakeUCharSpan(bytes);
+    BOOST_CHECK_EQUAL(span.size(), bytes.size());
+    BOOST_CHECK_EQUAL(span[0], 0x12);
+    BOOST_CHECK_EQUAL(span[1], 0x34);
+}
+
+BOOST_AUTO_TEST_CASE(span_uchar_cast)
+{
+    std::array<std::byte, 2> bytes{std::byte{0xab}, std::byte{0xcd}};
+    const auto ptr = UCharCast(bytes.data());
+    BOOST_CHECK_EQUAL(ptr[0], 0xab);
+    BOOST_CHECK_EQUAL(ptr[1], 0xcd);
+}
+
+BOOST_AUTO_TEST_CASE(span_pop_back)
+{
+    std::array values{1, 2, 3};
+    std::span<int> span{values};
+    const int last = SpanPopBack(span);
+    BOOST_CHECK_EQUAL(last, 3);
+    BOOST_CHECK_EQUAL(span.size(), 2);
+    BOOST_CHECK_EQUAL(span[0], 1);
+    BOOST_CHECK_EQUAL(span[1], 2);
+}
+
 BOOST_AUTO_TEST_CASE(util_Join)
 {
     // Normal version

--- a/src/wallet/migrate.cpp
+++ b/src/wallet/migrate.cpp
@@ -249,7 +249,7 @@ public:
     void Unserialize(Stream& s)
     {
         data.resize(m_header.len);
-        s.read(std::as_writable_bytes(std::span(data.data(), data.size())));
+        s.read(MakeWritableByteSpan(data));
     }
 };
 
@@ -277,7 +277,7 @@ public:
         s >> records;
 
         data.resize(m_header.len);
-        s.read(std::as_writable_bytes(std::span(data.data(), data.size())));
+        s.read(MakeWritableByteSpan(data));
 
         if (m_header.other_endian) {
             page_num = internal_bswap_32(page_num);
@@ -461,7 +461,7 @@ public:
     void Unserialize(Stream& s)
     {
         data.resize(m_header.hf_offset);
-        s.read(std::as_writable_bytes(std::span(data.data(), data.size())));
+        s.read(MakeWritableByteSpan(data));
     }
 };
 

--- a/src/wallet/test/db_tests.cpp
+++ b/src/wallet/test/db_tests.cpp
@@ -8,6 +8,7 @@
 #include <util/check.h>
 #include <util/fs.h>
 #include <util/translation.h>
+#include <span.h>
 #include <wallet/sqlite.h>
 #include <wallet/migrate.h>
 #include <wallet/test/util.h>
@@ -32,14 +33,9 @@ inline std::ostream& operator<<(std::ostream& os, const std::pair<const Serializ
 
 namespace wallet {
 
-inline std::span<const std::byte> StringBytes(std::string_view str)
-{
-    return std::as_bytes(std::span{str});
-}
-
 static SerializeData StringData(std::string_view str)
 {
-    auto bytes = StringBytes(str);
+    auto bytes = MakeByteSpan(str);
     return SerializeData{bytes.begin(), bytes.end()};
 }
 
@@ -137,10 +133,10 @@ BOOST_AUTO_TEST_CASE(db_cursor_prefix_byte_test)
             batch->Write(std::span{k}, std::span{v});
         }
 
-        CheckPrefix(*batch, StringBytes(""), {e, p, ps, f, fs, ff, ffs});
-        CheckPrefix(*batch, StringBytes("prefix"), {p, ps});
-        CheckPrefix(*batch, StringBytes("\xff"), {f, fs, ff, ffs});
-        CheckPrefix(*batch, StringBytes("\xff\xff"), {ff, ffs});
+        CheckPrefix(*batch, MakeByteSpan(""), {e, p, ps, f, fs, ff, ffs});
+        CheckPrefix(*batch, MakeByteSpan("prefix"), {p, ps});
+        CheckPrefix(*batch, MakeByteSpan("\xff"), {f, fs, ff, ffs});
+        CheckPrefix(*batch, MakeByteSpan("\xff\xff"), {ff, ffs});
         batch.reset();
         database->Close();
     }


### PR DESCRIPTION
- Standardize byte/span conversions to the project’s helpers to reduce manual casts and make intent clearer.
- Reduce repeated boilerplate for spans and bytes without changing behavior.
- Add a focused test that locks in the mainnet genesis scriptSig bytes, so the consensus critical genesis construction can be refactored safely.

- Replace ad hoc byte/span conversions with MakeByteSpan, MakeWritableByteSpan, MakeUCharSpan, UCharCast, and SpanPopBack.
- Switch genesis timestamp bytes to MakeUCharSpan(std::string_view{...}) with no change to output.
