### PR TITLE
net_processing: randomize start time of private broadcast

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -679,6 +679,11 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
                    DEFAULT_PRIVATE_BROADCAST),
                    ArgsManager::ALLOW_ANY,
                    OptionsCategory::NODE_RELAY);
+    argsman.AddArg("-privatebroadcastdelay=<n>",
+                   strprintf("Maximum random delay in milliseconds before starting private broadcast for transactions submitted via sendrawtransaction (default: %u). Set to 0 to disable.",
+                             Ticks<std::chrono::milliseconds>(DEFAULT_PRIVATE_BROADCAST_DELAY_MAX)),
+                   ArgsManager::ALLOW_ANY,
+                   OptionsCategory::NODE_RELAY);
     argsman.AddArg("-whitelistforcerelay", strprintf("Add 'forcerelay' permission to whitelisted peers with default permissions. This will relay transactions even if the transactions were already in the mempool. (default: %d)", DEFAULT_WHITELISTFORCERELAY), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-whitelistrelay", strprintf("Add 'relay' permission to whitelisted peers with default permissions. This will accept relayed transactions even when not relaying transactions (default: %d)", DEFAULT_WHITELISTRELAY), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
 

--- a/src/net.h
+++ b/src/net.h
@@ -87,6 +87,8 @@ static const bool DEFAULT_BLOCKSONLY = false;
 static const int64_t DEFAULT_PEER_CONNECT_TIMEOUT = 60;
 /** Default for -privatebroadcast. */
 static constexpr bool DEFAULT_PRIVATE_BROADCAST{false};
+/** Default for -privatebroadcastdelay. */
+static constexpr auto DEFAULT_PRIVATE_BROADCAST_DELAY_MAX{5s};
 /** Number of file descriptors required for message capture **/
 static const int NUM_FDS_MESSAGE_CAPTURE = 1;
 /** Interval for ASMap Health Check **/

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -92,6 +92,8 @@ public:
         uint32_t max_headers_result{MAX_HEADERS_RESULTS};
         //! Whether private broadcast is used for sending transactions.
         bool private_broadcast{DEFAULT_PRIVATE_BROADCAST};
+        //! Maximum random delay before starting private broadcast for transactions submitted via sendrawtransaction.
+        std::chrono::milliseconds private_broadcast_delay_max{0};
     };
 
     static std::unique_ptr<PeerManager> make(CConnman& connman, AddrMan& addrman,

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -93,7 +93,7 @@ public:
         //! Whether private broadcast is used for sending transactions.
         bool private_broadcast{DEFAULT_PRIVATE_BROADCAST};
         //! Maximum random delay before starting private broadcast for transactions submitted via sendrawtransaction.
-        std::chrono::milliseconds private_broadcast_delay_max{0};
+        std::chrono::milliseconds private_broadcast_delay_max{DEFAULT_PRIVATE_BROADCAST_DELAY_MAX};
     };
 
     static std::unique_ptr<PeerManager> make(CConnman& connman, AddrMan& addrman,

--- a/src/node/peerman_args.cpp
+++ b/src/node/peerman_args.cpp
@@ -25,7 +25,10 @@ void ApplyArgsManOptions(const ArgsManager& argsman, PeerManager::Options& optio
     if (auto value{argsman.GetBoolArg("-blocksonly")}) options.ignore_incoming_txs = *value;
 
     if (auto value{argsman.GetBoolArg("-privatebroadcast")}) options.private_broadcast = *value;
+
+    if (auto value{argsman.GetIntArg("-privatebroadcastdelay")}) {
+        options.private_broadcast_delay_max = std::chrono::milliseconds{std::max<int64_t>(*value, 0)};
+    }
 }
 
 } // namespace node
-

--- a/test/functional/p2p_private_broadcast.py
+++ b/test/functional/p2p_private_broadcast.py
@@ -246,6 +246,7 @@ class P2PPrivateBroadcast(BitcoinTestFramework):
                 "-v2transport=0",
                 "-test=addrman",
                 "-privatebroadcast",
+                "-privatebroadcastdelay=0",
                 f"-proxy={socks5_server_config.addr[0]}:{socks5_server_config.addr[1]}",
                 # To increase coverage, make it think that the I2P network is reachable so that it
                 # selects such addresses as well. Pick a proxy address where nobody is listening


### PR DESCRIPTION
Add a small random delay before starting private-broadcast connections for transactions submitted via `sendrawtransaction` (when `-privatebroadcast=1`), to reduce timing correlation between unrelated broadcasts.

The new `-privatebroadcastdelay=<ms>` configuration option defaults to 5s max.