### PR TITLE
http: avoid copying large reply bodies

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -514,7 +514,7 @@ bool HTTPRequest::LoadBody(LineReader& reader)
     }
 }
 
-void HTTPRequest::WriteReplyImpl(HTTPStatusCode status, std::span<const std::byte> reply_body)
+void HTTPRequest::WriteReplyImpl(HTTPStatusCode status, std::span<const std::byte> reply_body, std::string* moved_body)
 {
     HTTPResponse res;
 
@@ -562,9 +562,9 @@ void HTTPRequest::WriteReplyImpl(HTTPStatusCode status, std::span<const std::byt
         }
     }
 
-    if (needs_content_length) {
-        res.m_headers.Write("Content-Length", util::ToString(reply_body.size()));
-    }
+    const bool moving_body{moved_body != nullptr};
+    const size_t body_size{moving_body ? moved_body->size() : reply_body.size()};
+    if (needs_content_length) res.m_headers.Write("Content-Length", util::ToString(body_size));
 
     if (needs_body && !res.m_headers.FindFirst("Content-Type")) {
         // Default type from libevent evhttp_new_object()
@@ -584,23 +584,26 @@ void HTTPRequest::WriteReplyImpl(HTTPStatusCode status, std::span<const std::byt
 
     // Serialize the response headers
     std::string response{res.StringifyHeaders()};
-    const size_t response_size{response.size() + reply_body.size()};
+    const size_t response_size{response.size() + body_size};
 
-    if (reply_body.size() >= LARGE_HTTP_REPLY_BYTES) {
-        LogDebug(BCLog::HTTP, "Large HTTP reply body copied: status=%d bytes=%d", status, reply_body.size());
+    if (body_size >= LARGE_HTTP_REPLY_BYTES) {
+        LogDebug(BCLog::HTTP, "Large HTTP reply body %s: status=%d bytes=%d", moving_body ? "moved" : "copied", status, body_size);
     }
 
-    // We've been using std::span up until now but it is finally time to copy
-    // data. The original data will go out of scope when WriteReply() returns.
-    // This is analogous to the memcpy() in libevent's evbuffer_add()
-    if (!reply_body.empty()) response.append(reinterpret_cast<const char*>(reply_body.data()), reply_body.size());
+    if (!moving_body) {
+        // We've been using std::span up until now but it is finally time to copy
+        // data. The original data will go out of scope when WriteReply() returns.
+        // This is analogous to the memcpy() in libevent's evbuffer_add()
+        if (!reply_body.empty()) response.append(reinterpret_cast<const char*>(reply_body.data()), reply_body.size());
+    }
 
     bool send_buffer_was_empty{false};
-    // Fill the send buffer with the complete serialized response headers + body
+    // Queue the serialized response headers and body.
     {
         LOCK(m_client->m_send_mutex);
         send_buffer_was_empty = m_client->m_send_buffer.empty();
         m_client->m_send_buffer.emplace_back(std::move(response));
+        if (moving_body && !moved_body->empty()) m_client->m_send_buffer.emplace_back(std::move(*moved_body));
 
         // If the buffer already held data, the I/O thread is (or soon will be)
         // draining it, so flag that there is more data to send. This must happen

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -583,24 +583,24 @@ void HTTPRequest::WriteReply(HTTPStatusCode status, std::span<const std::byte> r
     m_client->m_keep_alive = keep_alive;
 
     // Serialize the response headers
-    const std::string headers{res.StringifyHeaders()};
-    const auto headers_bytes{std::as_bytes(std::span{headers})};
+    std::string response{res.StringifyHeaders()};
+    const size_t response_size{response.size() + reply_body.size()};
 
     if (reply_body.size() >= LARGE_HTTP_REPLY_BYTES) {
         LogDebug(BCLog::HTTP, "Large HTTP reply body copied: status=%d bytes=%d", status, reply_body.size());
     }
+
+    // We've been using std::span up until now but it is finally time to copy
+    // data. The original data will go out of scope when WriteReply() returns.
+    // This is analogous to the memcpy() in libevent's evbuffer_add()
+    if (!reply_body.empty()) response.append(reinterpret_cast<const char*>(reply_body.data()), reply_body.size());
 
     bool send_buffer_was_empty{false};
     // Fill the send buffer with the complete serialized response headers + body
     {
         LOCK(m_client->m_send_mutex);
         send_buffer_was_empty = m_client->m_send_buffer.empty();
-        m_client->m_send_buffer.insert(m_client->m_send_buffer.end(), headers_bytes.begin(), headers_bytes.end());
-
-        // We've been using std::span up until now but it is finally time to copy
-        // data. The original data will go out of scope when WriteReply() returns.
-        // This is analogous to the memcpy() in libevent's evbuffer_add()
-        m_client->m_send_buffer.insert(m_client->m_send_buffer.end(), reply_body.begin(), reply_body.end());
+        m_client->m_send_buffer.emplace_back(std::move(response));
 
         // If the buffer already held data, the I/O thread is (or soon will be)
         // draining it, so flag that there is more data to send. This must happen
@@ -617,7 +617,7 @@ void HTTPRequest::WriteReply(HTTPStatusCode status, std::span<const std::byte> r
         BCLog::HTTP,
         "HTTPResponse (status code: %d size: %lld) added to send buffer for client %s (id=%llu)",
         status,
-        headers_bytes.size() + reply_body.size(),
+        response_size,
         m_client->m_origin,
         m_client->m_id);
 
@@ -1135,6 +1135,8 @@ bool HTTPRemoteClient::MaybeSendBytesFromBuffer()
     // Send as much data from this client's buffer as we can
     LOCK(m_send_mutex);
     if (!m_send_buffer.empty()) {
+        auto& front{m_send_buffer.front()};
+
         // Socket flags (See kernel docs for send(2) and tcp(7) for more details).
         // MSG_NOSIGNAL: If the remote end of the connection is closed,
         //               fail with EPIPE (an error) as opposed to triggering
@@ -1149,9 +1151,7 @@ bool HTTPRemoteClient::MaybeSendBytesFromBuffer()
         ssize_t bytes_sent;
         {
             LOCK(m_sock_mutex);
-            bytes_sent = m_sock->Send(m_send_buffer.data(),
-                                      m_send_buffer.size(),
-                                      flags);
+            bytes_sent = m_sock->Send(front.data(), front.size(), flags);
         }
 
         if (bytes_sent < 0) {
@@ -1179,14 +1179,15 @@ bool HTTPRemoteClient::MaybeSendBytesFromBuffer()
         }
 
         // Successful send, remove sent bytes from our local buffer.
-        Assume(static_cast<size_t>(bytes_sent) <= m_send_buffer.size());
-        m_send_buffer.erase(m_send_buffer.begin(),
-                            m_send_buffer.begin() + bytes_sent);
+        const size_t sent{static_cast<size_t>(bytes_sent)};
+        Assume(sent <= front.size());
+        front.erase(0, sent);
+        if (front.empty()) m_send_buffer.pop_front();
 
         LogDebug(
             BCLog::HTTP,
             "Sent %d bytes to client %s (id=%llu)",
-            bytes_sent,
+            sent,
             m_origin,
             m_id);
 

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -514,7 +514,7 @@ bool HTTPRequest::LoadBody(LineReader& reader)
     }
 }
 
-void HTTPRequest::WriteReply(HTTPStatusCode status, std::span<const std::byte> reply_body)
+void HTTPRequest::WriteReplyImpl(HTTPStatusCode status, std::span<const std::byte> reply_body)
 {
     HTTPResponse res;
 
@@ -631,6 +631,11 @@ void HTTPRequest::WriteReply(HTTPStatusCode status, std::span<const std::byte> r
 
     // Signal to the I/O loop that we are ready to handle the next request.
     m_client->m_req_busy = false;
+}
+
+void HTTPRequest::WriteReply(HTTPStatusCode status, std::span<const std::byte> reply_body)
+{
+    WriteReplyImpl(status, reply_body);
 }
 
 CService HTTPRequest::GetPeer() const

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -47,6 +47,8 @@
 //! the sleep time needs to be small to avoid new sockets stalling.
 static constexpr auto SELECT_TIMEOUT{50ms};
 
+static constexpr size_t LARGE_HTTP_REPLY_BYTES{16_MiB};
+
 //! Explicit alias for setting socket option methods.
 static constexpr int SOCKET_OPTION_TRUE{1};
 
@@ -583,6 +585,10 @@ void HTTPRequest::WriteReply(HTTPStatusCode status, std::span<const std::byte> r
     // Serialize the response headers
     const std::string headers{res.StringifyHeaders()};
     const auto headers_bytes{std::as_bytes(std::span{headers})};
+
+    if (reply_body.size() >= LARGE_HTTP_REPLY_BYTES) {
+        LogDebug(BCLog::HTTP, "Large HTTP reply body copied: status=%d bytes=%d", status, reply_body.size());
+    }
 
     bool send_buffer_was_empty{false};
     // Fill the send buffer with the complete serialized response headers + body

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -641,6 +641,17 @@ void HTTPRequest::WriteReply(HTTPStatusCode status, std::span<const std::byte> r
     WriteReplyImpl(status, reply_body);
 }
 
+void HTTPRequest::WriteReply(HTTPStatusCode status, std::string&& reply_body)
+{
+    // Keep small replies coalesced in one send chunk.
+    if (reply_body.size() < LARGE_HTTP_REPLY_BYTES) {
+        WriteReply(status, std::string_view{reply_body});
+        return;
+    }
+
+    WriteReplyImpl(status, {}, &reply_body);
+}
+
 CService HTTPRequest::GetPeer() const
 {
     return m_client->m_addr;

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -1136,6 +1136,7 @@ bool HTTPRemoteClient::MaybeSendBytesFromBuffer()
     LOCK(m_send_mutex);
     if (!m_send_buffer.empty()) {
         auto& front{m_send_buffer.front()};
+        Assume(m_send_offset < front.size());
 
         // Socket flags (See kernel docs for send(2) and tcp(7) for more details).
         // MSG_NOSIGNAL: If the remote end of the connection is closed,
@@ -1151,7 +1152,7 @@ bool HTTPRemoteClient::MaybeSendBytesFromBuffer()
         ssize_t bytes_sent;
         {
             LOCK(m_sock_mutex);
-            bytes_sent = m_sock->Send(front.data(), front.size(), flags);
+            bytes_sent = m_sock->Send(front.data() + m_send_offset, front.size() - m_send_offset, flags);
         }
 
         if (bytes_sent < 0) {
@@ -1178,11 +1179,14 @@ bool HTTPRemoteClient::MaybeSendBytesFromBuffer()
             }
         }
 
-        // Successful send, remove sent bytes from our local buffer.
+        // Successful send, skip sent bytes in our local buffer.
         const size_t sent{static_cast<size_t>(bytes_sent)};
-        Assume(sent <= front.size());
-        front.erase(0, sent);
-        if (front.empty()) m_send_buffer.pop_front();
+        Assume(sent <= front.size() - m_send_offset);
+        m_send_offset += sent;
+        if (m_send_offset == front.size()) {
+            m_send_buffer.pop_front();
+            m_send_offset = 0;
+        }
 
         LogDebug(
             BCLog::HTTP,

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -197,7 +197,7 @@ public:
     void WriteHeader(std::string&& hdr, std::string&& value);
 
 private:
-    void WriteReplyImpl(HTTPStatusCode status, std::span<const std::byte> reply_body);
+    void WriteReplyImpl(HTTPStatusCode status, std::span<const std::byte> reply_body, std::string* moved_body = nullptr);
 };
 
 class HTTPServer

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -195,6 +195,9 @@ public:
     std::pair<bool, std::string> GetHeader(std::string_view hdr) const;
     std::string ReadBody() const { return m_body; }
     void WriteHeader(std::string&& hdr, std::string&& value);
+
+private:
+    void WriteReplyImpl(HTTPStatusCode status, std::span<const std::byte> reply_body);
 };
 
 class HTTPServer

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -475,11 +475,13 @@ public:
 
     /**
      * Response data destined for this client.
-     * Written to by http worker threads, read and erased by HTTPServer I/O thread
+     * Written to by http worker threads, read by HTTPServer I/O thread
      */
     /// @{
     Mutex m_send_mutex;
     std::deque<std::string> m_send_buffer GUARDED_BY(m_send_mutex);
+    //! Bytes of m_send_buffer.front() already sent
+    size_t m_send_offset GUARDED_BY(m_send_mutex){0};
     /// @}
 
     /**

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -479,7 +479,7 @@ public:
      */
     /// @{
     Mutex m_send_mutex;
-    std::vector<std::byte> m_send_buffer GUARDED_BY(m_send_mutex);
+    std::deque<std::string> m_send_buffer GUARDED_BY(m_send_mutex);
     /// @}
 
     /**

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -181,10 +181,16 @@ public:
     /// @}
 
     void WriteReply(HTTPStatusCode status, std::span<const std::byte> reply_body = {});
+    //! Keeps string literals from becoming ambiguous after adding the std::string&& overload
+    void WriteReply(HTTPStatusCode status, const char* reply_body)
+    {
+        WriteReply(status, std::string_view{reply_body});
+    }
     void WriteReply(HTTPStatusCode status, std::string_view reply_body_view)
     {
         WriteReply(status, std::as_bytes(std::span{reply_body_view}));
     }
+    void WriteReply(HTTPStatusCode status, std::string&& reply_body);
 
     // These methods reimplement the API from http_libevent::HTTPRequest
     // for downstream JSONRPC and REST modules.

--- a/src/test/httpserver_tests.cpp
+++ b/src/test/httpserver_tests.cpp
@@ -5,7 +5,6 @@
 #include <httpserver.h>
 #include <rpc/protocol.h>
 #include <test/util/common.h>
-#include <test/util/logging.h>
 #include <test/util/setup_common.h>
 #include <util/string.h>
 #include <util/threadpool.h>
@@ -648,22 +647,9 @@ BOOST_AUTO_TEST_CASE(http_socket_error_tests)
         Assert(workers.Submit(std::move(item)));
     }};
 
-    // All replies will be the same size
-    static constexpr std::size_t reply_length = std::string_view{
-        "HTTP/1.1 200 OK\r\n"
-        "Date: Thu, 01 Jan 2026 00:00:00 GMT\r\n"           // All RFC1123 dates are 29 characters
-        "Content-Length: 10\r\n"
-        "Content-Type: text/html; charset=ISO-8859-1\r\n"
-        "\r\n"
-        "height: 0\n"
-    }.size();
-
     /**
-     * A mocked Sock derived from DynSock whose Send() only succeeds when there is more than
-     * one reply being sent (send buffer length > reply_length). Otherwise it returns
-     * a recoverable error (WSAEAGAIN).
-     *
-     * After it sends successfully once, it continues to always succeed.
+     * A mocked Sock derived from DynSock whose first Send() returns a
+     * recoverable error (WSAEAGAIN). After that it continues to always succeed.
      *
      * Useful for testing "try again" logic around non-blocking socket Send() failures.
      */
@@ -675,20 +661,20 @@ BOOST_AUTO_TEST_CASE(http_socket_error_tests)
 
         ssize_t Send(const void* buf, size_t len, int flags) const override
         {
-            if (len <= reply_length && !m_have_sent) {
+            if (!m_have_failed) {
                 #ifdef WIN32
                 WSASetLastError(WSAEWOULDBLOCK);
                 #else
                 errno = WSAEAGAIN;
                 #endif
+                m_have_failed = true;
                 return -1;
             } else {
-                m_have_sent = true;
                 return DynSock::Send(buf, len, flags);
             }
         }
 
-        mutable bool m_have_sent{false};
+        mutable bool m_have_failed{false};
     };
 
     // Simpler server startup than the last test
@@ -706,21 +692,6 @@ BOOST_AUTO_TEST_CASE(http_socket_error_tests)
     for (int i = 0; i < num_requests; i++) {
         all_requests += keepalive_request;
     }
-
-    // Watch the log messages to ensure that the first two replies were sent
-    // together. This indicates the non-optimistic send path was used
-    // because a reply was already sitting in the send buffer when a second reply
-    // was added.
-    DebugLogHelper find_two_replies{strprintf("Sent %d bytes to client", reply_length * 2),
-                                    [&](const std::string* s) {
-                                        return true;
-                                    }};
-    // Last reply should be sent on its own by optimistic send path, because
-    // the send buffer was empty when the reply was written.
-    DebugLogHelper find_one_reply{strprintf("Sent %d bytes to client", reply_length),
-                                  [&](const std::string* s) {
-                                      return true;
-                                   }};
 
     // Connect the ErrorSock as mock client with the preloaded data and get a handle on the I/O pipes
     std::shared_ptr<ErrorSock::Pipes> mock_client_socket_pipes{

--- a/test/functional/rpc_batch_large_reply.py
+++ b/test/functional/rpc_batch_large_reply.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Exercise large JSON-RPC batch replies.
+
+This test creates a large RPC reply and asserts it is served through the
+expected HTTP reply path.
+"""
+
+import http.client
+import json
+from urllib.parse import urlparse
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    create_lots_of_big_transactions,
+    gen_return_txouts,
+    str_to_b64str,
+)
+from test_framework.wallet import MiniWallet
+
+
+def raw_jsonrpc_request(url, payload, *, timeout):
+    parsed = urlparse(url)
+    assert parsed.hostname and parsed.port and None not in (parsed.username, parsed.password)
+
+    auth_b64 = str_to_b64str(f"{parsed.username}:{parsed.password}")
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Basic {auth_b64}",
+    }
+
+    conn = http.client.HTTPConnection(parsed.hostname, parsed.port, timeout=timeout)
+    conn.request("POST", "/", body=payload, headers=headers)
+    response = conn.getresponse()
+    while response.read(64 * 1024):
+        pass
+    conn.close()
+    return response.status
+
+
+class RPCBatchLargeReplyTest(BitcoinTestFramework):
+    def add_options(self, parser):
+        parser.add_argument("--target-response-mib", default=32, type=int)
+
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def run_test(self):
+        self.skip_if_running_under_valgrind()
+
+        node = self.nodes[0]
+        mini_wallet = MiniWallet(node)
+        # Create enough mature coinbase UTXOs for multiple spends.
+        self.generate(mini_wallet, 120)
+
+        txouts = gen_return_txouts()
+        fee = 100 * node.getnetworkinfo()["relayfee"]
+        create_lots_of_big_transactions(mini_wallet, node, fee, tx_batch_size=8, txouts=txouts)
+        self.generate(mini_wallet, 1)
+
+        block_hash = node.getbestblockhash()
+        # Fetch metadata here; the batch request materializes the block hex
+        block_size = node.getblock(block_hash, 1)["size"]
+        block_hex_len = block_size * 2
+
+        # Cross the HTTP server's large-reply log threshold
+        target_response_bytes = self.options.target_response_mib * 1024 * 1024
+        batch_size = (target_response_bytes + block_hex_len - 1) // block_hex_len
+
+        batch = [
+            {"jsonrpc": "2.0", "id": i, "method": "getblock", "params": [block_hash, 0]}
+            for i in range(batch_size)
+        ]
+        payload = json.dumps(batch).encode()
+
+        with node.assert_debug_log(["Large HTTP reply body copied:"]):
+            status = raw_jsonrpc_request(node.url, payload, timeout=120)
+        assert_equal(status, 200)
+        assert node.process.poll() is None
+
+
+if __name__ == "__main__":
+    RPCBatchLargeReplyTest(__file__).main()

--- a/test/functional/rpc_batch_large_reply.py
+++ b/test/functional/rpc_batch_large_reply.py
@@ -77,7 +77,7 @@ class RPCBatchLargeReplyTest(BitcoinTestFramework):
         ]
         payload = json.dumps(batch).encode()
 
-        with node.assert_debug_log(["Large HTTP reply body copied:"]):
+        with node.assert_debug_log(["Large HTTP reply body moved:"], unexpected_msgs=["Large HTTP reply body copied:"]):
             status = raw_jsonrpc_request(node.url, payload, timeout=120)
         assert_equal(status, 200)
         assert node.process.poll() is None

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -140,6 +140,7 @@ BASE_SCRIPTS = [
     'wallet_taproot.py',
     'feature_bip68_sequence.py',
     'rpc_packages.py',
+    'rpc_batch_large_reply.py',
     'rpc_bind.py --ipv4',
     'rpc_bind.py --ipv6',
     'rpc_bind.py --nonloopback',


### PR DESCRIPTION
Fixes #31041

**Problem:** Large JSON-RPC batch responses are serialized into a temporary `std::string` by the RPC layer, then copied into the HTTP client's send buffer before being drained to the socket.
That extra full-body copy can push low-memory systems over the edge for indexer-style batches.

**Fix:** Store queued HTTP reply data as owned `std::string` chunks and add an rvalue `HTTPRequest::WriteReply` overload so temporary response strings can move into the send queue.
Borrowed spans and string views still copy into a single headers-plus-body chunk, preserving the small-reply path, while temporary JSON-RPC response strings queue the headers and moved body as separate owned chunks.
The send loop drains chunks with an offset into the front chunk, so partial sends do not copy the unsent tail and transient send failures still use the normal readiness and idle-time accounting.

<details><summary>Peak RSS per commit (1598.8 MiB down to 1077.6 MiB)</summary>

```bash
out=/tmp/rpc-rss-by-commit.tsv
printf "commit\tpeak_mib\trc\tsubject\n" > "$out"
for c in $(git rev-list origin/master..HEAD); do
  git checkout -q "$c" || break
  (cmake -B build >/tmp/rpc-build.log 2>&1 && \
    cmake --build build -j --target bitcoind bitcoin-cli >>/tmp/rpc-build.log 2>&1 && \
    build/test/functional/test_runner.py rpc_batch_large_reply.py --target-response-mib=512) &
  pid=$!
  peak=$(while ps -p "$pid" >/dev/null; do ps -axo rss=,command=; sleep 0.01; done \
    | awk "/[b]itcoind/ && /rpc_batch_large_reply_/ && \$1 > max {max=\$1} END {printf \"%.1f\", max/1024}")
  wait "$pid"; rc=$?
  printf "%s\t%s\t%s\t%s\n" \
    "$(git rev-parse --short HEAD)" "$peak" "$rc" "$(git show -s --format=%s)" >> "$out"
done
git checkout -q "$start"
column -t -s $'\t' "$out"
```

> 9265e2d680 1077.6 0 http: move large temporary reply bodies
c097a60d3b 1598.8 0 http: allow reply helper to queue moved bodies
3e62a3c383 1598.6 0 http: move reply writing to member helper
3491187726 1598.5 0 http: drain send chunks by offset
87eeb9f271 1598.8 0 http: store queued replies as strings
634b3c25d0 1598.8 0 test: decouple HTTP retry test from send coalescing
6f503f80f3 1598.8 0 http, test: exercise large RPC batch replies
</details>