### PR TITLE
refactor: enable move-const-arg trivially-copyable check

### DIFF
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -36,8 +36,6 @@ WarningsAsErrors: '*'
 CheckOptions:
  - key: modernize-deprecated-headers.CheckHeaderFile
    value: false
- - key: performance-move-const-arg.CheckTriviallyCopyableMove
-   value: false
  - key: bugprone-unhandled-self-assignment.WarnOnlyIfThisHasSuspiciousField
    value: false
  - key: bugprone-unused-return-value.CheckedReturnTypes


### PR DESCRIPTION
tidy without fixes (see https://github.com/l0rinc/bitcoin/pull/113)