### PR TITLE
Serialization specializations

### DIFF
--- a/src/bench/CMakeLists.txt
+++ b/src/bench/CMakeLists.txt
@@ -48,6 +48,7 @@ add_executable(bench_bitcoin
   rpc_blockchain.cpp
   rpc_mempool.cpp
   sign_transaction.cpp
+  serialization.cpp
   streams_findbyte.cpp
   strencodings.cpp
   txgraph.cpp

--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -10,8 +10,134 @@
 #include <streams.h>
 #include <validation.h>
 
+#include <array>
 #include <cassert>
 #include <cstddef>
+#include <utility>
+#include <vector>
+
+using SizeWeight = std::pair<size_t, size_t>;
+
+static std::vector<unsigned char> ByteVector(size_t size, unsigned char tag)
+{
+    return std::vector(size, tag);
+}
+
+static CScript ScriptOfSize(size_t size, unsigned char tag)
+{
+    const auto bytes{ByteVector(size, tag)};
+    return {bytes.begin(), bytes.end()};
+}
+
+template <size_t N>
+static size_t WeightedSize(const std::array<SizeWeight, N>& weights, size_t index)
+{
+    size_t total{0};
+    for (const auto& [_, weight] : weights) {
+        total += weight;
+    }
+    index %= total;
+    for (const auto& [size, weight] : weights) {
+        if (index < weight) return size;
+        index -= weight;
+    }
+    assert(false);
+    return 0;
+}
+
+static CTransactionRef MakeSizedTransaction(size_t index)
+{
+    CMutableTransaction tx;
+    const auto tag{static_cast<unsigned char>(index)};
+    constexpr std::array prevector_sizes{
+        SizeWeight{0, 20},
+        SizeWeight{23, 19},
+        SizeWeight{25, 18},
+        SizeWeight{22, 14},
+        SizeWeight{106, 8},
+        SizeWeight{107, 7},
+        SizeWeight{34, 6},
+        SizeWeight{35, 2},
+        SizeWeight{33, 2},
+        SizeWeight{71, 2},
+        SizeWeight{72, 1},
+        SizeWeight{64, 1},
+    };
+    constexpr std::array vector_sizes{
+        SizeWeight{33, 37},
+        SizeWeight{71, 29},
+        SizeWeight{72, 15},
+        SizeWeight{64, 7},
+        SizeWeight{0, 5},
+        SizeWeight{105, 3},
+        SizeWeight{65, 2},
+        SizeWeight{37, 2},
+    };
+
+    tx.vin.emplace_back(COutPoint{}, ScriptOfSize(WeightedSize(prevector_sizes, index * 3), tag));
+    tx.vout.emplace_back(0, ScriptOfSize(WeightedSize(prevector_sizes, index * 3 + 1), tag));
+    tx.vout.emplace_back(0, ScriptOfSize(WeightedSize(prevector_sizes, index * 3 + 2), tag));
+    tx.vin[0].scriptWitness.stack.push_back(ByteVector(WeightedSize(vector_sizes, index * 2), tag));
+    if (index % 4 != 0) {
+        tx.vin[0].scriptWitness.stack.push_back(ByteVector(WeightedSize(vector_sizes, index * 2 + 1), tag));
+    }
+    return MakeTransactionRef(std::move(tx));
+}
+
+// The real block fixture below predates witness data. Use a mixed block for
+// serialization-only benchmarks so the hot byte-vector sizes seen in modern
+// block data are exercised.
+static CBlock CreateSerializationBenchmarkBlock()
+{
+    CBlock block;
+    block.vtx.reserve(4096);
+    while (block.vtx.size() < 4096) {
+        block.vtx.push_back(MakeSizedTransaction(block.vtx.size()));
+    }
+    return block;
+}
+
+static void SizeComputerBlock(benchmark::Bench& bench)
+{
+    const CBlock block{CreateSerializationBenchmarkBlock()};
+    DataStream expected_stream;
+    expected_stream << TX_WITH_WITNESS(block);
+    const auto expected_size{expected_stream.size()};
+
+    bench.unit("block").run([&] {
+        SizeComputer size_computer;
+        size_computer << TX_WITH_WITNESS(block);
+        assert(size_computer.size() == expected_size);
+    });
+}
+
+static void SerializeBlock(benchmark::Bench& bench)
+{
+    const CBlock block{CreateSerializationBenchmarkBlock()};
+    DataStream expected_stream;
+    expected_stream << TX_WITH_WITNESS(block);
+    const auto expected_size{expected_stream.size()};
+
+    bench.unit("block").run([&] {
+        DataStream output_stream;
+        output_stream.reserve(expected_size);
+        output_stream << TX_WITH_WITNESS(block);
+        assert(output_stream.size() == expected_size);
+    });
+}
+
+static void DeserializeSerializationBlock(benchmark::Bench& bench)
+{
+    DataStream stream;
+    stream << TX_WITH_WITNESS(CreateSerializationBenchmarkBlock());
+    const std::vector<std::byte> block_data{stream.begin(), stream.end()};
+
+    bench.unit("block").run([&] {
+        CBlock block;
+        SpanReader{block_data} >> TX_WITH_WITNESS(block);
+        assert(block.vtx.size() == 4096);
+    });
+}
 
 // These are the two major time-sinks which happen after we have fully received
 // a block off the wire, but before we can relay the block on to peers using
@@ -46,5 +172,8 @@ static void CheckBlockTest(benchmark::Bench& bench)
         });
 }
 
+BENCHMARK(SizeComputerBlock);
+BENCHMARK(SerializeBlock);
+BENCHMARK(DeserializeSerializationBlock);
 BENCHMARK(DeserializeBlockTest);
 BENCHMARK(CheckBlockTest);

--- a/src/bench/serialization.cpp
+++ b/src/bench/serialization.cpp
@@ -1,0 +1,281 @@
+// Copyright (c) 2026-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit/.
+
+#include <bench/bench.h>
+#include <prevector.h>
+#include <serialize.h>
+#include <streams.h>
+
+#include <array>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using SizeWeight = std::pair<size_t, size_t>;
+
+template <size_t N>
+size_t WeightedSize(const std::array<SizeWeight, N>& weights, size_t index)
+{
+    size_t total{0};
+    for (const auto& [_, weight] : weights) total += weight;
+    index %= total;
+    for (const auto& [size, weight] : weights) {
+        if (index < weight) return size;
+        index -= weight;
+    }
+    assert(false);
+    return 0;
+}
+
+template <size_t N>
+std::array<std::byte, N> FixedBytes(size_t seed)
+{
+    std::array<std::byte, N> bytes{};
+    for (size_t i{0}; i < bytes.size(); ++i) {
+        bytes[i] = std::byte{static_cast<unsigned char>(seed + i)};
+    }
+    return bytes;
+}
+
+std::vector<std::byte> ByteVector(size_t size, size_t seed)
+{
+    std::vector<std::byte> bytes(size);
+    for (size_t i{0}; i < bytes.size(); ++i) {
+        bytes[i] = std::byte{static_cast<unsigned char>(seed + i)};
+    }
+    return bytes;
+}
+
+prevector<28, unsigned char> BytePrevector(size_t size, size_t seed)
+{
+    prevector<28, unsigned char> bytes;
+    bytes.resize(size);
+    for (size_t i{0}; i < bytes.size(); ++i) {
+        bytes[i] = static_cast<unsigned char>(seed + i);
+    }
+    return bytes;
+}
+
+std::string StringOfSize(size_t size, size_t seed)
+{
+    std::string str(size, '\0');
+    for (size_t i{0}; i < str.size(); ++i) {
+        str[i] = static_cast<char>('a' + ((seed + i) % 26));
+    }
+    return str;
+}
+
+uint64_t CompactSizeValue(size_t index)
+{
+    constexpr std::array values{
+        SizeWeight{22, 50},
+        SizeWeight{23, 20},
+        SizeWeight{106, 20},
+        SizeWeight{162, 9},
+        SizeWeight{253, 1},
+    };
+    return WeightedSize(values, index);
+}
+
+uint64_t VarIntValue(size_t index)
+{
+    constexpr std::array values{
+        SizeWeight{42, 54},
+        SizeWeight{300, 14},
+        SizeWeight{70'000, 28},
+        SizeWeight{3'000'000, 4},
+    };
+    return WeightedSize(values, index);
+}
+
+struct SerializationDistributionData {
+    std::vector<std::array<std::byte, 1>> fixed_1;
+    std::vector<std::array<std::byte, 4>> fixed_4;
+    std::vector<std::array<std::byte, 8>> fixed_8;
+    std::vector<std::array<std::byte, 32>> fixed_32;
+    std::vector<std::vector<std::byte>> raw_spans;
+    std::vector<std::vector<std::byte>> byte_vectors;
+    std::vector<prevector<28, unsigned char>> byte_prevectors;
+    std::vector<std::string> strings;
+    std::vector<std::byte> serialized;
+};
+
+SerializationDistributionData CreateSerializationDistributionData()
+{
+    constexpr size_t samples{512};
+    constexpr std::array raw_span_sizes{
+        SizeWeight{1, 77},
+        SizeWeight{32, 15},
+        SizeWeight{21, 3},
+        SizeWeight{22, 2},
+        SizeWeight{34, 2},
+        SizeWeight{105, 1},
+    };
+    constexpr std::array vector_sizes{
+        SizeWeight{33, 37},
+        SizeWeight{71, 29},
+        SizeWeight{72, 15},
+        SizeWeight{64, 7},
+        SizeWeight{0, 5},
+        SizeWeight{105, 3},
+        SizeWeight{65, 1},
+        SizeWeight{37, 1},
+        SizeWeight{109, 1},
+        SizeWeight{128, 1},
+    };
+    constexpr std::array prevector_sizes{
+        SizeWeight{0, 20},
+        SizeWeight{23, 19},
+        SizeWeight{25, 18},
+        SizeWeight{22, 14},
+        SizeWeight{106, 8},
+        SizeWeight{107, 7},
+        SizeWeight{34, 6},
+        SizeWeight{35, 2},
+        SizeWeight{139, 1},
+        SizeWeight{253, 1},
+        SizeWeight{21, 1},
+        SizeWeight{10, 1},
+    };
+
+    SerializationDistributionData data;
+    data.fixed_1.reserve(samples);
+    data.fixed_4.reserve(samples);
+    data.fixed_8.reserve(samples);
+    data.fixed_32.reserve(samples);
+    data.raw_spans.reserve(samples);
+    data.byte_vectors.reserve(samples);
+    data.byte_prevectors.reserve(samples);
+    data.strings.reserve(samples);
+
+    for (size_t i{0}; i < samples; ++i) {
+        data.fixed_1.push_back(FixedBytes<1>(i));
+        data.fixed_4.push_back(FixedBytes<4>(i));
+        data.fixed_8.push_back(FixedBytes<8>(i));
+        data.fixed_32.push_back(FixedBytes<32>(i));
+        data.raw_spans.push_back(ByteVector(WeightedSize(raw_span_sizes, i), i));
+        data.byte_vectors.push_back(ByteVector(WeightedSize(vector_sizes, i), i));
+        data.byte_prevectors.push_back(BytePrevector(WeightedSize(prevector_sizes, i), i));
+        data.strings.push_back(StringOfSize(CompactSizeValue(i), i));
+    }
+    return data;
+}
+
+template <typename Stream>
+void SerializeDistribution(Stream& stream, const SerializationDistributionData& data)
+{
+    for (size_t i{0}; i < data.byte_vectors.size(); ++i) {
+        WriteCompactSize(stream, CompactSizeValue(i));
+        WriteVarInt<Stream, VarIntMode::DEFAULT, uint64_t>(stream, VarIntValue(i));
+        stream << static_cast<uint8_t>(i);
+        stream << static_cast<uint32_t>(i);
+        stream << static_cast<uint64_t>(i);
+        stream << std::span<const std::byte, 1>{data.fixed_1[i]};
+        stream << std::span<const std::byte, 4>{data.fixed_4[i]};
+        stream << std::span<const std::byte, 8>{data.fixed_8[i]};
+        stream << std::span<const std::byte, 32>{data.fixed_32[i]};
+        stream << std::span<const std::byte>{data.raw_spans[i]};
+        stream << data.byte_vectors[i];
+        stream << data.byte_prevectors[i];
+        stream << data.strings[i];
+    }
+}
+
+template <typename Stream>
+void UnserializeDistribution(Stream& stream, const SerializationDistributionData& data)
+{
+    for (size_t i{0}; i < data.byte_vectors.size(); ++i) {
+        uint8_t u8;
+        uint32_t u32;
+        uint64_t u64;
+        std::array<std::byte, 1> fixed_1;
+        std::array<std::byte, 4> fixed_4;
+        std::array<std::byte, 8> fixed_8;
+        std::array<std::byte, 32> fixed_32;
+        std::vector<std::byte> raw_span(data.raw_spans[i].size());
+        std::vector<std::byte> byte_vector;
+        prevector<28, unsigned char> byte_prevector;
+        std::string str;
+
+        assert(ReadCompactSize(stream) == CompactSizeValue(i));
+        assert((ReadVarInt<Stream, VarIntMode::DEFAULT, uint64_t>(stream)) == VarIntValue(i));
+        stream >> u8 >> u32 >> u64;
+        stream >> std::span<std::byte, 1>{fixed_1};
+        stream >> std::span<std::byte, 4>{fixed_4};
+        stream >> std::span<std::byte, 8>{fixed_8};
+        stream >> std::span<std::byte, 32>{fixed_32};
+        stream >> std::span<std::byte>{raw_span};
+        stream >> byte_vector;
+        stream >> byte_prevector;
+        stream >> str;
+
+        assert(u8 == static_cast<uint8_t>(i));
+        assert(u32 == static_cast<uint32_t>(i));
+        assert(u64 == static_cast<uint64_t>(i));
+        assert(fixed_1 == data.fixed_1[i]);
+        assert(fixed_4 == data.fixed_4[i]);
+        assert(fixed_8 == data.fixed_8[i]);
+        assert(fixed_32 == data.fixed_32[i]);
+        assert(raw_span == data.raw_spans[i]);
+        assert(byte_vector == data.byte_vectors[i]);
+        assert(byte_prevector.size() == data.byte_prevectors[i].size());
+        assert(std::equal(byte_prevector.begin(), byte_prevector.end(), data.byte_prevectors[i].begin()));
+        assert(str == data.strings[i]);
+    }
+}
+
+SerializationDistributionData CreateSerializedDistributionData()
+{
+    auto data{CreateSerializationDistributionData()};
+    DataStream stream;
+    SerializeDistribution(stream, data);
+    data.serialized.assign(stream.begin(), stream.end());
+    return data;
+}
+
+} // namespace
+
+static void SizeComputerSerializationDistribution(benchmark::Bench& bench)
+{
+    const auto data{CreateSerializedDistributionData()};
+
+    bench.batch(data.byte_vectors.size()).unit("item").run([&] {
+        SizeComputer size_computer;
+        SerializeDistribution(size_computer, data);
+        assert(size_computer.size() == data.serialized.size());
+    });
+}
+
+static void WriteSerializationDistribution(benchmark::Bench& bench)
+{
+    const auto data{CreateSerializedDistributionData()};
+
+    bench.batch(data.byte_vectors.size()).unit("item").run([&] {
+        DataStream stream;
+        stream.reserve(data.serialized.size());
+        SerializeDistribution(stream, data);
+        assert(stream.size() == data.serialized.size());
+    });
+}
+
+static void ReadSerializationDistribution(benchmark::Bench& bench)
+{
+    const auto data{CreateSerializedDistributionData()};
+
+    bench.batch(data.byte_vectors.size()).unit("item").run([&] {
+        SpanReader stream{data.serialized};
+        UnserializeDistribution(stream, data);
+        assert(stream.empty());
+    });
+}
+
+BENCHMARK(SizeComputerSerializationDistribution);
+BENCHMARK(WriteSerializationDistribution);
+BENCHMARK(ReadSerializationDistribution);

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -35,6 +35,7 @@ CBlockHeaderAndShortTxIDs::CBlockHeaderAndShortTxIDs(const CBlock& block, uint64
 void CBlockHeaderAndShortTxIDs::FillShortTxIDSelector() const
 {
     DataStream stream{};
+    stream.reserve(CBlockHeader::SERIALIZED_SIZE + sizeof(nonce));
     stream << header << nonce;
     CSHA256 hasher;
     hasher.Write((unsigned char*)&(*stream.begin()), stream.end() - stream.begin());

--- a/src/common/bloom.cpp
+++ b/src/common/bloom.cpp
@@ -62,6 +62,7 @@ void CBloomFilter::insert(std::span<const unsigned char> vKey)
 void CBloomFilter::insert(const COutPoint& outpoint)
 {
     DataStream stream{};
+    stream.reserve(COutPoint::SERIALIZED_SIZE);
     stream << outpoint;
     insert(MakeUCharSpan(stream));
 }
@@ -83,6 +84,7 @@ bool CBloomFilter::contains(std::span<const unsigned char> vKey) const
 bool CBloomFilter::contains(const COutPoint& outpoint) const
 {
     DataStream stream{};
+    stream.reserve(COutPoint::SERIALIZED_SIZE);
     stream << outpoint;
     return contains(MakeUCharSpan(stream));
 }

--- a/src/kernel/coinstats.cpp
+++ b/src/kernel/coinstats.cpp
@@ -11,6 +11,7 @@
 #include <node/blockstorage.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
+#include <serialize.h>
 #include <span.h>
 #include <streams.h>
 #include <sync.h>
@@ -50,6 +51,15 @@ static void TxOutSer(T& ss, const COutPoint& outpoint, const Coin& coin)
     ss << coin.out;
 }
 
+static size_t TxOutSerSize(const Coin& coin)
+{
+    return COutPoint::SERIALIZED_SIZE +
+           sizeof(uint32_t) +
+           sizeof(coin.out.nValue) +
+           GetSizeOfCompactSize(coin.out.scriptPubKey.size()) +
+           coin.out.scriptPubKey.size();
+}
+
 static void ApplyCoinHash(HashWriter& ss, const COutPoint& outpoint, const Coin& coin)
 {
     TxOutSer(ss, outpoint, coin);
@@ -58,6 +68,7 @@ static void ApplyCoinHash(HashWriter& ss, const COutPoint& outpoint, const Coin&
 void ApplyCoinHash(MuHash3072& muhash, const COutPoint& outpoint, const Coin& coin)
 {
     DataStream ss{};
+    ss.reserve(TxOutSerSize(coin));
     TxOutSer(ss, outpoint, coin);
     muhash.Insert(MakeUCharSpan(ss));
 }
@@ -65,6 +76,7 @@ void ApplyCoinHash(MuHash3072& muhash, const COutPoint& outpoint, const Coin& co
 void RemoveCoinHash(MuHash3072& muhash, const COutPoint& outpoint, const Coin& coin)
 {
     DataStream ss{};
+    ss.reserve(TxOutSerSize(coin));
     TxOutSer(ss, outpoint, coin);
     muhash.Remove(MakeUCharSpan(ss));
 }

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -26,6 +26,8 @@
 class CBlockHeader
 {
 public:
+    static constexpr auto SERIALIZED_SIZE{sizeof(int32_t) + 2 * uint256::size() + 3 * sizeof(uint32_t)};
+
     // header
     int32_t nVersion;
     uint256 hashPrevBlock;

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -32,6 +32,7 @@ public:
     uint32_t n;
 
     static constexpr uint32_t NULL_INDEX = std::numeric_limits<uint32_t>::max();
+    static constexpr auto SERIALIZED_SIZE{Txid::size() + sizeof(uint32_t)};
 
     COutPoint(): n(NULL_INDEX) { }
     COutPoint(const Txid& hashIn, uint32_t nIn): hash(hashIn), n(nIn) { }

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -585,6 +585,7 @@ static bool rest_filter_header(const std::any& context, HTTPRequest* req, const 
     switch (rf) {
     case RESTResponseFormat::BINARY: {
         DataStream ssHeader{};
+        ssHeader.reserve(filter_headers.size() * uint256::size());
         for (const uint256& header : filter_headers) {
             ssHeader << header;
         }
@@ -595,6 +596,7 @@ static bool rest_filter_header(const std::any& context, HTTPRequest* req, const 
     }
     case RESTResponseFormat::HEX: {
         DataStream ssHeader{};
+        ssHeader.reserve(filter_headers.size() * uint256::size());
         for (const uint256& header : filter_headers) {
             ssHeader << header;
         }
@@ -1117,6 +1119,7 @@ static bool rest_blockhash_by_height(const std::any& context, HTTPRequest* req,
     switch (rf) {
     case RESTResponseFormat::BINARY: {
         DataStream ss_blockhash{};
+        ss_blockhash.reserve(uint256::size());
         ss_blockhash << pblockindex->GetBlockHash();
         req->WriteHeader("Content-Type", "application/octet-stream");
         req->WriteReply(HTTP_OK, ss_blockhash);

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -237,6 +237,7 @@ static bool rest_headers(const std::any& context,
     switch (rf) {
     case RESTResponseFormat::BINARY: {
         DataStream ssHeader{};
+        ssHeader.reserve(headers.size() * CBlockHeader::SERIALIZED_SIZE);
         for (const CBlockIndex *pindex : headers) {
             ssHeader << pindex->GetBlockHeader();
         }
@@ -248,6 +249,7 @@ static bool rest_headers(const std::any& context,
 
     case RESTResponseFormat::HEX: {
         DataStream ssHeader{};
+        ssHeader.reserve(headers.size() * CBlockHeader::SERIALIZED_SIZE);
         for (const CBlockIndex *pindex : headers) {
             ssHeader << pindex->GetBlockHeader();
         }

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -682,9 +682,13 @@ static bool rest_block_filter(const std::any& context, HTTPRequest* req, const s
         return RESTERR(req, HTTP_NOT_FOUND, errmsg);
     }
 
+    const size_t filter_response_size{
+        sizeof(uint8_t) + uint256::size() + GetSerializeSize(filter.GetEncodedFilter())};
+
     switch (rf) {
     case RESTResponseFormat::BINARY: {
         DataStream ssResp{};
+        ssResp.reserve(filter_response_size);
         ssResp << filter;
 
         req->WriteHeader("Content-Type", "application/octet-stream");
@@ -693,6 +697,7 @@ static bool rest_block_filter(const std::any& context, HTTPRequest* req, const s
     }
     case RESTResponseFormat::HEX: {
         DataStream ssResp{};
+        ssResp.reserve(filter_response_size);
         ssResp << filter;
 
         std::string strHex = HexStr(ssResp) + "\n";

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -667,6 +667,7 @@ static RPCMethod getblockheader()
     if (!fVerbose)
     {
         DataStream ssBlock{};
+        ssBlock.reserve(CBlockHeader::SERIALIZED_SIZE);
         ssBlock << pblockindex->GetBlockHeader();
         std::string strHex = HexStr(ssBlock);
         return strHex;

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -865,7 +865,7 @@ void Serialize(Stream& os, const prevector<N, T>& v)
 {
     if constexpr (BasicByte<T>) { // Use optimized version for unformatted basic bytes
         WriteCompactSize(os, v.size());
-        if (!v.empty()) os.write(MakeByteSpan(v));
+        if (!v.empty()) [[likely]] os.write(MakeByteSpan(v));
     } else {
         Serialize(os, Using<VectorFormatter<DefaultFormatter>>(v));
     }
@@ -879,9 +879,16 @@ void Unserialize(Stream& is, prevector<N, T>& v)
         // Limit size per read so bogus size value won't cause out of memory
         v.clear();
         unsigned int nSize = ReadCompactSize(is);
+        if (nSize == 0) [[unlikely]] return;
+        constexpr unsigned int max_chunk{(unsigned int)(1 + 4999999 / sizeof(T))};
+        if (nSize <= max_chunk) [[likely]] {
+            v.resize_uninitialized(nSize);
+            is.read(std::as_writable_bytes(std::span{v.data(), nSize}));
+            return;
+        }
         unsigned int i = 0;
         while (i < nSize) {
-            unsigned int blk = std::min(nSize - i, (unsigned int)(1 + 4999999 / sizeof(T)));
+            unsigned int blk = std::min(nSize - i, max_chunk);
             v.resize_uninitialized(i + blk);
             is.read(std::as_writable_bytes(std::span{&v[i], blk}));
             i += blk;
@@ -900,7 +907,7 @@ void Serialize(Stream& os, const std::vector<T, A>& v)
 {
     if constexpr (BasicByte<T>) { // Use optimized version for unformatted basic bytes
         WriteCompactSize(os, v.size());
-        if (!v.empty()) os.write(MakeByteSpan(v));
+        if (!v.empty()) [[likely]] os.write(MakeByteSpan(v));
     } else if constexpr (std::is_same_v<T, bool>) {
         // A special case for std::vector<bool>, as dereferencing
         // std::vector<bool>::const_iterator does not result in a const bool&
@@ -922,9 +929,16 @@ void Unserialize(Stream& is, std::vector<T, A>& v)
         // Limit size per read so bogus size value won't cause out of memory
         v.clear();
         unsigned int nSize = ReadCompactSize(is);
+        if (nSize == 0) [[unlikely]] return;
+        constexpr unsigned int max_chunk{(unsigned int)(1 + 4999999 / sizeof(T))};
+        if (nSize <= max_chunk) [[likely]] {
+            v.resize(nSize);
+            is.read(std::as_writable_bytes(std::span{v.data(), nSize}));
+            return;
+        }
         unsigned int i = 0;
         while (i < nSize) {
-            unsigned int blk = std::min(nSize - i, (unsigned int)(1 + 4999999 / sizeof(T)));
+            unsigned int blk = std::min(nSize - i, max_chunk);
             v.resize(i + blk);
             is.read(std::as_writable_bytes(std::span{&v[i], blk}));
             i += blk;

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -50,66 +50,74 @@ static const unsigned int MAX_VECTOR_ALLOCATE = 5000000;
 struct deserialize_type {};
 constexpr deserialize_type deserialize {};
 
+class SizeComputer;
+
+//! Check if type contains a stream by seeing if it has a GetStream() method.
+template<typename T>
+concept ContainsStream = requires(T t) { t.GetStream(); };
+
+template<typename T>
+concept ContainsSizeComputer = ContainsStream<T> &&
+    std::is_same_v<std::remove_reference_t<decltype(std::declval<T>().GetStream())>, SizeComputer>;
+
 /*
  * Lowest-level serialization and conversion.
  */
 template<typename Stream> inline void ser_writedata8(Stream &s, uint8_t obj)
 {
-    s.write(std::as_bytes(std::span{&obj, 1}));
+    s.write(std::as_bytes(std::span<uint8_t, 1>{&obj, 1}));
 }
 template<typename Stream> inline void ser_writedata16(Stream &s, uint16_t obj)
 {
     obj = htole16_internal(obj);
-    s.write(std::as_bytes(std::span{&obj, 1}));
+    s.write(std::as_bytes(std::span<uint16_t, 1>{&obj, 1}));
 }
 template<typename Stream> inline void ser_writedata32(Stream &s, uint32_t obj)
 {
     obj = htole32_internal(obj);
-    s.write(std::as_bytes(std::span{&obj, 1}));
+    s.write(std::as_bytes(std::span<uint32_t, 1>{&obj, 1}));
 }
 template<typename Stream> inline void ser_writedata32be(Stream &s, uint32_t obj)
 {
     obj = htobe32_internal(obj);
-    s.write(std::as_bytes(std::span{&obj, 1}));
+    s.write(std::as_bytes(std::span<uint32_t, 1>{&obj, 1}));
 }
 template<typename Stream> inline void ser_writedata64(Stream &s, uint64_t obj)
 {
     obj = htole64_internal(obj);
-    s.write(std::as_bytes(std::span{&obj, 1}));
+    s.write(std::as_bytes(std::span<uint64_t, 1>{&obj, 1}));
 }
 template<typename Stream> inline uint8_t ser_readdata8(Stream &s)
 {
     uint8_t obj;
-    s.read(std::as_writable_bytes(std::span{&obj, 1}));
+    s.read(std::as_writable_bytes(std::span<uint8_t, 1>{&obj, 1}));
     return obj;
 }
 template<typename Stream> inline uint16_t ser_readdata16(Stream &s)
 {
     uint16_t obj;
-    s.read(std::as_writable_bytes(std::span{&obj, 1}));
+    s.read(std::as_writable_bytes(std::span<uint16_t, 1>{&obj, 1}));
     return le16toh_internal(obj);
 }
 template<typename Stream> inline uint32_t ser_readdata32(Stream &s)
 {
     uint32_t obj;
-    s.read(std::as_writable_bytes(std::span{&obj, 1}));
+    s.read(std::as_writable_bytes(std::span<uint32_t, 1>{&obj, 1}));
     return le32toh_internal(obj);
 }
 template<typename Stream> inline uint32_t ser_readdata32be(Stream &s)
 {
     uint32_t obj;
-    s.read(std::as_writable_bytes(std::span{&obj, 1}));
+    s.read(std::as_writable_bytes(std::span<uint32_t, 1>{&obj, 1}));
     return be32toh_internal(obj);
 }
 template<typename Stream> inline uint64_t ser_readdata64(Stream &s)
 {
     uint64_t obj;
-    s.read(std::as_writable_bytes(std::span{&obj, 1}));
+    s.read(std::as_writable_bytes(std::span<uint64_t, 1>{&obj, 1}));
     return le64toh_internal(obj);
 }
 
-
-class SizeComputer;
 
 /**
  * Convert any argument to a reference to X, maintaining constness.
@@ -242,41 +250,76 @@ const Out& AsBase(const In& x)
 template<class T>
 concept CharNotInt8 = std::same_as<T, char> && !std::same_as<T, int8_t>;
 
-// clang-format off
-template <typename Stream, CharNotInt8 V> void Serialize(Stream&, V) = delete; // char serialization forbidden. Use uint8_t or int8_t
-template <typename Stream> void Serialize(Stream& s, std::byte a) { ser_writedata8(s, uint8_t(a)); }
-template <typename Stream> void Serialize(Stream& s, int8_t a)    { ser_writedata8(s, uint8_t(a)); }
-template <typename Stream> void Serialize(Stream& s, uint8_t a)   { ser_writedata8(s, a); }
-template <typename Stream> void Serialize(Stream& s, int16_t a)   { ser_writedata16(s, uint16_t(a)); }
-template <typename Stream> void Serialize(Stream& s, uint16_t a)  { ser_writedata16(s, a); }
-template <typename Stream> void Serialize(Stream& s, int32_t a)   { ser_writedata32(s, uint32_t(a)); }
-template <typename Stream> void Serialize(Stream& s, uint32_t a)  { ser_writedata32(s, a); }
-template <typename Stream> void Serialize(Stream& s, int64_t a)   { ser_writedata64(s, uint64_t(a)); }
-template <typename Stream> void Serialize(Stream& s, uint64_t a)  { ser_writedata64(s, a); }
+template <typename T>
+concept ByteOrIntegral = std::is_same_v<T, std::byte> ||
+    (std::is_integral_v<T> && !std::is_same_v<T, char>);
 
-template <typename Stream, BasicByte B, size_t N> void Serialize(Stream& s, const B (&a)[N])           { s.write(MakeByteSpan(a)); }
-template <typename Stream, BasicByte B, size_t N> void Serialize(Stream& s, const std::array<B, N>& a) { s.write(MakeByteSpan(a)); }
-template <typename Stream, BasicByte B, size_t N> void Serialize(Stream& s, std::span<B, N> span)      { s.write(std::as_bytes(span)); }
-template <typename Stream, BasicByte B>           void Serialize(Stream& s, std::span<B> span)         { s.write(std::as_bytes(span)); }
+template <typename Stream, CharNotInt8 V> void Serialize(Stream&, V) = delete; // char serialization forbidden. Use uint8_t or int8_t
+template <typename Stream, ByteOrIntegral T> void Serialize(Stream& s, T a)
+{
+    if constexpr (ContainsSizeComputer<Stream>) {
+        s.GetStream().seek(sizeof(T));
+    } else if constexpr (sizeof(T) == 1) {
+        ser_writedata8(s, static_cast<uint8_t>(a));   // (u)int8_t or std::byte or bool
+    } else if constexpr (sizeof(T) == 2) {
+        ser_writedata16(s, static_cast<uint16_t>(a)); // (u)int16_t
+    } else if constexpr (sizeof(T) == 4) {
+        ser_writedata32(s, static_cast<uint32_t>(a)); // (u)int32_t
+    } else {
+        static_assert(sizeof(T) == 8);
+        ser_writedata64(s, static_cast<uint64_t>(a)); // (u)int64_t
+    }
+}
+template <typename Stream, BasicByte B, int N> void Serialize(Stream& s, const B (&a)[N])
+{
+    if constexpr (ContainsSizeComputer<Stream>) {
+        s.GetStream().seek(N);
+    } else {
+        s.write(MakeByteSpan(a));
+    }
+}
+template <typename Stream, BasicByte B, std::size_t N> void Serialize(Stream& s, const std::array<B, N>& a)
+{
+    if constexpr (ContainsSizeComputer<Stream>) {
+        s.GetStream().seek(N);
+    } else {
+        s.write(MakeByteSpan(a));
+    }
+}
+template <typename Stream, BasicByte B, std::size_t N> void Serialize(Stream& s, std::span<B, N> span)
+{
+    if constexpr (ContainsSizeComputer<Stream>) {
+        s.GetStream().seek(N);
+    } else {
+        s.write(std::as_bytes(span));
+    }
+}
+template <typename Stream, BasicByte B> void Serialize(Stream& s, std::span<B> span)
+{
+    if constexpr (ContainsSizeComputer<Stream>) {
+        s.GetStream().seek(span.size());
+    } else {
+        s.write(std::as_bytes(span));
+    }
+}
 
 template <typename Stream, CharNotInt8 V> void Unserialize(Stream&, V) = delete; // char serialization forbidden. Use uint8_t or int8_t
-template <typename Stream> void Unserialize(Stream& s, std::byte& a) { a = std::byte(ser_readdata8(s)); }
-template <typename Stream> void Unserialize(Stream& s, int8_t& a)    { a = int8_t(ser_readdata8(s)); }
-template <typename Stream> void Unserialize(Stream& s, uint8_t& a)   { a = ser_readdata8(s); }
-template <typename Stream> void Unserialize(Stream& s, int16_t& a)   { a = int16_t(ser_readdata16(s)); }
-template <typename Stream> void Unserialize(Stream& s, uint16_t& a)  { a = ser_readdata16(s); }
-template <typename Stream> void Unserialize(Stream& s, int32_t& a)   { a = int32_t(ser_readdata32(s)); }
-template <typename Stream> void Unserialize(Stream& s, uint32_t& a)  { a = ser_readdata32(s); }
-template <typename Stream> void Unserialize(Stream& s, int64_t& a)   { a = int64_t(ser_readdata64(s)); }
-template <typename Stream> void Unserialize(Stream& s, uint64_t& a)  { a = ser_readdata64(s); }
-
-template <typename Stream, BasicByte B, size_t N> void Unserialize(Stream& s, B (&a)[N])            { s.read(MakeWritableByteSpan(a)); }
-template <typename Stream, BasicByte B, size_t N> void Unserialize(Stream& s, std::array<B, N>& a)  { s.read(MakeWritableByteSpan(a)); }
-template <typename Stream, BasicByte B, size_t N> void Unserialize(Stream& s, std::span<B, N> span) { s.read(std::as_writable_bytes(span)); }
-template <typename Stream, BasicByte B>           void Unserialize(Stream& s, std::span<B> span)    { s.read(std::as_writable_bytes(span)); }
-
-template <typename Stream> void Serialize(Stream& s, bool a)    { uint8_t f = a; ser_writedata8(s, f); }
-template <typename Stream> void Unserialize(Stream& s, bool& a) { uint8_t f = ser_readdata8(s); a = f; }
+template <typename Stream, ByteOrIntegral T> void Unserialize(Stream& s, T& a)
+{
+    if constexpr (sizeof(T) == 1) {
+        a = static_cast<T>(ser_readdata8(s));  // (u)int8_t or std::byte or bool
+    } else if constexpr (sizeof(T) == 2) {
+        a = static_cast<T>(ser_readdata16(s)); // (u)int16_t
+    } else if constexpr (sizeof(T) == 4) {
+        a = static_cast<T>(ser_readdata32(s)); // (u)int32_t
+    } else {
+        static_assert(sizeof(T) == 8);
+        a = static_cast<T>(ser_readdata64(s)); // (u)int64_t
+    }
+}
+template <typename Stream, BasicByte B, int N> void Unserialize(Stream& s, B (&a)[N]) { s.read(MakeWritableByteSpan(a)); }
+template <typename Stream, BasicByte B, std::size_t N> void Unserialize(Stream& s, std::array<B, N>& a) { s.read(MakeWritableByteSpan(a)); }
+template <typename Stream, BasicByte B, std::size_t N> void Unserialize(Stream& s, std::span<B, N> span) { s.read(std::as_writable_bytes(span)); }
 // clang-format on
 
 
@@ -295,12 +338,14 @@ constexpr inline unsigned int GetSizeOfCompactSize(uint64_t nSize)
     else                         return sizeof(unsigned char) + sizeof(uint64_t);
 }
 
-inline void WriteCompactSize(SizeComputer& os, uint64_t nSize);
-
 template<typename Stream>
 void WriteCompactSize(Stream& os, uint64_t nSize)
 {
-    if (nSize < 253)
+    if constexpr (ContainsSizeComputer<Stream>)
+    {
+        os.GetStream().seek(GetSizeOfCompactSize(nSize));
+    }
+    else if (nSize < 253)
     {
         ser_writedata8(os, nSize);
     }
@@ -407,7 +452,7 @@ struct CheckVarIntMode {
 };
 
 template<VarIntMode Mode, typename I>
-inline unsigned int GetSizeOfVarInt(I n)
+constexpr unsigned int GetSizeOfVarInt(I n)
 {
     CheckVarIntMode<Mode, I>();
     int nRet = 0;
@@ -420,25 +465,26 @@ inline unsigned int GetSizeOfVarInt(I n)
     return nRet;
 }
 
-template<typename I>
-inline void WriteVarInt(SizeComputer& os, I n);
-
 template<typename Stream, VarIntMode Mode, typename I>
 void WriteVarInt(Stream& os, I n)
 {
-    CheckVarIntMode<Mode, I>();
-    unsigned char tmp[CeilDiv(sizeof(n) * 8, 7u)];
-    int len=0;
-    while(true) {
-        tmp[len] = (n & 0x7F) | (len ? 0x80 : 0x00);
-        if (n <= 0x7F)
-            break;
-        n = (n >> 7) - 1;
-        len++;
+    if constexpr (ContainsSizeComputer<Stream>) {
+        os.GetStream().seek(GetSizeOfVarInt<Mode, I>(n));
+    } else {
+        CheckVarIntMode<Mode, I>();
+        unsigned char tmp[CeilDiv(sizeof(n) * 8, 7u)];
+        int len=0;
+        while(true) {
+            tmp[len] = (n & 0x7F) | (len ? 0x80 : 0x00);
+            if (n <= 0x7F)
+                break;
+            n = (n >> 7) - 1;
+            len++;
+        }
+        do {
+            ser_writedata8(os, tmp[len]);
+        } while(len--);
     }
-    do {
-        ser_writedata8(os, tmp[len]);
-    } while(len--);
 }
 
 template<typename Stream, VarIntMode Mode, typename I>
@@ -482,7 +528,7 @@ public:
  * serialization, and Unser(stream, object&) for deserialization. Serialization routines (inside
  * READWRITE, or directly with << and >> operators), can then use Using<Formatter>(object).
  *
- * This works by constructing a Wrapper<Formatter, T>-wrapped version of object, where T is
+ * This works by constructing a Wrapper<Formatter, T&>-wrapped version of object, where T is
  * const during serialization, and non-const during deserialization, which maintains const
  * correctness.
  */
@@ -527,12 +573,14 @@ struct CustomUintFormatter
     template <typename Stream, typename I> void Ser(Stream& s, I v)
     {
         if (v < 0 || v > MAX) throw std::ios_base::failure("CustomUintFormatter value out of range");
-        if (BigEndian) {
+        if constexpr (ContainsSizeComputer<Stream>) {
+            s.GetStream().seek(Bytes);
+        } else if (BigEndian) {
             uint64_t raw = htobe64_internal(v);
-            s.write(std::as_bytes(std::span{&raw, 1}).last(Bytes));
+            s.write(std::as_bytes(std::span{&raw, 1}).template last<Bytes>());
         } else {
             uint64_t raw = htole64_internal(v);
-            s.write(std::as_bytes(std::span{&raw, 1}).first(Bytes));
+            s.write(std::as_bytes(std::span{&raw, 1}).template first<Bytes>());
         }
     }
 
@@ -542,10 +590,10 @@ struct CustomUintFormatter
         static_assert(std::numeric_limits<U>::max() >= MAX && std::numeric_limits<U>::min() <= 0, "Assigned type too small");
         uint64_t raw = 0;
         if (BigEndian) {
-            s.read(std::as_writable_bytes(std::span{&raw, 1}).last(Bytes));
+            s.read(std::as_writable_bytes(std::span{&raw, 1}).last<Bytes>());
             v = static_cast<I>(be64toh_internal(raw));
         } else {
-            s.read(std::as_writable_bytes(std::span{&raw, 1}).first(Bytes));
+            s.read(std::as_writable_bytes(std::span{&raw, 1}).first<Bytes>());
             v = static_cast<I>(le64toh_internal(raw));
         }
     }
@@ -1071,6 +1119,9 @@ protected:
 public:
     SizeComputer() = default;
 
+    SizeComputer& GetStream() { return *this; }
+    const SizeComputer& GetStream() const { return *this; };
+
     void write(std::span<const std::byte> src)
     {
         m_size += src.size();
@@ -1095,26 +1146,11 @@ public:
     }
 };
 
-template<typename I>
-inline void WriteVarInt(SizeComputer &s, I n)
-{
-    s.seek(GetSizeOfVarInt<I>(n));
-}
-
-inline void WriteCompactSize(SizeComputer &s, uint64_t nSize)
-{
-    s.seek(GetSizeOfCompactSize(nSize));
-}
-
 template <typename T>
 uint64_t GetSerializeSize(const T& t)
 {
     return (SizeComputer() << t).size();
 }
-
-//! Check if type contains a stream by seeing if has a GetStream() method.
-template<typename T>
-concept ContainsStream = requires(T t) { t.GetStream(); };
 
 /** Wrapper that overrides the GetParams() function of a stream. */
 template <typename SubStream, typename Params>

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -1011,7 +1011,7 @@ void Unserialize(Stream& is, std::map<K, T, Pred, A>& m)
     {
         std::pair<K, T> item;
         Unserialize(is, item);
-        mi = m.insert(mi, item);
+        mi = m.insert(mi, std::move(item));
     }
 }
 
@@ -1038,7 +1038,7 @@ void Unserialize(Stream& is, std::set<K, Pred, A>& m)
     {
         K key;
         Unserialize(is, key);
-        it = m.insert(it, key);
+        it = m.insert(it, std::move(key));
     }
 }
 

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -339,13 +339,13 @@ constexpr inline unsigned int GetSizeOfCompactSize(uint64_t nSize)
 }
 
 template<typename Stream>
-void WriteCompactSize(Stream& os, uint64_t nSize)
+ALWAYS_INLINE void WriteCompactSize(Stream& os, uint64_t nSize)
 {
     if constexpr (ContainsSizeComputer<Stream>)
     {
         os.GetStream().seek(GetSizeOfCompactSize(nSize));
     }
-    else if (nSize < 253)
+    else if (nSize < 253) [[likely]]
     {
         ser_writedata8(os, nSize);
     }
@@ -374,15 +374,12 @@ void WriteCompactSize(Stream& os, uint64_t nSize)
  * check is performed. When used as a generic number encoding, range_check should be set to false.
  */
 template<typename Stream>
-uint64_t ReadCompactSize(Stream& is, bool range_check = true)
+ALWAYS_INLINE uint64_t ReadCompactSize(Stream& is, bool range_check = true)
 {
     uint8_t chSize = ser_readdata8(is);
+    if (chSize < 253) [[likely]] return chSize;
     uint64_t nSizeRet = 0;
-    if (chSize < 253)
-    {
-        nSizeRet = chSize;
-    }
-    else if (chSize == 253)
+    if (chSize == 253)
     {
         nSizeRet = ser_readdata16(is);
         if (nSizeRet < 253)

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -87,31 +87,31 @@ template<typename Stream> inline void ser_writedata64(Stream &s, uint64_t obj)
     obj = htole64_internal(obj);
     s.write(std::as_bytes(std::span<uint64_t, 1>{&obj, 1}));
 }
-template<typename Stream> inline uint8_t ser_readdata8(Stream &s)
+template<typename Stream> ALWAYS_INLINE uint8_t ser_readdata8(Stream &s)
 {
     uint8_t obj;
     s.read(std::as_writable_bytes(std::span<uint8_t, 1>{&obj, 1}));
     return obj;
 }
-template<typename Stream> inline uint16_t ser_readdata16(Stream &s)
+template<typename Stream> ALWAYS_INLINE uint16_t ser_readdata16(Stream &s)
 {
     uint16_t obj;
     s.read(std::as_writable_bytes(std::span<uint16_t, 1>{&obj, 1}));
     return le16toh_internal(obj);
 }
-template<typename Stream> inline uint32_t ser_readdata32(Stream &s)
+template<typename Stream> ALWAYS_INLINE uint32_t ser_readdata32(Stream &s)
 {
     uint32_t obj;
     s.read(std::as_writable_bytes(std::span<uint32_t, 1>{&obj, 1}));
     return le32toh_internal(obj);
 }
-template<typename Stream> inline uint32_t ser_readdata32be(Stream &s)
+template<typename Stream> ALWAYS_INLINE uint32_t ser_readdata32be(Stream &s)
 {
     uint32_t obj;
     s.read(std::as_writable_bytes(std::span<uint32_t, 1>{&obj, 1}));
     return be32toh_internal(obj);
 }
-template<typename Stream> inline uint64_t ser_readdata64(Stream &s)
+template<typename Stream> ALWAYS_INLINE uint64_t ser_readdata64(Stream &s)
 {
     uint64_t obj;
     s.read(std::as_writable_bytes(std::span<uint64_t, 1>{&obj, 1}));
@@ -452,40 +452,65 @@ template<VarIntMode Mode, typename I>
 constexpr unsigned int GetSizeOfVarInt(I n)
 {
     CheckVarIntMode<Mode, I>();
-    int nRet = 0;
-    while(true) {
-        nRet++;
-        if (n <= 0x7F)
-            break;
+    unsigned int nRet = 1;
+    while (n > 0x7F) {
+        ++nRet;
         n = (n >> 7) - 1;
     }
     return nRet;
 }
 
+template <size_t N, typename Stream, typename I>
+ALWAYS_INLINE void WriteVarIntFixed(Stream& os, I n)
+{
+    static_assert(N == 2 || N == 3);
+    unsigned char out[N];
+    if constexpr (N == 2) {
+        out[0] = static_cast<unsigned char>(((n >> 7) - 1) | 0x80);
+        out[1] = static_cast<unsigned char>(n & 0x7F);
+    } else {
+        I x = n;
+        out[N - 1] = static_cast<unsigned char>(x & 0x7F);
+        x = (x >> 7) - 1;
+        out[1] = static_cast<unsigned char>((x & 0x7F) | 0x80);
+        x = (x >> 7) - 1;
+        out[0] = static_cast<unsigned char>((x & 0x7F) | 0x80);
+    }
+    os.write(std::as_bytes(std::span{out}));
+}
+
 template<typename Stream, VarIntMode Mode, typename I>
-void WriteVarInt(Stream& os, I n)
+ALWAYS_INLINE void WriteVarInt(Stream& os, I n)
 {
     if constexpr (ContainsSizeComputer<Stream>) {
         os.GetStream().seek(GetSizeOfVarInt<Mode, I>(n));
     } else {
         CheckVarIntMode<Mode, I>();
-        unsigned char tmp[CeilDiv(sizeof(n) * 8, 7u)];
-        int len=0;
-        while(true) {
-            tmp[len] = (n & 0x7F) | (len ? 0x80 : 0x00);
-            if (n <= 0x7F)
-                break;
-            n = (n >> 7) - 1;
-            len++;
+        if (n <= 0x7F) [[likely]] {
+            ser_writedata8(os, n);
+            return;
         }
-        do {
-            ser_writedata8(os, tmp[len]);
-        } while(len--);
+        if (n <= 0x407F) {
+            WriteVarIntFixed<2>(os, n);
+            return;
+        }
+        if (n <= 0x20407F) {
+            WriteVarIntFixed<3>(os, n);
+            return;
+        }
+        unsigned char tmp[CeilDiv(sizeof(n) * 8, 7u)];
+        size_t pos = std::size(tmp);
+        tmp[--pos] = n & 0x7F;
+        while (n > 0x7F) {
+            n = (n >> 7) - 1;
+            tmp[--pos] = (n & 0x7F) | 0x80;
+        }
+        os.write(std::as_bytes(std::span{tmp}.subspan(pos)));
     }
 }
 
 template<typename Stream, VarIntMode Mode, typename I>
-I ReadVarInt(Stream& is)
+ALWAYS_INLINE I ReadVarInt(Stream& is)
 {
     CheckVarIntMode<Mode, I>();
     I n = 0;

--- a/src/streams.h
+++ b/src/streams.h
@@ -25,6 +25,7 @@
 #include <limits>
 #include <optional>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 /* Minimal stream for overwriting and/or appending to an existing byte vector
@@ -55,13 +56,20 @@ public:
     }
     void write(std::span<const std::byte> src)
     {
+        if (src.empty()) return;
         assert(nPos <= vchData.size());
+        const auto src_ptr{UCharCast(src.data())};
+        if (nPos == vchData.size()) {
+            vchData.insert(vchData.end(), src_ptr, src_ptr + src.size());
+            nPos += src.size();
+            return;
+        }
         size_t nOverwrite = std::min(src.size(), vchData.size() - nPos);
         if (nOverwrite) {
             memcpy(vchData.data() + nPos, src.data(), nOverwrite);
         }
         if (nOverwrite < src.size()) {
-            vchData.insert(vchData.end(), UCharCast(src.data()) + nOverwrite, UCharCast(src.data() + src.size()));
+            vchData.insert(vchData.end(), src_ptr + nOverwrite, src_ptr + src.size());
         }
         nPos += src.size();
     }
@@ -101,18 +109,24 @@ public:
     size_t size() const { return m_data.size(); }
     bool empty() const { return m_data.empty(); }
 
-    void read(std::span<std::byte> dst)
+    template <size_t Extent = std::dynamic_extent>
+    void read(std::span<std::byte, Extent> dst)
     {
-        if (dst.size() == 0) {
-            return;
+        if constexpr (Extent == 1) {
+            if (m_data.empty()) {
+                throw std::ios_base::failure("SpanReader::read(): end of data");
+            }
+            dst[0] = m_data[0];
+            m_data = m_data.subspan(1);
+        } else {
+            const auto n{dst.size()};
+            // Read from the beginning of the buffer
+            if (n > m_data.size()) {
+                throw std::ios_base::failure("SpanReader::read(): end of data");
+            }
+            memcpy(dst.data(), m_data.data(), n);
+            m_data = m_data.subspan(n);
         }
-
-        // Read from the beginning of the buffer
-        if (dst.size() > m_data.size()) {
-            throw std::ios_base::failure("SpanReader::read(): end of data");
-        }
-        memcpy(dst.data(), m_data.data(), dst.size());
-        m_data = m_data.subspan(dst.size());
     }
 
     void ignore(size_t n)
@@ -208,22 +222,35 @@ public:
     //
     // Stream subset
     //
-    void read(std::span<value_type> dst)
+    template <size_t Extent = std::dynamic_extent>
+    void read(std::span<value_type, Extent> dst)
     {
-        if (dst.size() == 0) return;
-
-        // Read from the beginning of the buffer
-        auto next_read_pos{CheckedAdd(m_read_pos, dst.size())};
-        if (!next_read_pos.has_value() || next_read_pos.value() > vch.size()) {
-            throw std::ios_base::failure("DataStream::read(): end of data");
+        if constexpr (Extent == 1) {
+            if (m_read_pos == vch.size()) {
+                throw std::ios_base::failure("DataStream::read(): end of data");
+            }
+            dst[0] = vch[m_read_pos];
+            ++m_read_pos;
+            if (m_read_pos == vch.size()) {
+                m_read_pos = 0;
+                vch.clear();
+            }
+        } else if constexpr (Extent > 1) {
+            const auto n{dst.size()};
+            const auto avail{vch.size() - m_read_pos};
+            if (n > avail) {
+                throw std::ios_base::failure("DataStream::read(): end of data");
+            }
+            if (n > 0) [[likely]] {
+                memcpy(dst.data(), &vch[m_read_pos], n);
+            }
+            if (n == avail) {
+                m_read_pos = 0;
+                vch.clear();
+                return;
+            }
+            m_read_pos += n;
         }
-        memcpy(dst.data(), &vch[m_read_pos], dst.size());
-        if (next_read_pos.value() == vch.size()) {
-            // If fully consumed, reset to empty state.
-            clear();
-            return;
-        }
-        m_read_pos = next_read_pos.value();
     }
 
     void ignore(size_t num_ignore)
@@ -241,10 +268,19 @@ public:
         m_read_pos = next_read_pos.value();
     }
 
-    void write(std::span<const value_type> src)
+    template <typename B, size_t Extent = std::dynamic_extent>
+        requires std::same_as<std::remove_cv_t<B>, value_type>
+    void write(std::span<B, Extent> src)
     {
+        const value_type* data{src.data()};
         // Write to the end of the buffer
-        vch.insert(vch.end(), src.begin(), src.end());
+        if constexpr (Extent == 1) {
+            vch.push_back(data[0]);
+        } else if constexpr (Extent == 32) {
+            vch.insert(vch.end(), data, data + Extent);
+        } else {
+            vch.insert(vch.end(), data, data + src.size());
+        }
     }
 
     template<typename T>

--- a/src/test/fuzz/CMakeLists.txt
+++ b/src/test/fuzz/CMakeLists.txt
@@ -117,6 +117,7 @@ add_executable(fuzz
   signature_checker.cpp
   signet.cpp
   socks5.cpp
+  serialization_equivalence.cpp
   span.cpp
   string.cpp
   strprintf.cpp

--- a/src/test/fuzz/serialization_equivalence.cpp
+++ b/src/test/fuzz/serialization_equivalence.cpp
@@ -1,0 +1,144 @@
+// Copyright (c) 2026-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit/.
+
+#include <prevector.h>
+#include <serialize.h>
+#include <streams.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::vector<std::byte> ToBytes(const DataStream& stream)
+{
+    return {stream.begin(), stream.end()};
+}
+
+std::vector<std::byte> ConsumeBytes(FuzzedDataProvider& provider, size_t size)
+{
+    std::vector<std::byte> bytes(size);
+    for (auto& byte : bytes) {
+        byte = std::byte{provider.ConsumeIntegral<unsigned char>()};
+    }
+    return bytes;
+}
+
+template <size_t N>
+std::array<std::byte, N> FixedInput(std::span<const std::byte> input)
+{
+    std::array<std::byte, N> out{};
+    std::copy_n(input.begin(), N, out.begin());
+    return out;
+}
+
+template <size_t N>
+void CheckStreamSpanEquivalence(FuzzedDataProvider& provider)
+{
+    const auto input{ConsumeBytes(provider, provider.ConsumeIntegralInRange<size_t>(N, 1024))};
+
+    const auto fixed_input{FixedInput<N>(input)};
+
+    DataStream dynamic_write;
+    dynamic_write.write(std::span<const std::byte>{fixed_input});
+    DataStream fixed_write;
+    fixed_write.write(std::span<const std::byte, N>{fixed_input});
+    assert(ToBytes(dynamic_write) == ToBytes(fixed_write));
+
+    auto mutable_fixed_input{fixed_input};
+    DataStream mutable_fixed_write;
+    mutable_fixed_write.write(std::span<std::byte, N>{mutable_fixed_input});
+    assert(ToBytes(dynamic_write) == ToBytes(mutable_fixed_write));
+
+    std::array<std::byte, N> fixed_out{};
+    std::vector<std::byte> dynamic_out(N);
+    DataStream dynamic_read{input};
+    DataStream fixed_read{input};
+    dynamic_read.read(std::span<std::byte>{dynamic_out});
+    fixed_read.read(std::span<std::byte, N>{fixed_out});
+    assert(std::equal(fixed_out.begin(), fixed_out.end(), dynamic_out.begin(), dynamic_out.end()));
+    assert(dynamic_read.size() == fixed_read.size());
+
+    std::fill(dynamic_out.begin(), dynamic_out.end(), std::byte{0});
+    fixed_out = {};
+    SpanReader dynamic_span_read{input};
+    SpanReader fixed_span_read{input};
+    dynamic_span_read.read(std::span<std::byte>{dynamic_out});
+    fixed_span_read.read(std::span<std::byte, N>{fixed_out});
+    assert(std::equal(fixed_out.begin(), fixed_out.end(), dynamic_out.begin(), dynamic_out.end()));
+    assert(dynamic_span_read.size() == fixed_span_read.size());
+}
+
+void CheckStreamSpanEquivalence(FuzzedDataProvider& provider)
+{
+    switch (provider.ConsumeIntegralInRange<int>(0, 3)) {
+    case 0:
+        CheckStreamSpanEquivalence<1>(provider);
+        break;
+    case 1:
+        CheckStreamSpanEquivalence<4>(provider);
+        break;
+    case 2:
+        CheckStreamSpanEquivalence<8>(provider);
+        break;
+    case 3:
+        CheckStreamSpanEquivalence<32>(provider);
+        break;
+    }
+}
+
+void CheckSizeComputerEquivalence(FuzzedDataProvider& provider, uint64_t value)
+{
+    const auto payload{ConsumeBytes(provider, provider.ConsumeIntegralInRange<size_t>(0, 1024))};
+    std::vector<std::byte> vector_payload{payload.begin(), payload.end()};
+    prevector<28, unsigned char> prevector_payload;
+    prevector_payload.resize(payload.size());
+    std::transform(payload.begin(), payload.end(), prevector_payload.begin(), [](std::byte b) {
+        return std::to_integer<unsigned char>(b);
+    });
+    std::string string_payload{reinterpret_cast<const char*>(payload.data()), payload.size()};
+
+    auto serialize = [&](auto& stream) {
+        stream << static_cast<uint8_t>(value);
+        stream << static_cast<uint32_t>(value);
+        stream << static_cast<uint64_t>(value);
+        stream << VARINT(value);
+        WriteCompactSize(stream, payload.size());
+        stream << std::span<const std::byte>{payload};
+        stream << vector_payload;
+        stream << prevector_payload;
+        stream << string_payload;
+    };
+
+    DataStream bytes;
+    SizeComputer size;
+    serialize(bytes);
+    serialize(size);
+    assert(size.size() == bytes.size());
+}
+
+} // namespace
+
+FUZZ_TARGET(serialization_equivalence)
+{
+    FuzzedDataProvider provider{buffer.data(), buffer.size()};
+    const uint64_t value{provider.ConsumeIntegral<uint64_t>()};
+
+    LIMITED_WHILE(provider.remaining_bytes(), 16)
+    {
+        if (provider.ConsumeBool()) {
+            CheckStreamSpanEquivalence(provider);
+        } else {
+            CheckSizeComputerEquivalence(provider, value);
+        }
+    }
+}

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <hash.h>
+#include <primitives/block.h>
 #include <serialize.h>
 #include <streams.h>
 #include <test/util/common.h>
@@ -100,6 +101,7 @@ BOOST_AUTO_TEST_CASE(sizes)
     BOOST_CHECK_EQUAL(GetSerializeSize(bool(0)), 1U);
     BOOST_CHECK_EQUAL(GetSerializeSize(std::array<uint8_t, 1>{0}), 1U);
     BOOST_CHECK_EQUAL(GetSerializeSize(std::array<uint8_t, 2>{0, 0}), 2U);
+    BOOST_CHECK_EQUAL(CBlockHeader::SERIALIZED_SIZE, GetSerializeSize(CBlockHeader{}));
 }
 
 BOOST_AUTO_TEST_CASE(varints)

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <hash.h>
 #include <primitives/block.h>
+#include <primitives/transaction.h>
 #include <serialize.h>
 #include <streams.h>
 #include <test/util/common.h>
@@ -102,6 +103,7 @@ BOOST_AUTO_TEST_CASE(sizes)
     BOOST_CHECK_EQUAL(GetSerializeSize(std::array<uint8_t, 1>{0}), 1U);
     BOOST_CHECK_EQUAL(GetSerializeSize(std::array<uint8_t, 2>{0, 0}), 2U);
     BOOST_CHECK_EQUAL(CBlockHeader::SERIALIZED_SIZE, GetSerializeSize(CBlockHeader{}));
+    BOOST_CHECK_EQUAL(COutPoint::SERIALIZED_SIZE, GetSerializeSize(COutPoint{}));
 }
 
 BOOST_AUTO_TEST_CASE(varints)

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -304,6 +304,23 @@ BOOST_AUTO_TEST_CASE(streams_vector_reader_rvalue)
     BOOST_CHECK(reader.empty());
 }
 
+BOOST_AUTO_TEST_CASE(streams_empty_read)
+{
+    std::vector<std::byte> empty;
+
+    DataStream stream{};
+    BOOST_CHECK_NO_THROW(stream.read(std::span{empty}));
+    BOOST_CHECK(stream.empty());
+
+    stream << uint8_t{1};
+    BOOST_CHECK_NO_THROW(stream.read(std::span{empty}));
+    BOOST_CHECK_EQUAL(stream.size(), 1U);
+
+    SpanReader reader{std::span<const std::byte>{}};
+    BOOST_CHECK_NO_THROW(reader.read(std::span{empty}));
+    BOOST_CHECK(reader.empty());
+}
+
 BOOST_AUTO_TEST_CASE(bitstream_reader_writer)
 {
     DataStream data{};

--- a/test/functional/interface_rest.py
+++ b/test/functional/interface_rest.py
@@ -309,7 +309,33 @@ class RESTTest (BitcoinTestFramework):
         json_obj = self.test_rest_request(f"/blockfilterheaders/basic/{bb_hash}", query_params={"count": 5})
         first_filter_header = json_obj[0]
         assert_equal(len(json_obj), 5)  # now we should have 5 filter header objects
+        expected_filter_headers = b''.join(bytes.fromhex(header)[::-1] for header in json_obj)
+        filter_headers_bin = self.test_rest_request(
+            f"/blockfilterheaders/basic/{bb_hash}",
+            req_type=ReqType.BIN,
+            ret_type=RetType.BYTES,
+            query_params={"count": 5},
+        )
+        filter_headers_hex = self.test_rest_request(
+            f"/blockfilterheaders/basic/{bb_hash}",
+            req_type=ReqType.HEX,
+            ret_type=RetType.BYTES,
+            query_params={"count": 5},
+        )
+        assert_equal(filter_headers_bin, expected_filter_headers)
+        assert_equal(filter_headers_hex.rstrip(b'\n'), expected_filter_headers.hex().encode())
         json_obj = self.test_rest_request(f"/blockfilter/basic/{bb_hash}")
+        filter_bytes = self.test_rest_request(
+            f"/blockfilter/basic/{bb_hash}",
+            req_type=ReqType.BIN,
+            ret_type=RetType.BYTES,
+        )
+        filter_hex = self.test_rest_request(
+            f"/blockfilter/basic/{bb_hash}",
+            req_type=ReqType.HEX,
+            ret_type=RetType.BYTES,
+        )
+        assert_equal(filter_hex.rstrip(b'\n'), filter_bytes.hex().encode())
 
         # Compare with normal RPC blockfilter response
         rpc_blockfilter = self.nodes[0].getblockfilter(bb_hash)


### PR DESCRIPTION
Measured on aarch64 with GNU 15.0.1, Release, BUILD_BENCH=ON, comparing the full optimization stack against this benchmark baseline with the median of three 5s runs:

SizeComputerBlock: 54.97 us -> 48.15 us elapsed (-12.41%), 267.7k -> 150.0k instructions (-43.98%)
SerializeBlock: 1.041 ms -> 1.019 ms elapsed (-2.12%), 7.93M -> 7.73M instructions (-2.62%)
DeserializeBlockTest: 2.761 ms -> 2.632 ms elapsed (-4.66%), 14.45M -> 13.72M instructions (-5.05%)

----

Serialization is heavily exercised during block and chainstate processing, but small protocol-level branches are not equally important in real workloads. This PR first adds temporary serialization branch statistics, reverts the instrumentation, then keeps only optimizations backed by the measured distributions and focused
benchmark results.

The reference workload parsed 989,164 debug-log lines, 989,004 `UpdateTip` lines from height 908,696 through 948,849, 633,585 TSV rows, 27 histograms, and 373,526,415,850 aggregate histogram samples.

## Changes

* Add temporary serialization branch stats collection, then revert it before production changes.
* Add distribution-shaped serialization benchmarks and a `serialization_equivalence` fuzz target.
* Make `SizeComputer` account for fixed-size byte writes directly.
* Specialize existing span read/write paths for fixed extents without adding new public overloads.
* Fast-path empty and single-chunk byte vector/prevector reads.
* Inline and specialize the one-byte CompactSize path.
* Fast-path 1-, 2-, and 3-byte VarInt writes without adding 4+ byte specializations.

This intentionally does not include map/set deserialization or response stream reservation changes. The reindex-chainstate stats did not meaningfully exercise map/set, and the reserve-only changes did not have committed benchmark evidence.

## Workload Evidence

* CompactSize width 1 covers 99.42% of writes and 99.50% of reads.
* VarInt widths <= 3 cover 96.09% of writes and 95.46% of reads.
* SpanReader sizes 1/4/8/32 cover 77.72% of reads.
* DataStream writes are dominated by 1-byte and 32-byte appends.
* Byte vector/prevector payloads are dominated by small single-chunk reads.

## Performance

| Change | Benchmark | Before | After | Median change | Throughput |
|---|---:|---:|---:|---:|---:|
| SizeComputer byte writes | `SizeComputerBlock` | 241902.61 ns/block | 189169.21 ns/block | -21.80% | +27.88% |
| Span read/write specialization | `WriteSerializationDistribution` | 281.89 ns/item | 233.38 ns/item | -17.21% | +20.79% |
| Byte vector read fast path | `DeserializeSerializationBlock` | 8257540.14 ns/block | 8119339.00 ns/block | -1.67% | +1.70% |
| CompactSize hot path | `SerializeBlock` | 1619619.63 ns/block | 1537380.24 ns/block | -5.08% | +5.35% |
| VarInt hot paths | `ReadSerializationDistribution` | 236.35 ns/item | 229.75 ns/item | -2.79% | +2.87% |

----

Decision Table

| Commit | Decision | Reason / Required Proof |
|---|---:|---|
| 1. bench: collect serialization branch stats | Modify | Keep as evidence commit, but update message/output to the new workload summary and 27 histograms. It should justify only the branches we actually keep.|
| 2. Revert stats commit | Keep | Required to keep measurement code out of production. |
| 3. bench: measure serialization paths | Modify | Refresh weights from the new stats and split broad mixed coverage into targeted benches: CompactSize, VarInt, DataStream read/write, SpanReader read, byte vector, byte prevector, generic tiny vector. |
| 4. serialize: size byte writes directly | Keep | Strong measured reason: SizeComputerBlock -21.80% median. Also supported by size_computer_write_size and size_computer_seek_size histograms. |
| 5. streams: specialize span reads and writes | Benchmark first / Modify | Current broad +17.21% write benchmark is promising but too mixed. Prove each kept part with DataStreamWriteSizes, DataStreamReadSizes, and SpanReaderReadSizes. Prefer a generic append improvement over adding more size cases. |
| 6. serialize: fast-path byte vector reads | Modify | Keep only if separate std::vector<byte> and prevector<byte> read benches stay positive. Remove/reconsider [[unlikely]] for zero size: prevector zero is common. |
| 7. serialize: specialize CompactSize hot paths | Keep | Strong reason: width=1 is 99.42% writes / 99.50% reads and SerializeBlock shows -5.08%. Do not add width 3/5/9 batching. |
| 8. serialize: specialize VarInt hot paths | Benchmark first / Modify | Keep 1/2/3-byte write paths only if a write-side benchmark proves it. Current claim using ReadSerializationDistribution is not causally convincing for a write-only change. Do not expand to 4+. |
| 9. serialize: move decoded map and set entries | Drop from this stack | Reindex stats show only one zero-sized map/set sample. Move to mempool-specific branch and justify with real mempool.dat load/save timings, not this serialization stack. |
| 10. streams: reserve block header streams | Benchmark first or Drop | Needs targeted proof: REST headers binary/hex, getblockheader hex, and compact-block short-id selector benchmark. Otherwise drop. |
| 11. streams: reserve outpoint streams | Benchmark first or Drop | Needs BloomOutPointInsertContains and MuHashCoinApplyRemove style benchmarks. Otherwise drop. |
| 12. streams: reserve uint256 response streams | Benchmark first or Drop | Needs REST filter-header and blockhash-by-height response benchmarks. Otherwise drop. |
| 13. streams: reserve block filter response streams | Benchmark first or Drop | Needs REST block-filter binary/hex benchmark. Otherwise drop. |

Benchmark TODO

Update src/bench/serialization.cpp first. The current fixture is stale: CompactSize values miss hot 0/1/2/25/33/34, VarInt percentages changed, span weights conflate fixed and dynamic spans, and vector/
prevector tails are incomplete.

Add or split these benchmarks before touching production code further:

- WriteCompactSizeDistribution / ReadCompactSizeDistribution: width=1 hot path only.
- WriteVarIntDistribution: widths 1/2/3/4/5+, to prove 2/3-byte write helpers.
- DataStreamWriteSizes: 1/32/21/22/34/105, with fixed and dynamic span variants separated.
- DataStreamReadSizes: 1/4/32.
- SpanReaderReadSizes: 1/4/8/32 plus 33/25/23/71/22/106/72/107/34.
- ByteVectorReadDistribution and ByteVectorWriteDistribution: 33/71/72/64/0/105 plus 65/37/109.
- BytePrevectorReadDistribution and BytePrevectorWriteDistribution: 0/23/25/22/106/107/34/35 plus 139/138/253/252.
- GenericVectorTinyReadWrite: sizes 0/1/2/3/4, preferably transaction-shaped, before optimizing generic vector serialization.
- Targeted reserve benchmarks only if those commits stay in the stack.

Code TODO

1. Keep SizeComputer direct byte sizing as-is unless the refreshed benchmark contradicts it.
2. For streams, try a generic DataStream::write append implementation that benefits all small dynamic writes, e.g. resize once and memcpy, before adding any 21/22/34 ladders. Keep Extent == 1 only if isolated
   data proves it.
3. Keep CompactSize simple: ContainsSizeComputer, width=1 likely branch, early return. No multi-byte batching.
4. Re-measure VarInt write paths. Keep 1/2/3 only if WriteVarIntDistribution improves. Do not optimize 4+ yet.
5. Split byte vector and prevector evidence. Remove [[unlikely]] from zero-size byte-container reads unless separate vector-only data proves it is still useful there.
6. Investigate tiny generic vectors only after a transaction-shaped benchmark exists. The 0/1/2/3/4 distribution is interesting, but generic vector code is broad and needs stronger proof.
7. Move map/set to a mempool branch. Use real mempool.dat import/dump timings as primary evidence.
8. Quarantine reserve commits. They are exact-size allocation cleanups, but current committed benchmarks claim 0.00%, so they should not remain in this optimization stack without targeted positive numbers.

Stale Claims

- VarInt <=3 wording should become 96.09% writes / 95.46% reads, not 96.39% / 93.40%.
- SpanReader 1/4/8/32 coverage should be 77.72%, not 77.86%.
- DataStream write 1/32 coverage should be 92.19%, not older 92.64%.
- Byte vector/prevector zero-size handling needs updated wording; zero is not rare for prevector.
- Map/set must not cite reindex stats.
- Reserve commits cannot be described as performance optimizations until targeted benchmarks show a positive result.

---

<details><summary>collect serialization branch stats</summary>

Add temporary histograms for the serialization branches optimized later in this stack.

This commit intentionally has no production performance improvement. It is measurement-only and the next commit reverts it before any optimization changes land, so benchmark results are not distorted by stats collection overhead.

To reproduce the stats, build bitcoind from this commit and run:

BITCOIN_SERIALIZE_STATS=/tmp/serialize-stats.tsv build/bin/bitcoind -datadir=<datadir> -reindex-chainstate -stopatheight=<height>

Omit -stopatheight for a full run. The output is a TSV with histogram, value, and count columns. It records CompactSize widths and values, VarInt widths, byte vector and prevector sizes, VectorWriter writes, SpanReader reads, and DataStream reads/writes.

```patch
commit ac1a946d2dc9e907744a8a31e2d0ec2b46d3ee7a
Author: Lőrinc <pap.lorinc@gmail.com>
Date:   Thu May 14 14:30:36 2026 +0000

bench: collect serialization branch stats

Add temporary histograms for the serialization branches optimized later in this stack.

This commit intentionally has no production performance improvement. It is measurement-only and the next commit reverts it before any optimization changes land, so benchmark results are not distorted by stats collection overhead.

To reproduce the stats, build bitcoind from this commit and run:

BITCOIN_SERIALIZE_STATS=/tmp/serialize-stats.tsv build/bin/bitcoind -datadir=<datadir> -reindex-chainstate -stopatheight=<height>

Omit -stopatheight for a full run. The output is a TSV with histogram, value, and count columns. It records CompactSize widths and values, VarInt widths, byte vector and prevector sizes, VectorWriter writes, SpanReader reads, and DataStream reads/writes.

diff --git a/src/serialize.h b/src/serialize.h
--- a/src/serialize.h	(revision 7802e578c3f1e9a5d9b57fb003349d0e032bb43b)
+++ b/src/serialize.h	(revision 9594de350fbffcf02167c6a227389b1f9e2a0181)
@@ -14,13 +14,18 @@
 #include <util/overflow.h>
 
 #include <algorithm>
+#include <array>
 #include <concepts>
+#include <cstddef>
+#include <cstdlib>
 #include <cstdint>
 #include <cstring>
+#include <fstream>
 #include <ios>
 #include <limits>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <set>
 #include <span>
 #include <string>
@@ -36,6 +41,133 @@
 /** Maximum amount of memory (in bytes) to allocate at once when deserializing vectors. */
 static const unsigned int MAX_VECTOR_ALLOCATE = 5000000;
 
+namespace serialization_stats {
+enum class Hist : size_t {
+    CompactSizeWriteWidth,
+    CompactSizeReadWidth,
+    CompactSizeWriteValue,
+    CompactSizeReadValue,
+    VarIntWriteWidth,
+    VarIntReadWidth,
+    VectorByteWriteSize,
+    VectorByteReadSize,
+    PrevectorByteWriteSize,
+    PrevectorByteReadSize,
+    IntegralWriteSize,
+    IntegralReadSize,
+    ByteArrayWriteSize,
+    ByteArrayReadSize,
+    FixedSpanWriteSize,
+    FixedSpanReadSize,
+    DynamicSpanWriteSize,
+    DynamicSpanReadSize,
+    StringWriteSize,
+    StringReadSize,
+    LimitedStringReadSize,
+    VectorBoolWriteSize,
+    VectorBoolReadSize,
+    VectorGenericWriteSize,
+    VectorGenericReadSize,
+    MapWriteSize,
+    MapReadSize,
+    SetWriteSize,
+    SetReadSize,
+    SizeComputerWriteSize,
+    SizeComputerSeekSize,
+    VectorWriterWriteSize,
+    SpanReaderReadSize,
+    SpanWriterWriteSize,
+    DataStreamReadSize,
+    DataStreamWriteSize,
+    Count,
+};
+
+inline const char* HistogramName(Hist hist)
+{
+    switch (hist) {
+    case Hist::CompactSizeWriteWidth: return "compact_size_write_width";
+    case Hist::CompactSizeReadWidth: return "compact_size_read_width";
+    case Hist::CompactSizeWriteValue: return "compact_size_write_value";
+    case Hist::CompactSizeReadValue: return "compact_size_read_value";
+    case Hist::VarIntWriteWidth: return "varint_write_width";
+    case Hist::VarIntReadWidth: return "varint_read_width";
+    case Hist::VectorByteWriteSize: return "vector_byte_write_size";
+    case Hist::VectorByteReadSize: return "vector_byte_read_size";
+    case Hist::PrevectorByteWriteSize: return "prevector_byte_write_size";
+    case Hist::PrevectorByteReadSize: return "prevector_byte_read_size";
+    case Hist::IntegralWriteSize: return "integral_write_size";
+    case Hist::IntegralReadSize: return "integral_read_size";
+    case Hist::ByteArrayWriteSize: return "byte_array_write_size";
+    case Hist::ByteArrayReadSize: return "byte_array_read_size";
+    case Hist::FixedSpanWriteSize: return "fixed_span_write_size";
+    case Hist::FixedSpanReadSize: return "fixed_span_read_size";
+    case Hist::DynamicSpanWriteSize: return "dynamic_span_write_size";
+    case Hist::DynamicSpanReadSize: return "dynamic_span_read_size";
+    case Hist::StringWriteSize: return "string_write_size";
+    case Hist::StringReadSize: return "string_read_size";
+    case Hist::LimitedStringReadSize: return "limited_string_read_size";
+    case Hist::VectorBoolWriteSize: return "vector_bool_write_size";
+    case Hist::VectorBoolReadSize: return "vector_bool_read_size";
+    case Hist::VectorGenericWriteSize: return "vector_generic_write_size";
+    case Hist::VectorGenericReadSize: return "vector_generic_read_size";
+    case Hist::MapWriteSize: return "map_write_size";
+    case Hist::MapReadSize: return "map_read_size";
+    case Hist::SetWriteSize: return "set_write_size";
+    case Hist::SetReadSize: return "set_read_size";
+    case Hist::SizeComputerWriteSize: return "size_computer_write_size";
+    case Hist::SizeComputerSeekSize: return "size_computer_seek_size";
+    case Hist::VectorWriterWriteSize: return "vector_writer_write_size";
+    case Hist::SpanReaderReadSize: return "span_reader_read_size";
+    case Hist::SpanWriterWriteSize: return "span_writer_write_size";
+    case Hist::DataStreamReadSize: return "datastream_read_size";
+    case Hist::DataStreamWriteSize: return "datastream_write_size";
+    case Hist::Count: break;
+    }
+    return "unknown";
+}
+
+class Stats
+{
+    static constexpr size_t HISTOGRAMS{static_cast<size_t>(Hist::Count)};
+
+    std::mutex m_mutex;
+    std::array<std::map<uint64_t, uint64_t>, HISTOGRAMS> m_histograms;
+
+public:
+    ~Stats()
+    {
+        const char* path{std::getenv("BITCOIN_SERIALIZE_STATS")};
+        if (path == nullptr || path[0] == '\0') return;
+
+        std::ofstream out{path};
+        out << "histogram\tvalue\tcount\n";
+        for (size_t hist{0}; hist < HISTOGRAMS; ++hist) {
+            const auto name{HistogramName(static_cast<Hist>(hist))};
+            for (const auto& [value, count] : m_histograms[hist]) {
+                out << name << '\t' << value << '\t' << count << '\n';
+            }
+        }
+    }
+
+    void Record(Hist hist, uint64_t value)
+    {
+        std::lock_guard lock{m_mutex};
+        ++m_histograms[static_cast<size_t>(hist)][value];
+    }
+};
+
+inline Stats& Global()
+{
+    static Stats stats;
+    return stats;
+}
+
+inline void Record(Hist hist, uint64_t value)
+{
+    Global().Record(hist, value);
+}
+} // namespace serialization_stats
+
 /**
  * Dummy data type to identify deserializing constructors.
  *
@@ -244,39 +376,39 @@
 
 // clang-format off
 template <typename Stream, CharNotInt8 V> void Serialize(Stream&, V) = delete; // char serialization forbidden. Use uint8_t or int8_t
-template <typename Stream> void Serialize(Stream& s, std::byte a) { ser_writedata8(s, uint8_t(a)); }
-template <typename Stream> void Serialize(Stream& s, int8_t a)    { ser_writedata8(s, uint8_t(a)); }
-template <typename Stream> void Serialize(Stream& s, uint8_t a)   { ser_writedata8(s, a); }
-template <typename Stream> void Serialize(Stream& s, int16_t a)   { ser_writedata16(s, uint16_t(a)); }
-template <typename Stream> void Serialize(Stream& s, uint16_t a)  { ser_writedata16(s, a); }
-template <typename Stream> void Serialize(Stream& s, int32_t a)   { ser_writedata32(s, uint32_t(a)); }
-template <typename Stream> void Serialize(Stream& s, uint32_t a)  { ser_writedata32(s, a); }
-template <typename Stream> void Serialize(Stream& s, int64_t a)   { ser_writedata64(s, uint64_t(a)); }
-template <typename Stream> void Serialize(Stream& s, uint64_t a)  { ser_writedata64(s, a); }
+template <typename Stream> void Serialize(Stream& s, std::byte a) { serialization_stats::Record(serialization_stats::Hist::IntegralWriteSize, 1); ser_writedata8(s, uint8_t(a)); }
+template <typename Stream> void Serialize(Stream& s, int8_t a)    { serialization_stats::Record(serialization_stats::Hist::IntegralWriteSize, 1); ser_writedata8(s, uint8_t(a)); }
+template <typename Stream> void Serialize(Stream& s, uint8_t a)   { serialization_stats::Record(serialization_stats::Hist::IntegralWriteSize, 1); ser_writedata8(s, a); }
+template <typename Stream> void Serialize(Stream& s, int16_t a)   { serialization_stats::Record(serialization_stats::Hist::IntegralWriteSize, 2); ser_writedata16(s, uint16_t(a)); }
+template <typename Stream> void Serialize(Stream& s, uint16_t a)  { serialization_stats::Record(serialization_stats::Hist::IntegralWriteSize, 2); ser_writedata16(s, a); }
+template <typename Stream> void Serialize(Stream& s, int32_t a)   { serialization_stats::Record(serialization_stats::Hist::IntegralWriteSize, 4); ser_writedata32(s, uint32_t(a)); }
+template <typename Stream> void Serialize(Stream& s, uint32_t a)  { serialization_stats::Record(serialization_stats::Hist::IntegralWriteSize, 4); ser_writedata32(s, a); }
+template <typename Stream> void Serialize(Stream& s, int64_t a)   { serialization_stats::Record(serialization_stats::Hist::IntegralWriteSize, 8); ser_writedata64(s, uint64_t(a)); }
+template <typename Stream> void Serialize(Stream& s, uint64_t a)  { serialization_stats::Record(serialization_stats::Hist::IntegralWriteSize, 8); ser_writedata64(s, a); }
 
-template <typename Stream, BasicByte B, size_t N> void Serialize(Stream& s, const B (&a)[N])           { s.write(MakeByteSpan(a)); }
-template <typename Stream, BasicByte B, size_t N> void Serialize(Stream& s, const std::array<B, N>& a) { s.write(MakeByteSpan(a)); }
-template <typename Stream, BasicByte B, size_t N> void Serialize(Stream& s, std::span<B, N> span)      { s.write(std::as_bytes(span)); }
-template <typename Stream, BasicByte B>           void Serialize(Stream& s, std::span<B> span)         { s.write(std::as_bytes(span)); }
+template <typename Stream, BasicByte B, size_t N> void Serialize(Stream& s, const B (&a)[N])           { serialization_stats::Record(serialization_stats::Hist::ByteArrayWriteSize, N); s.write(MakeByteSpan(a)); }
+template <typename Stream, BasicByte B, size_t N> void Serialize(Stream& s, const std::array<B, N>& a) { serialization_stats::Record(serialization_stats::Hist::ByteArrayWriteSize, N); s.write(MakeByteSpan(a)); }
+template <typename Stream, BasicByte B, size_t N> void Serialize(Stream& s, std::span<B, N> span)      { serialization_stats::Record(serialization_stats::Hist::FixedSpanWriteSize, N); s.write(std::as_bytes(span)); }
+template <typename Stream, BasicByte B>           void Serialize(Stream& s, std::span<B> span)         { serialization_stats::Record(serialization_stats::Hist::DynamicSpanWriteSize, span.size()); s.write(std::as_bytes(span)); }
 
 template <typename Stream, CharNotInt8 V> void Unserialize(Stream&, V) = delete; // char serialization forbidden. Use uint8_t or int8_t
-template <typename Stream> void Unserialize(Stream& s, std::byte& a) { a = std::byte(ser_readdata8(s)); }
-template <typename Stream> void Unserialize(Stream& s, int8_t& a)    { a = int8_t(ser_readdata8(s)); }
-template <typename Stream> void Unserialize(Stream& s, uint8_t& a)   { a = ser_readdata8(s); }
-template <typename Stream> void Unserialize(Stream& s, int16_t& a)   { a = int16_t(ser_readdata16(s)); }
-template <typename Stream> void Unserialize(Stream& s, uint16_t& a)  { a = ser_readdata16(s); }
-template <typename Stream> void Unserialize(Stream& s, int32_t& a)   { a = int32_t(ser_readdata32(s)); }
-template <typename Stream> void Unserialize(Stream& s, uint32_t& a)  { a = ser_readdata32(s); }
-template <typename Stream> void Unserialize(Stream& s, int64_t& a)   { a = int64_t(ser_readdata64(s)); }
-template <typename Stream> void Unserialize(Stream& s, uint64_t& a)  { a = ser_readdata64(s); }
+template <typename Stream> void Unserialize(Stream& s, std::byte& a) { serialization_stats::Record(serialization_stats::Hist::IntegralReadSize, 1); a = std::byte(ser_readdata8(s)); }
+template <typename Stream> void Unserialize(Stream& s, int8_t& a)    { serialization_stats::Record(serialization_stats::Hist::IntegralReadSize, 1); a = int8_t(ser_readdata8(s)); }
+template <typename Stream> void Unserialize(Stream& s, uint8_t& a)   { serialization_stats::Record(serialization_stats::Hist::IntegralReadSize, 1); a = ser_readdata8(s); }
+template <typename Stream> void Unserialize(Stream& s, int16_t& a)   { serialization_stats::Record(serialization_stats::Hist::IntegralReadSize, 2); a = int16_t(ser_readdata16(s)); }
+template <typename Stream> void Unserialize(Stream& s, uint16_t& a)  { serialization_stats::Record(serialization_stats::Hist::IntegralReadSize, 2); a = ser_readdata16(s); }
+template <typename Stream> void Unserialize(Stream& s, int32_t& a)   { serialization_stats::Record(serialization_stats::Hist::IntegralReadSize, 4); a = int32_t(ser_readdata32(s)); }
+template <typename Stream> void Unserialize(Stream& s, uint32_t& a)  { serialization_stats::Record(serialization_stats::Hist::IntegralReadSize, 4); a = ser_readdata32(s); }
+template <typename Stream> void Unserialize(Stream& s, int64_t& a)   { serialization_stats::Record(serialization_stats::Hist::IntegralReadSize, 8); a = int64_t(ser_readdata64(s)); }
+template <typename Stream> void Unserialize(Stream& s, uint64_t& a)  { serialization_stats::Record(serialization_stats::Hist::IntegralReadSize, 8); a = ser_readdata64(s); }
 
-template <typename Stream, BasicByte B, size_t N> void Unserialize(Stream& s, B (&a)[N])            { s.read(MakeWritableByteSpan(a)); }
-template <typename Stream, BasicByte B, size_t N> void Unserialize(Stream& s, std::array<B, N>& a)  { s.read(MakeWritableByteSpan(a)); }
-template <typename Stream, BasicByte B, size_t N> void Unserialize(Stream& s, std::span<B, N> span) { s.read(std::as_writable_bytes(span)); }
-template <typename Stream, BasicByte B>           void Unserialize(Stream& s, std::span<B> span)    { s.read(std::as_writable_bytes(span)); }
+template <typename Stream, BasicByte B, size_t N> void Unserialize(Stream& s, B (&a)[N])            { serialization_stats::Record(serialization_stats::Hist::ByteArrayReadSize, N); s.read(MakeWritableByteSpan(a)); }
+template <typename Stream, BasicByte B, size_t N> void Unserialize(Stream& s, std::array<B, N>& a)  { serialization_stats::Record(serialization_stats::Hist::ByteArrayReadSize, N); s.read(MakeWritableByteSpan(a)); }
+template <typename Stream, BasicByte B, size_t N> void Unserialize(Stream& s, std::span<B, N> span) { serialization_stats::Record(serialization_stats::Hist::FixedSpanReadSize, N); s.read(std::as_writable_bytes(span)); }
+template <typename Stream, BasicByte B>           void Unserialize(Stream& s, std::span<B> span)    { serialization_stats::Record(serialization_stats::Hist::DynamicSpanReadSize, span.size()); s.read(std::as_writable_bytes(span)); }
 
-template <typename Stream> void Serialize(Stream& s, bool a)    { uint8_t f = a; ser_writedata8(s, f); }
-template <typename Stream> void Unserialize(Stream& s, bool& a) { uint8_t f = ser_readdata8(s); a = f; }
+template <typename Stream> void Serialize(Stream& s, bool a)    { serialization_stats::Record(serialization_stats::Hist::IntegralWriteSize, 1); uint8_t f = a; ser_writedata8(s, f); }
+template <typename Stream> void Unserialize(Stream& s, bool& a) { serialization_stats::Record(serialization_stats::Hist::IntegralReadSize, 1); uint8_t f = ser_readdata8(s); a = f; }
 // clang-format on
 
 
@@ -300,6 +432,8 @@
 template<typename Stream>
 void WriteCompactSize(Stream& os, uint64_t nSize)
 {
+    serialization_stats::Record(serialization_stats::Hist::CompactSizeWriteWidth, GetSizeOfCompactSize(nSize));
+    serialization_stats::Record(serialization_stats::Hist::CompactSizeWriteValue, nSize);
     if (nSize < 253)
     {
         ser_writedata8(os, nSize);
@@ -332,6 +466,7 @@
 uint64_t ReadCompactSize(Stream& is, bool range_check = true)
 {
     uint8_t chSize = ser_readdata8(is);
+    serialization_stats::Record(serialization_stats::Hist::CompactSizeReadWidth, chSize < 253 ? 1 : chSize == 253 ? 3 : chSize == 254 ? 5 : 9);
     uint64_t nSizeRet = 0;
     if (chSize < 253)
     {
@@ -358,6 +493,7 @@
     if (range_check && nSizeRet > MAX_SIZE) {
         throw std::ios_base::failure("ReadCompactSize(): size too large");
     }
+    serialization_stats::Record(serialization_stats::Hist::CompactSizeReadValue, nSizeRet);
     return nSizeRet;
 }
 
@@ -436,6 +572,7 @@
         n = (n >> 7) - 1;
         len++;
     }
+    serialization_stats::Record(serialization_stats::Hist::VarIntWriteWidth, static_cast<unsigned int>(len + 1));
     do {
         ser_writedata8(os, tmp[len]);
     } while(len--);
@@ -446,8 +583,10 @@
 {
     CheckVarIntMode<Mode, I>();
     I n = 0;
+    unsigned int bytes{0};
     while(true) {
         unsigned char chData = ser_readdata8(is);
+        ++bytes;
         if (n > (std::numeric_limits<I>::max() >> 7)) {
            throw std::ios_base::failure("ReadVarInt(): size too large");
         }
@@ -458,6 +597,7 @@
             }
             n++;
         } else {
+            serialization_stats::Record(serialization_stats::Hist::VarIntReadWidth, bytes);
             return n;
         }
     }
@@ -633,6 +773,7 @@
     void Unser(Stream& s, std::string& v)
     {
         size_t size = ReadCompactSize(s);
+        serialization_stats::Record(serialization_stats::Hist::LimitedStringReadSize, size);
         if (size > Limit) {
             throw std::ios_base::failure("String length limit exceeded");
         }
@@ -667,6 +808,7 @@
     void Ser(Stream& s, const V& v)
     {
         Formatter formatter;
+        serialization_stats::Record(serialization_stats::Hist::VectorGenericWriteSize, v.size());
         WriteCompactSize(s, v.size());
         for (const typename V::value_type& elem : v) {
             formatter.Ser(s, elem);
@@ -679,6 +821,7 @@
         Formatter formatter;
         v.clear();
         size_t size = ReadCompactSize(s);
+        serialization_stats::Record(serialization_stats::Hist::VectorGenericReadSize, size);
         size_t allocated = 0;
         while (allocated < size) {
             // For DoS prevention, do not blindly allocate as much as the stream claims to contain.
@@ -793,6 +936,7 @@
 template<typename Stream, typename C>
 void Serialize(Stream& os, const std::basic_string<C>& str)
 {
+    serialization_stats::Record(serialization_stats::Hist::StringWriteSize, str.size());
     WriteCompactSize(os, str.size());
     if (!str.empty())
         os.write(MakeByteSpan(str));
@@ -802,6 +946,7 @@
 void Unserialize(Stream& is, std::basic_string<C>& str)
 {
     unsigned int nSize = ReadCompactSize(is);
+    serialization_stats::Record(serialization_stats::Hist::StringReadSize, nSize);
     str.resize(nSize);
     if (nSize != 0)
         is.read(MakeWritableByteSpan(str));
@@ -816,6 +961,7 @@
 void Serialize(Stream& os, const prevector<N, T>& v)
 {
     if constexpr (BasicByte<T>) { // Use optimized version for unformatted basic bytes
+        serialization_stats::Record(serialization_stats::Hist::PrevectorByteWriteSize, v.size());
         WriteCompactSize(os, v.size());
         if (!v.empty()) os.write(MakeByteSpan(v));
     } else {
@@ -831,6 +977,7 @@
         // Limit size per read so bogus size value won't cause out of memory
         v.clear();
         unsigned int nSize = ReadCompactSize(is);
+        serialization_stats::Record(serialization_stats::Hist::PrevectorByteReadSize, nSize);
         unsigned int i = 0;
         while (i < nSize) {
             unsigned int blk = std::min(nSize - i, (unsigned int)(1 + 4999999 / sizeof(T)));
@@ -851,12 +998,14 @@
 void Serialize(Stream& os, const std::vector<T, A>& v)
 {
     if constexpr (BasicByte<T>) { // Use optimized version for unformatted basic bytes
+        serialization_stats::Record(serialization_stats::Hist::VectorByteWriteSize, v.size());
         WriteCompactSize(os, v.size());
         if (!v.empty()) os.write(MakeByteSpan(v));
     } else if constexpr (std::is_same_v<T, bool>) {
         // A special case for std::vector<bool>, as dereferencing
         // std::vector<bool>::const_iterator does not result in a const bool&
         // due to std::vector's special casing for bool arguments.
+        serialization_stats::Record(serialization_stats::Hist::VectorBoolWriteSize, v.size());
         WriteCompactSize(os, v.size());
         for (bool elem : v) {
             ::Serialize(os, elem);
@@ -874,6 +1023,7 @@
         // Limit size per read so bogus size value won't cause out of memory
         v.clear();
         unsigned int nSize = ReadCompactSize(is);
+        serialization_stats::Record(serialization_stats::Hist::VectorByteReadSize, nSize);
         unsigned int i = 0;
         while (i < nSize) {
             unsigned int blk = std::min(nSize - i, (unsigned int)(1 + 4999999 / sizeof(T)));
@@ -881,6 +1031,16 @@
             is.read(std::as_writable_bytes(std::span{&v[i], blk}));
             i += blk;
         }
+    } else if constexpr (std::is_same_v<T, bool>) {
+        v.clear();
+        unsigned int nSize = ReadCompactSize(is);
+        serialization_stats::Record(serialization_stats::Hist::VectorBoolReadSize, nSize);
+        v.reserve(nSize);
+        for (unsigned int i = 0; i < nSize; ++i) {
+            bool elem;
+            ::Unserialize(is, elem);
+            v.push_back(elem);
+        }
     } else {
         Unserialize(is, Using<VectorFormatter<DefaultFormatter>>(v));
     }
@@ -912,6 +1072,7 @@
 template<typename Stream, typename K, typename T, typename Pred, typename A>
 void Serialize(Stream& os, const std::map<K, T, Pred, A>& m)
 {
+    serialization_stats::Record(serialization_stats::Hist::MapWriteSize, m.size());
     WriteCompactSize(os, m.size());
     for (const auto& entry : m)
         Serialize(os, entry);
@@ -922,6 +1083,7 @@
 {
     m.clear();
     unsigned int nSize = ReadCompactSize(is);
+    serialization_stats::Record(serialization_stats::Hist::MapReadSize, nSize);
     typename std::map<K, T, Pred, A>::iterator mi = m.begin();
     for (unsigned int i = 0; i < nSize; i++)
     {
@@ -939,6 +1101,7 @@
 template<typename Stream, typename K, typename Pred, typename A>
 void Serialize(Stream& os, const std::set<K, Pred, A>& m)
 {
+    serialization_stats::Record(serialization_stats::Hist::SetWriteSize, m.size());
     WriteCompactSize(os, m.size());
     for (typename std::set<K, Pred, A>::const_iterator it = m.begin(); it != m.end(); ++it)
         Serialize(os, (*it));
@@ -949,6 +1112,7 @@
 {
     m.clear();
     unsigned int nSize = ReadCompactSize(is);
+    serialization_stats::Record(serialization_stats::Hist::SetReadSize, nSize);
     typename std::set<K, Pred, A>::iterator it = m.begin();
     for (unsigned int i = 0; i < nSize; i++)
     {
@@ -1073,12 +1237,14 @@
 
     void write(std::span<const std::byte> src)
     {
+        serialization_stats::Record(serialization_stats::Hist::SizeComputerWriteSize, src.size());
         m_size += src.size();
     }
 
     /** Pretend this many bytes are written, without specifying them. */
     void seek(uint64_t num)
     {
+        serialization_stats::Record(serialization_stats::Hist::SizeComputerSeekSize, num);
         m_size += num;
     }
 
@@ -1098,12 +1264,17 @@
 template<typename I>
 inline void WriteVarInt(SizeComputer &s, I n)
 {
-    s.seek(GetSizeOfVarInt<I>(n));
+    const unsigned int size{GetSizeOfVarInt<I>(n)};
+    serialization_stats::Record(serialization_stats::Hist::VarIntWriteWidth, size);
+    s.seek(size);
 }
 
 inline void WriteCompactSize(SizeComputer &s, uint64_t nSize)
 {
-    s.seek(GetSizeOfCompactSize(nSize));
+    const unsigned int size{GetSizeOfCompactSize(nSize)};
+    serialization_stats::Record(serialization_stats::Hist::CompactSizeWriteWidth, size);
+    serialization_stats::Record(serialization_stats::Hist::CompactSizeWriteValue, nSize);
+    s.seek(size);
 }
 
 template <typename T>
Index: src/streams.h
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/src/streams.h b/src/streams.h
--- a/src/streams.h	(revision 7802e578c3f1e9a5d9b57fb003349d0e032bb43b)
+++ b/src/streams.h	(revision 9594de350fbffcf02167c6a227389b1f9e2a0181)
@@ -55,6 +55,7 @@
     }
     void write(std::span<const std::byte> src)
     {
+        serialization_stats::Record(serialization_stats::Hist::VectorWriterWriteSize, src.size());
         assert(nPos <= vchData.size());
         size_t nOverwrite = std::min(src.size(), vchData.size() - nPos);
         if (nOverwrite) {
@@ -103,6 +104,7 @@
 
     void read(std::span<std::byte> dst)
     {
+        serialization_stats::Record(serialization_stats::Hist::SpanReaderReadSize, dst.size());
         if (dst.size() == 0) {
             return;
         }
@@ -141,6 +143,7 @@
 
     void write(std::span<const std::byte> src)
     {
+        serialization_stats::Record(serialization_stats::Hist::SpanWriterWriteSize, src.size());
         if (src.size() > m_dest.size()) {
             throw std::ios_base::failure("SpanWriter::write(): exceeded buffer size");
         }
@@ -210,6 +213,7 @@
     //
     void read(std::span<value_type> dst)
     {
+        serialization_stats::Record(serialization_stats::Hist::DataStreamReadSize, dst.size());
         if (dst.size() == 0) return;
 
         // Read from the beginning of the buffer
@@ -243,6 +247,7 @@
 
     void write(std::span<const value_type> src)
     {
+        serialization_stats::Record(serialization_stats::Hist::DataStreamWriteSize, src.size());
         // Write to the end of the buffer
         vch.insert(vch.end(), src.begin(), src.end());
     }


```

</details>
