### PR TITLE
node: shrink automatic dbcache after IBD

### DIFF
--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -201,7 +201,7 @@ fi
 
 if [[ "${RUN_IWYU}" == true ]]; then
   # TODO: Consider enforcing IWYU across the entire codebase.
-  FILES_WITH_ENFORCED_IWYU="/src/((crypto|index|kernel|primitives|univalue/(lib|test)|zmq)/.*\\.cpp|node/blockstorage\\.cpp|node/utxo_snapshot\\.cpp|core_io\\.cpp|signet\\.cpp|common/system_ram\\.cpp)"
+  FILES_WITH_ENFORCED_IWYU="/src/((crypto|index|kernel|primitives|univalue/(lib|test)|zmq)/.*\\.cpp|node/blockstorage\\.cpp|node/utxo_snapshot\\.cpp|core_io\\.cpp|signet\\.cpp|common/system_ram\\.cpp|node/dbcache\\.cpp)"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns)))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_errors.json"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns) | not))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_warnings.json"
 

--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -201,7 +201,7 @@ fi
 
 if [[ "${RUN_IWYU}" == true ]]; then
   # TODO: Consider enforcing IWYU across the entire codebase.
-  FILES_WITH_ENFORCED_IWYU="/src/((crypto|index|kernel|primitives|univalue/(lib|test)|zmq)/.*\\.cpp|node/blockstorage\\.cpp|node/utxo_snapshot\\.cpp|core_io\\.cpp|signet\\.cpp)"
+  FILES_WITH_ENFORCED_IWYU="/src/((crypto|index|kernel|primitives|univalue/(lib|test)|zmq)/.*\\.cpp|node/blockstorage\\.cpp|node/utxo_snapshot\\.cpp|core_io\\.cpp|signet\\.cpp|common/system_ram\\.cpp)"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns)))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_errors.json"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns) | not))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_warnings.json"
 

--- a/doc/reduce-memory.md
+++ b/doc/reduce-memory.md
@@ -15,7 +15,8 @@ Bitcoin Core may warn at startup when `-dbcache` looks too large for the detecte
 
 The size of some in-memory caches can be reduced. As caches trade off memory usage for performance, reducing these will usually have a negative effect on performance.
 
-- `-dbcache=<n>` - the UTXO database cache size, this defaults to `1024` (or `450` if less than `4096` MiB system RAM is detected). The unit is MiB (1024).
+- `-dbcache=<n>` - the UTXO database cache size. The unit is MiB (1024).
+  - Automatic default scales with system RAM, up to 2 GiB.
   - The minimum value for `-dbcache` is 4.
   - A lower `-dbcache` makes initial sync time much longer. After the initial sync, the effect is less pronounced for most use-cases, unless fast validation of blocks is important, such as for mining.
 

--- a/doc/release-notes-34641.md
+++ b/doc/release-notes-34641.md
@@ -1,0 +1,7 @@
+Updated `dbcache` default settings
+----------------------------------
+
+- When `-dbcache` is not set explicitly, Bitcoin Core now chooses a RAM-aware default between 100 MiB and 2 GiB.
+  The selected `-dbcache` value is reduced after IBD for steady-state operation and unused mempool allocation may still be shared with this cache while syncing.
+  In environments with external memory limits (e.g. containers), automatic sizing may not match effective limits.
+  Set `-dbcache` explicitly if needed, to maintain the previous behavior, set `-dbcache=450`. (#34641)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -104,6 +104,7 @@ add_library(bitcoin_common STATIC EXCLUDE_FROM_ALL
   common/settings.cpp
   common/signmessage.cpp
   common/system.cpp
+  common/system_ram.cpp
   common/url.cpp
   compressor.cpp
   core_io.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -211,6 +211,7 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   node/blockmanager_args.cpp
   node/blockstorage.cpp
   node/caches.cpp
+  node/dbcache.cpp
   node/chainstate.cpp
   node/chainstatemanager_args.cpp
   node/coin.cpp

--- a/src/common/system.cpp
+++ b/src/common/system.cpp
@@ -111,22 +111,6 @@ int GetNumCores()
     return std::thread::hardware_concurrency();
 }
 
-std::optional<size_t> GetTotalRAM()
-{
-    [[maybe_unused]] auto clamp{[](uint64_t v) { return size_t(std::min(v, uint64_t{std::numeric_limits<size_t>::max()})); }};
-#ifdef WIN32
-    if (MEMORYSTATUSEX m{}; (m.dwLength = sizeof(m), GlobalMemoryStatusEx(&m))) return clamp(m.ullTotalPhys);
-#elif defined(__APPLE__) || \
-      defined(__FreeBSD__) || \
-      defined(__NetBSD__) || \
-      defined(__OpenBSD__) || \
-      defined(__illumos__) || \
-      defined(__linux__)
-    if (long p{sysconf(_SC_PHYS_PAGES)}, s{sysconf(_SC_PAGESIZE)}; p > 0 && s > 0) return clamp(1ULL * p * s);
-#endif
-    return std::nullopt;
-}
-
 namespace {
     const auto g_startup_time{SteadyClock::now()};
 } // namespace

--- a/src/common/system.h
+++ b/src/common/system.h
@@ -8,10 +8,6 @@
 
 #include <bitcoin-build-config.h> // IWYU pragma: keep
 #include <util/time.h>
-
-#include <chrono>
-#include <cstdint>
-#include <optional>
 #include <string>
 
 /// Monotonic uptime (not affected by system time changes).
@@ -31,10 +27,5 @@ void runCommand(const std::string& strCommand);
  * @note This does count virtual cores, such as those provided by HyperThreading.
  */
 int GetNumCores();
-
-/**
- * Return the total RAM available on the current system, if detectable.
- */
-std::optional<size_t> GetTotalRAM();
 
 #endif // BITCOIN_COMMON_SYSTEM_H

--- a/src/common/system_ram.cpp
+++ b/src/common/system_ram.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <common/system_ram.h>
+
+#ifdef WIN32
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+
+std::optional<size_t> TryGetTotalRam()
+{
+    static const auto total_ram{[]() -> std::optional<size_t> {
+        [[maybe_unused]] auto clamp{[](uint64_t v) { return size_t(std::min(v, uint64_t{std::numeric_limits<size_t>::max()})); }};
+#ifdef WIN32
+        if (MEMORYSTATUSEX m{}; (m.dwLength = sizeof(m), GlobalMemoryStatusEx(&m))) return clamp(m.ullTotalPhys);
+#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__illumos__) || defined(__linux__)
+        if (long p{sysconf(_SC_PHYS_PAGES)}, s{sysconf(_SC_PAGESIZE)}; p > 0 && s > 0) return clamp(1ULL * p * s);
+#endif
+        return std::nullopt;
+    }()};
+    return total_ram;
+}

--- a/src/common/system_ram.h
+++ b/src/common/system_ram.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_COMMON_SYSTEM_RAM_H
+#define BITCOIN_COMMON_SYSTEM_RAM_H
+
+#include <cstddef>
+#include <optional>
+
+/**
+ * Return the total RAM available on the current system, if detectable.
+ */
+std::optional<size_t> TryGetTotalRam();
+
+#endif // BITCOIN_COMMON_SYSTEM_RAM_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1303,6 +1303,7 @@ static ChainstateLoadResult InitAndLoadChainstate(
     NodeContext& node,
     bool do_reindex,
     const bool do_reindex_chainstate,
+    const size_t total_dbcache,
     const kernel::CacheSizes& cache_sizes,
     const ArgsManager& args)
 {
@@ -1384,6 +1385,9 @@ static ChainstateLoadResult InitAndLoadChainstate(
     };
     node::ChainstateLoadOptions options;
     options.mempool = Assert(node.mempool.get());
+    options.auto_dbcache = !args.GetIntArg("-dbcache");
+    options.total_ram_bytes = node::GetTotalRam();
+    options.fixed_index_cache_bytes = total_dbcache - (cache_sizes.block_tree_db + cache_sizes.coins_db + cache_sizes.coins);
     options.wipe_chainstate_db = do_reindex || do_reindex_chainstate;
     options.prune = chainman.m_blockman.IsPruneMode();
     options.check_blocks = args.GetIntArg("-checkblocks", DEFAULT_CHECKBLOCKS);
@@ -1834,6 +1838,13 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         node::LogAutoDbCacheSettings();
     }
     const auto [index_cache_sizes, kernel_cache_sizes] = CalculateCacheSizes(args, g_enabled_filter_types.size());
+    const size_t total_dbcache{
+        index_cache_sizes.tx_index +
+        index_cache_sizes.txospender_index +
+        index_cache_sizes.filter_index * g_enabled_filter_types.size() +
+        kernel_cache_sizes.block_tree_db +
+        kernel_cache_sizes.coins_db +
+        kernel_cache_sizes.coins};
 
     LogInfo("Cache configuration:");
     LogInfo("* Using %.1f MiB for block index database", kernel_cache_sizes.block_tree_db * (1.0 / 1024 / 1024));
@@ -1860,6 +1871,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         node,
         do_reindex,
         do_reindex_chainstate,
+        total_dbcache,
         kernel_cache_sizes,
         args);
     if (status == ChainstateLoadStatus::FAILURE && !do_reindex && !ShutdownRequested(node)) {
@@ -1880,6 +1892,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
             node,
             do_reindex,
             do_reindex_chainstate,
+            total_dbcache,
             kernel_cache_sizes,
             args);
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -504,7 +504,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
     argsman.AddArg("-conf=<file>", strprintf("Specify path to read-only configuration file. Relative paths will be prefixed by datadir location (only useable from command line, not configuration file) (default: %s)", BITCOIN_CONF_FILENAME), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-datadir=<dir>", "Specify data directory", ArgsManager::ALLOW_ANY | ArgsManager::DISALLOW_NEGATION, OptionsCategory::OPTIONS);
     argsman.AddArg("-dbbatchsize", strprintf("Maximum database write batch size in bytes (default: %u)", DEFAULT_DB_CACHE_BATCH), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::OPTIONS);
-    argsman.AddArg("-dbcache=<n>", strprintf("Maximum database cache size <n> MiB (minimum %d, default: %d). Make sure you have enough RAM. In addition, unused memory allocated to the mempool is shared with this cache (see -maxmempool).", MIN_DB_CACHE >> 20, node::GetDefaultDBCache() >> 20), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-dbcache=<n>", strprintf("Maximum database cache size <n> MiB (minimum %s, default: %s MiB). In addition, unused memory allocated to the mempool is shared with this cache (see -maxmempool).", MIN_DB_CACHE >> 20, node::GetDefaultDBCache() >> 20), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-includeconf=<file>", "Specify additional configuration file, relative to the -datadir path (only useable from configuration file, not command line)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-allowignoredconf", strprintf("For backwards compatibility, treat an unused %s file in the datadir as a warning, not an error.", BITCOIN_CONF_FILENAME), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-loadblock=<file>", "Imports blocks from external file on startup", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
@@ -1828,7 +1828,11 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     // ********************************************************* Step 7: load block chain
 
     // cache size calculations
-    node::LogOversizedDbCache(args);
+    if (args.GetIntArg("-dbcache")) {
+        node::LogOversizedDbCache(args);
+    } else {
+        node::LogAutoDbCacheSettings();
+    }
     const auto [index_cache_sizes, kernel_cache_sizes] = CalculateCacheSizes(args, g_enabled_filter_types.size());
 
     LogInfo("Cache configuration:");

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -660,6 +660,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
     argsman.AddArg("-limitclustersize=<n>", strprintf("Do not accept transactions whose virtual size with all in-mempool connected transactions exceeds <n> kilobytes (default: %u)", DEFAULT_CLUSTER_SIZE_LIMIT_KVB), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-capturemessages", "Capture all P2P messages to disk", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-mocktime=<n>", "Replace actual time with " + UNIX_EPOCH_TIME + " (default: 0)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
+    argsman.AddArg("-mocktotalram=<n>", "Replace detected system RAM with <n> MiB for automatic dbcache sizing tests (default: 0, disabled)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-maxsigcachesize=<n>", strprintf("Limit sum of signature cache and script execution cache sizes to <n> MiB (default: %u)", DEFAULT_VALIDATION_CACHE_BYTES >> 20), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-maxtipage=<n>",
                    strprintf("Maximum tip age in seconds to consider node in initial block download (default: %u)",

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -51,6 +51,7 @@
 #include <node/chainstate.h>
 #include <node/chainstatemanager_args.h>
 #include <node/context.h>
+#include <node/dbcache.h>
 #include <node/interface_ui.h>
 #include <node/kernel_notifications.h>
 #include <node/mempool_args.h>

--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(bitcoinkernel
   cs_main.cpp
   disconnected_transactions.cpp
   mempool_removal_reason.cpp
+  ../common/system_ram.cpp
   ../arith_uint256.cpp
   ../chain.cpp
   ../coins.cpp
@@ -32,6 +33,7 @@ add_library(bitcoinkernel
   ../hash.cpp
   ../logging.cpp
   ../node/blockstorage.cpp
+  ../node/dbcache.cpp
   ../node/chainstate.cpp
   ../node/utxo_snapshot.cpp
   ../policy/ephemeral_policy.cpp

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -19,6 +19,7 @@
 #include <logging.h>
 #include <node/blockstorage.h>
 #include <node/chainstate.h>
+#include <node/dbcache.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <script/interpreter.h>
@@ -460,7 +461,7 @@ struct ChainstateManagerOptions {
               .notifications = *context->m_notifications,
               .block_tree_db_params = DBParams{
                   .path = data_dir / "blocks" / "index",
-                  .cache_bytes = kernel::CacheSizes{DEFAULT_KERNEL_CACHE}.block_tree_db,
+                  .cache_bytes = kernel::CacheSizes{node::GetDefaultDBCache()}.block_tree_db,
               }}},
           m_context{context}, m_chainstate_load_options{node::ChainstateLoadOptions{}}
     {
@@ -1010,7 +1011,7 @@ btck_ChainstateManager* btck_chainstate_manager_create(
     try {
         const auto chainstate_load_opts{WITH_LOCK(opts.m_mutex, return opts.m_chainstate_load_options)};
 
-        kernel::CacheSizes cache_sizes{DEFAULT_KERNEL_CACHE};
+        kernel::CacheSizes cache_sizes{node::GetDefaultDBCache()};
         auto [status, chainstate_err]{node::LoadChainstate(*chainman, cache_sizes, chainstate_load_opts)};
         if (status != node::ChainstateLoadStatus::SUCCESS) {
             LogError("Failed to load chain state from your data directory: %s", chainstate_err.original);

--- a/src/kernel/caches.h
+++ b/src/kernel/caches.h
@@ -9,8 +9,6 @@
 
 #include <algorithm>
 
-//! Suggested default amount of cache reserved for the kernel (bytes)
-static constexpr size_t DEFAULT_KERNEL_CACHE{450_MiB};
 //! Default LevelDB write batch size
 static constexpr size_t DEFAULT_DB_CACHE_BATCH{32_MiB};
 

--- a/src/node/caches.cpp
+++ b/src/node/caches.cpp
@@ -3,18 +3,21 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <node/caches.h>
-
 #include <common/args.h>
 #include <common/system_ram.h>
 #include <index/txindex.h>
 #include <index/txospenderindex.h>
 #include <kernel/caches.h>
-#include <logging.h>
+#include <node/dbcache.h>
 #include <node/interface_ui.h>
 #include <tinyformat.h>
 #include <util/byte_units.h>
+#include <util/overflow.h>
+#include <util/translation.h>
 
 #include <algorithm>
+#include <cstdint>
+#include <optional>
 #include <string>
 
 // Unlike for the UTXO database, for the txindex scenario the leveldb cache make
@@ -25,31 +28,14 @@ static constexpr size_t MAX_TX_INDEX_CACHE{1024_MiB};
 static constexpr size_t MAX_FILTER_INDEX_CACHE{1024_MiB};
 //! Max memory allocated to tx spenderindex DB specific cache in bytes.
 static constexpr size_t MAX_TXOSPENDER_INDEX_CACHE{1024_MiB};
-//! Maximum dbcache size on 32-bit systems.
-static constexpr size_t MAX_32BIT_DBCACHE{1024_MiB};
-//! Larger default dbcache on 64-bit systems with enough RAM.
-static constexpr size_t HIGH_DEFAULT_DBCACHE{1024_MiB};
-//! Minimum detected RAM required for HIGH_DEFAULT_DBCACHE.
-static constexpr uint64_t HIGH_DEFAULT_DBCACHE_MIN_TOTAL_RAM{4096ULL << 20};
 
 namespace node {
-size_t GetDefaultDBCache()
-{
-    if constexpr (sizeof(void*) >= 8) {
-        if (TryGetTotalRam().value_or(0) >= HIGH_DEFAULT_DBCACHE_MIN_TOTAL_RAM) {
-            return HIGH_DEFAULT_DBCACHE;
-        }
-    }
-    return DEFAULT_DB_CACHE;
-}
-
 size_t CalculateDbCacheBytes(const ArgsManager& args)
 {
     if (auto db_cache{args.GetIntArg("-dbcache")}) {
         if (*db_cache < 0) db_cache = 0;
         const uint64_t db_cache_bytes{SaturatingLeftShift<uint64_t>(*db_cache, 20)};
-        constexpr auto max_db_cache{sizeof(void*) == 4 ? MAX_32BIT_DBCACHE : std::numeric_limits<size_t>::max()};
-        return std::max<size_t>(MIN_DB_CACHE, std::min<uint64_t>(db_cache_bytes, max_db_cache));
+        return std::max<size_t>(MIN_DB_CACHE, std::min<uint64_t>(db_cache_bytes, MAX_DBCACHE_BYTES));
     }
     return GetDefaultDBCache();
 }

--- a/src/node/caches.cpp
+++ b/src/node/caches.cpp
@@ -12,6 +12,7 @@
 #include <node/interface_ui.h>
 #include <tinyformat.h>
 #include <util/byte_units.h>
+#include <util/log.h>
 #include <util/overflow.h>
 #include <util/translation.h>
 
@@ -62,9 +63,17 @@ void LogOversizedDbCache(const ArgsManager& args) noexcept
     if (const auto total_ram{TryGetTotalRam()}) {
         const size_t db_cache{CalculateDbCacheBytes(args)};
         if (ShouldWarnOversizedDbCache(db_cache, *total_ram)) {
-            InitWarning(bilingual_str{tfm::format(_("A %zu MiB dbcache may be too large for a system memory of only %zu MiB."),
+            InitWarning(bilingual_str{tfm::format(_("A %s MiB dbcache may be too large for a system with only %s MiB of memory."),
                         db_cache >> 20, *total_ram >> 20)});
         }
     }
+}
+
+void LogAutoDbCacheSettings() noexcept
+{
+    LogInfo("Automatically selected -dbcache=%s MiB based on %s system memory of %s MiB.",
+            GetDefaultDBCache(GetTotalRam()) >> 20,
+            TryGetTotalRam() ? "detected" : "assumed",
+            GetTotalRam() >> 20);
 }
 } // namespace node

--- a/src/node/caches.cpp
+++ b/src/node/caches.cpp
@@ -5,7 +5,7 @@
 #include <node/caches.h>
 
 #include <common/args.h>
-#include <common/system.h>
+#include <common/system_ram.h>
 #include <index/txindex.h>
 #include <index/txospenderindex.h>
 #include <kernel/caches.h>
@@ -36,7 +36,7 @@ namespace node {
 size_t GetDefaultDBCache()
 {
     if constexpr (sizeof(void*) >= 8) {
-        if (GetTotalRAM().value_or(0) >= HIGH_DEFAULT_DBCACHE_MIN_TOTAL_RAM) {
+        if (TryGetTotalRam().value_or(0) >= HIGH_DEFAULT_DBCACHE_MIN_TOTAL_RAM) {
             return HIGH_DEFAULT_DBCACHE;
         }
     }
@@ -73,7 +73,7 @@ CacheSizes CalculateCacheSizes(const ArgsManager& args, size_t n_indexes)
 
 void LogOversizedDbCache(const ArgsManager& args) noexcept
 {
-    if (const auto total_ram{GetTotalRAM()}) {
+    if (const auto total_ram{TryGetTotalRam()}) {
         const size_t db_cache{CalculateDbCacheBytes(args)};
         if (ShouldWarnOversizedDbCache(db_cache, *total_ram)) {
             InitWarning(bilingual_str{tfm::format(_("A %zu MiB dbcache may be too large for a system memory of only %zu MiB."),

--- a/src/node/caches.h
+++ b/src/node/caches.h
@@ -23,6 +23,7 @@ struct CacheSizes {
 CacheSizes CalculateCacheSizes(const ArgsManager& args, size_t n_indexes = 0);
 
 void LogOversizedDbCache(const ArgsManager& args) noexcept;
+void LogAutoDbCacheSettings() noexcept;
 } // namespace node
 
 #endif // BITCOIN_NODE_CACHES_H

--- a/src/node/caches.h
+++ b/src/node/caches.h
@@ -6,19 +6,11 @@
 #define BITCOIN_NODE_CACHES_H
 
 #include <kernel/caches.h>
-#include <util/byte_units.h>
-
 #include <cstddef>
 
 class ArgsManager;
 
-//! min. -dbcache (bytes)
-static constexpr size_t MIN_DB_CACHE{4_MiB};
-//! -dbcache default (bytes)
-static constexpr size_t DEFAULT_DB_CACHE{DEFAULT_KERNEL_CACHE};
-
 namespace node {
-size_t GetDefaultDBCache();
 struct IndexCacheSizes {
     size_t tx_index{0};
     size_t filter_index{0};
@@ -29,11 +21,6 @@ struct CacheSizes {
     kernel::CacheSizes kernel;
 };
 CacheSizes CalculateCacheSizes(const ArgsManager& args, size_t n_indexes = 0);
-constexpr bool ShouldWarnOversizedDbCache(size_t dbcache, size_t total_ram) noexcept
-{
-    const size_t cap{(total_ram < 2048_MiB) ? DEFAULT_DB_CACHE : (total_ram / 100) * 75};
-    return dbcache > cap;
-}
 
 void LogOversizedDbCache(const ArgsManager& args) noexcept;
 } // namespace node

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -21,6 +21,7 @@
 #include <util/time.h>
 #include <util/translation.h>
 #include <validation.h>
+#include <node/dbcache.h>
 
 #include <algorithm>
 #include <cassert>
@@ -171,6 +172,9 @@ ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSize
 
     chainman.m_total_coinstip_cache = cache_sizes.coins;
     chainman.m_total_coinsdb_cache = cache_sizes.coins_db;
+    chainman.m_auto_dbcache = options.auto_dbcache;
+    chainman.m_total_ram_bytes = options.total_ram_bytes.value_or(node::GetTotalRam());
+    chainman.m_fixed_index_cache_bytes = options.fixed_index_cache_bytes;
 
     // Load the fully validated chainstate.
     Chainstate& validated_cs{chainman.InitializeChainstate(options.mempool)};

--- a/src/node/chainstate.h
+++ b/src/node/chainstate.h
@@ -8,8 +8,10 @@
 #include <util/translation.h>
 #include <validation.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <optional>
 #include <tuple>
 
 class CTxMemPool;
@@ -22,6 +24,9 @@ namespace node {
 
 struct ChainstateLoadOptions {
     CTxMemPool* mempool{nullptr};
+    bool auto_dbcache{true};
+    std::optional<size_t> total_ram_bytes{};
+    size_t fixed_index_cache_bytes{0};
     bool coins_db_in_memory{false};
     // Whether to wipe the chainstate database when loading it. If set, this
     // will cause the chainstate database to be rebuilt starting from genesis.

--- a/src/node/dbcache.cpp
+++ b/src/node/dbcache.cpp
@@ -1,0 +1,26 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/dbcache.h>
+#include <cstddef>
+#include <common/system_ram.h>
+#include <algorithm>
+
+namespace node {
+size_t GetDefaultDBCache() noexcept
+{
+    if constexpr (sizeof(void*) >= 8) {
+        if (TryGetTotalRam().value_or(0) >= HIGH_DEFAULT_DBCACHE_MIN_TOTAL_RAM) {
+            return HIGH_DEFAULT_DBCACHE;
+        }
+    }
+    return 450_MiB;
+}
+
+bool ShouldWarnOversizedDbCache(size_t dbcache, size_t total_ram) noexcept
+{
+    return (total_ram < 2048_MiB) ? dbcache > GetDefaultDBCache()
+                                  : dbcache > (total_ram / 100) * 75;
+}
+} // namespace node

--- a/src/node/dbcache.cpp
+++ b/src/node/dbcache.cpp
@@ -2,25 +2,26 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <node/dbcache.h>
-#include <cstddef>
 #include <common/system_ram.h>
+#include <node/dbcache.h>
+
 #include <algorithm>
+#include <cstddef>
+#include <optional>
 
 namespace node {
-size_t GetDefaultDBCache() noexcept
+size_t GetTotalRam() noexcept { return TryGetTotalRam().value_or(FALLBACK_RAM_BYTES); }
+
+size_t GetDefaultDBCache(std::optional<size_t> total_ram) noexcept
 {
-    if constexpr (sizeof(void*) >= 8) {
-        if (TryGetTotalRam().value_or(0) >= HIGH_DEFAULT_DBCACHE_MIN_TOTAL_RAM) {
-            return HIGH_DEFAULT_DBCACHE;
-        }
-    }
-    return 450_MiB;
+    if (!total_ram) total_ram.emplace(GetTotalRam());
+    const size_t usable{*total_ram > RESERVED_RAM ? *total_ram - RESERVED_RAM : 0};
+    return std::clamp(usable / 4, MIN_DEFAULT_DBCACHE, std::min(MAX_DEFAULT_DBCACHE, MAX_DBCACHE_BYTES));
 }
 
 bool ShouldWarnOversizedDbCache(size_t dbcache, size_t total_ram) noexcept
 {
-    return (total_ram < 2048_MiB) ? dbcache > GetDefaultDBCache()
-                                  : dbcache > (total_ram / 100) * 75;
+    return (total_ram < FALLBACK_RAM_BYTES) ? dbcache > GetDefaultDBCache(total_ram)
+                                            : dbcache > (total_ram / 100) * 75;
 }
 } // namespace node

--- a/src/node/dbcache.cpp
+++ b/src/node/dbcache.cpp
@@ -2,11 +2,14 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/args.h>
 #include <common/system_ram.h>
 #include <node/dbcache.h>
 
 #include <algorithm>
 #include <cstddef>
+#include <cstdint>
+#include <limits>
 #include <optional>
 
 namespace node {
@@ -21,6 +24,12 @@ size_t GetAutoDbCache(std::optional<size_t> total_ram, bool ibd) noexcept
 
 size_t GetTotalRam() noexcept
 {
+    if (const auto mock_total_ram_mib{gArgs.GetIntArg("-mocktotalram")};
+        mock_total_ram_mib && *mock_total_ram_mib > 0) {
+        const uint64_t mib{static_cast<uint64_t>(std::max<int64_t>(*mock_total_ram_mib, 0))};
+        constexpr uint64_t max_size_t{std::numeric_limits<size_t>::max()};
+        return mib > (max_size_t >> 20) ? max_size_t : mib << 20;
+    }
     return TryGetTotalRam().value_or(FALLBACK_RAM_BYTES);
 }
 

--- a/src/node/dbcache.cpp
+++ b/src/node/dbcache.cpp
@@ -10,13 +10,23 @@
 #include <optional>
 
 namespace node {
-size_t GetTotalRam() noexcept { return TryGetTotalRam().value_or(FALLBACK_RAM_BYTES); }
-
-size_t GetDefaultDBCache(std::optional<size_t> total_ram) noexcept
+namespace {
+size_t GetAutoDbCache(std::optional<size_t> total_ram, bool ibd) noexcept
 {
     if (!total_ram) total_ram.emplace(GetTotalRam());
     const size_t usable{*total_ram > RESERVED_RAM ? *total_ram - RESERVED_RAM : 0};
-    return std::clamp(usable / 4, MIN_DEFAULT_DBCACHE, std::min(MAX_DEFAULT_DBCACHE, MAX_DBCACHE_BYTES));
+    return std::clamp(usable / (ibd ? 4 : 20), MIN_DEFAULT_DBCACHE, std::min(MAX_DEFAULT_DBCACHE, MAX_DBCACHE_BYTES));
+}
+} // namespace
+
+size_t GetTotalRam() noexcept
+{
+    return TryGetTotalRam().value_or(FALLBACK_RAM_BYTES);
+}
+
+size_t GetDefaultDBCache(std::optional<size_t> total_ram, bool ibd) noexcept
+{
+    return GetAutoDbCache(total_ram, ibd);
 }
 
 bool ShouldWarnOversizedDbCache(size_t dbcache, size_t total_ram) noexcept

--- a/src/node/dbcache.h
+++ b/src/node/dbcache.h
@@ -27,7 +27,7 @@ static constexpr size_t MAX_DBCACHE_BYTES{SIZE_MAX == UINT64_MAX ? std::numeric_
 
 namespace node {
 size_t GetTotalRam() noexcept;
-size_t GetDefaultDBCache(std::optional<size_t> total_ram = {}) noexcept;
+size_t GetDefaultDBCache(std::optional<size_t> total_ram = {}, bool ibd = true) noexcept;
 
 bool ShouldWarnOversizedDbCache(size_t dbcache, size_t total_ram) noexcept;
 } // namespace node

--- a/src/node/dbcache.h
+++ b/src/node/dbcache.h
@@ -1,0 +1,29 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODE_DBCACHE_H
+#define BITCOIN_NODE_DBCACHE_H
+
+#include <util/byte_units.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+//! min. -dbcache (bytes)
+static constexpr size_t MIN_DB_CACHE{4_MiB};
+//! Maximum dbcache size on current architecture.
+static constexpr size_t MAX_DBCACHE_BYTES{SIZE_MAX == UINT64_MAX ? std::numeric_limits<size_t>::max() : 1024_MiB};
+//! Larger default dbcache on 64-bit systems with enough RAM.
+static constexpr size_t HIGH_DEFAULT_DBCACHE{1024_MiB};
+//! Minimum detected RAM required for HIGH_DEFAULT_DBCACHE.
+static constexpr uint64_t HIGH_DEFAULT_DBCACHE_MIN_TOTAL_RAM{4096ULL << 20};
+
+namespace node {
+size_t GetDefaultDBCache() noexcept;
+
+bool ShouldWarnOversizedDbCache(size_t dbcache, size_t total_ram) noexcept;
+} // namespace node
+
+#endif // BITCOIN_NODE_DBCACHE_H

--- a/src/node/dbcache.h
+++ b/src/node/dbcache.h
@@ -10,18 +10,24 @@
 #include <cstddef>
 #include <cstdint>
 #include <limits>
+#include <optional>
 
 //! min. -dbcache (bytes)
 static constexpr size_t MIN_DB_CACHE{4_MiB};
+//! Automatic -dbcache floor (bytes)
+static constexpr size_t MIN_DEFAULT_DBCACHE{100_MiB};
+//! Automatic -dbcache cap (bytes)
+static constexpr size_t MAX_DEFAULT_DBCACHE{2048_MiB};
+//! Assumed total RAM when we cannot determine it.
+static constexpr size_t FALLBACK_RAM_BYTES{SIZE_MAX == UINT64_MAX ? 4096_MiB : 2048_MiB};
+//! Reserved non-dbcache memory usage.
+static constexpr size_t RESERVED_RAM{2048_MiB};
 //! Maximum dbcache size on current architecture.
 static constexpr size_t MAX_DBCACHE_BYTES{SIZE_MAX == UINT64_MAX ? std::numeric_limits<size_t>::max() : 1024_MiB};
-//! Larger default dbcache on 64-bit systems with enough RAM.
-static constexpr size_t HIGH_DEFAULT_DBCACHE{1024_MiB};
-//! Minimum detected RAM required for HIGH_DEFAULT_DBCACHE.
-static constexpr uint64_t HIGH_DEFAULT_DBCACHE_MIN_TOTAL_RAM{4096ULL << 20};
 
 namespace node {
-size_t GetDefaultDBCache() noexcept;
+size_t GetTotalRam() noexcept;
+size_t GetDefaultDBCache(std::optional<size_t> total_ram = {}) noexcept;
 
 bool ShouldWarnOversizedDbCache(size_t dbcache, size_t total_ram) noexcept;
 } // namespace node

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -16,7 +16,7 @@
 #include <common/system.h>
 #include <interfaces/node.h>
 #include <netbase.h>
-#include <node/caches.h>
+#include <node/dbcache.h>
 #include <node/chainstatemanager_args.h>
 #include <util/strencodings.h>
 

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -15,8 +15,8 @@
 #include <mapport.h>
 #include <net.h>
 #include <netbase.h>
-#include <node/caches.h>
 #include <node/chainstatemanager_args.h>
+#include <node/dbcache.h>
 #include <univalue.h>
 #include <util/string.h>
 #include <validation.h>
@@ -732,7 +732,7 @@ void OptionsModel::checkAndMigrate()
         // see https://github.com/bitcoin/bitcoin/pull/8273
         // force people to upgrade to the new value if they are using 100MB
         if (settingsVersion < 130000 && settings.contains("nDatabaseCache") && settings.value("nDatabaseCache").toLongLong() == 100)
-            settings.setValue("nDatabaseCache", (qint64)(DEFAULT_DB_CACHE >> 20));
+            settings.setValue("nDatabaseCache", qint64(node::GetDefaultDBCache() >> 20));
 
         settings.setValue(strSettingsVersionKey, CLIENT_VERSION);
     }

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -201,7 +201,6 @@ function(add_boost_test source_file)
       SKIP_REGULAR_EXPRESSION
         "no test cases matching filter"
         "skipping script_assets_test"
-        "skipping total_ram"
     )
   endforeach()
 endfunction()

--- a/src/test/caches_tests.cpp
+++ b/src/test/caches_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or https://opensource.org/license/mit.
 
 #include <node/caches.h>
+#include <node/dbcache.h>
 #include <util/byte_units.h>
 
 #include <boost/test/unit_test.hpp>
@@ -13,10 +14,10 @@ BOOST_AUTO_TEST_SUITE(caches_tests)
 
 BOOST_AUTO_TEST_CASE(oversized_dbcache_warning)
 {
-    // memory restricted setup - cap is DEFAULT_DB_CACHE (450 MiB)
-    BOOST_CHECK(!ShouldWarnOversizedDbCache(/*dbcache=*/4_MiB, /*total_ram=*/1024_MiB));    // Under cap
-    BOOST_CHECK( ShouldWarnOversizedDbCache(/*dbcache=*/512_MiB, /*total_ram=*/1024_MiB));  // At cap
-    BOOST_CHECK( ShouldWarnOversizedDbCache(/*dbcache=*/1500_MiB, /*total_ram=*/1024_MiB)); // Over cap
+    // Below 2 GiB RAM, the warning cap follows `GetDefaultDBCache()`.
+    BOOST_CHECK(!ShouldWarnOversizedDbCache(MIN_DB_CACHE, /*total_ram=*/1024_MiB));            // Under cap
+    BOOST_CHECK(!ShouldWarnOversizedDbCache(GetDefaultDBCache(), /*total_ram=*/1024_MiB));     // At cap
+    BOOST_CHECK( ShouldWarnOversizedDbCache(GetDefaultDBCache() + 1, /*total_ram=*/1024_MiB)); // Over cap
 
     // 2 GiB RAM - cap is 75%
     BOOST_CHECK(!ShouldWarnOversizedDbCache(/*dbcache=*/1500_MiB, /*total_ram=*/2048_MiB)); // Under cap

--- a/src/test/caches_tests.cpp
+++ b/src/test/caches_tests.cpp
@@ -2,43 +2,84 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/license/mit.
 
-#include <node/caches.h>
 #include <node/dbcache.h>
 #include <util/byte_units.h>
 
 #include <boost/test/unit_test.hpp>
 
+#include <array>
+#include <cstdint>
+#include <limits>
+#include <utility>
+
 using namespace node;
+
+namespace {
+void CheckDbCacheWarnThreshold(size_t threshold, size_t total_ram)
+{
+    BOOST_CHECK(!ShouldWarnOversizedDbCache(threshold, total_ram));
+    BOOST_CHECK( ShouldWarnOversizedDbCache(threshold + 1, total_ram));
+}
+} // namespace
 
 BOOST_AUTO_TEST_SUITE(caches_tests)
 
-BOOST_AUTO_TEST_CASE(oversized_dbcache_warning)
+BOOST_AUTO_TEST_CASE(default_dbcache_formula_by_total_ram)
 {
-    // Below 2 GiB RAM, the warning cap follows `GetDefaultDBCache()`.
-    BOOST_CHECK(!ShouldWarnOversizedDbCache(MIN_DB_CACHE, /*total_ram=*/1024_MiB));            // Under cap
-    BOOST_CHECK(!ShouldWarnOversizedDbCache(GetDefaultDBCache(), /*total_ram=*/1024_MiB));     // At cap
-    BOOST_CHECK( ShouldWarnOversizedDbCache(GetDefaultDBCache() + 1, /*total_ram=*/1024_MiB)); // Over cap
+    BOOST_CHECK(FALLBACK_RAM_BYTES >= 1024_MiB);
+    for (const auto& [total_ram, expected] : std::array<std::pair<size_t, size_t>, 4>{{
+        {512_MiB, MIN_DEFAULT_DBCACHE},
+        {1024_MiB, MIN_DEFAULT_DBCACHE},
+        {RESERVED_RAM - 1, MIN_DEFAULT_DBCACHE},
+        {RESERVED_RAM, MIN_DEFAULT_DBCACHE}
+    }}) {
+        BOOST_CHECK_EQUAL(GetDefaultDBCache(total_ram), expected);
+    }
 
-    // 2 GiB RAM - cap is 75%
-    BOOST_CHECK(!ShouldWarnOversizedDbCache(/*dbcache=*/1500_MiB, /*total_ram=*/2048_MiB)); // Under cap
-    BOOST_CHECK( ShouldWarnOversizedDbCache(/*dbcache=*/1600_MiB, /*total_ram=*/2048_MiB)); // Over cap
+    BOOST_CHECK_EQUAL(GetDefaultDBCache(3072_MiB), 256_MiB);
 
     if constexpr (SIZE_MAX == UINT64_MAX) {
-        // 4 GiB RAM - cap is 75%
-        BOOST_CHECK(!ShouldWarnOversizedDbCache(/*dbcache=*/2500_MiB, /*total_ram=*/4096_MiB)); // Under cap
-        BOOST_CHECK( ShouldWarnOversizedDbCache(/*dbcache=*/3500_MiB, /*total_ram=*/4096_MiB)); // Over cap
+        for (const auto& [total_ram_64, expected] : std::array<std::pair<size_t, size_t>, 3>{{
+            {8192_MiB, 1536_MiB},
+            {16384_MiB, MAX_DEFAULT_DBCACHE},
+            {32768_MiB, MAX_DEFAULT_DBCACHE}
+        }}) {
+            BOOST_CHECK_EQUAL(GetDefaultDBCache(total_ram_64), expected);
+        }
+    }
+}
 
-        // 8 GiB RAM - cap is 75%
-        BOOST_CHECK(!ShouldWarnOversizedDbCache(/*dbcache=*/6000_MiB, /*total_ram=*/8192_MiB)); // Under cap
-        BOOST_CHECK( ShouldWarnOversizedDbCache(/*dbcache=*/7000_MiB, /*total_ram=*/8192_MiB)); // Over cap
+BOOST_AUTO_TEST_CASE(default_dbcache_uses_current_total_ram)
+{
+    BOOST_CHECK_EQUAL(GetDefaultDBCache(), GetDefaultDBCache(GetTotalRam()));
+}
 
-        // 16 GiB RAM - cap is 75%
-        BOOST_CHECK(!ShouldWarnOversizedDbCache(/*dbcache=*/10'000_MiB, /*total_ram=*/16384_MiB)); // Under cap
-        BOOST_CHECK( ShouldWarnOversizedDbCache(/*dbcache=*/15'000_MiB, /*total_ram=*/16384_MiB)); // Over cap
+BOOST_AUTO_TEST_CASE(oversized_dbcache_warning)
+{
+    BOOST_CHECK(!ShouldWarnOversizedDbCache(MIN_DB_CACHE, 1024_MiB));
 
-        // 32 GiB RAM - cap is 75%
-        BOOST_CHECK(!ShouldWarnOversizedDbCache(/*dbcache=*/20'000_MiB, /*total_ram=*/32768_MiB)); // Under cap
-        BOOST_CHECK( ShouldWarnOversizedDbCache(/*dbcache=*/30'000_MiB, /*total_ram=*/32768_MiB)); // Over cap
+    CheckDbCacheWarnThreshold(GetDefaultDBCache(1024_MiB), 1024_MiB);
+    CheckDbCacheWarnThreshold(GetDefaultDBCache(FALLBACK_RAM_BYTES - 1_MiB), FALLBACK_RAM_BYTES - 1_MiB);
+
+    CheckDbCacheWarnThreshold((FALLBACK_RAM_BYTES / 100) * 75, FALLBACK_RAM_BYTES);
+
+    if constexpr (SIZE_MAX == UINT64_MAX) {
+        const size_t total_ram{16384_MiB};
+        BOOST_CHECK(!ShouldWarnOversizedDbCache(/*dbcache=*/12'000_MiB, total_ram));
+        BOOST_CHECK( ShouldWarnOversizedDbCache(/*dbcache=*/13'000_MiB, total_ram));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(default_dbcache_never_warns)
+{
+    for (const auto& total_ram : {1024_MiB, 2048_MiB, 3072_MiB}) {
+        BOOST_CHECK(!ShouldWarnOversizedDbCache(GetDefaultDBCache(total_ram), total_ram));
+    }
+
+    if constexpr (SIZE_MAX == UINT64_MAX) {
+        for (const auto& total_ram : {4096_MiB, 8192_MiB, 16384_MiB, 32768_MiB}) {
+            BOOST_CHECK(!ShouldWarnOversizedDbCache(GetDefaultDBCache(total_ram), total_ram));
+        }
     }
 }
 

--- a/src/test/caches_tests.cpp
+++ b/src/test/caches_tests.cpp
@@ -49,9 +49,35 @@ BOOST_AUTO_TEST_CASE(default_dbcache_formula_by_total_ram)
     }
 }
 
+BOOST_AUTO_TEST_CASE(post_ibd_dbcache_formula_by_total_ram)
+{
+    for (const auto& [total_ram, expected] : std::array<std::pair<size_t, size_t>, 4>{{
+        {512_MiB, MIN_DEFAULT_DBCACHE},
+        {1024_MiB, MIN_DEFAULT_DBCACHE},
+        {RESERVED_RAM - 1, MIN_DEFAULT_DBCACHE},
+        {4108_MiB, 103_MiB}
+    }}) {
+        BOOST_CHECK_EQUAL(GetDefaultDBCache(total_ram, /*ibd=*/false), expected);
+        BOOST_CHECK_LE(GetDefaultDBCache(total_ram, /*ibd=*/false), GetDefaultDBCache(total_ram));
+    }
+
+    BOOST_CHECK_EQUAL(GetDefaultDBCache(8208_MiB, /*ibd=*/false), 308_MiB);
+
+    if constexpr (SIZE_MAX == UINT64_MAX) {
+        for (const auto& [total_ram_64, expected] : std::array<std::pair<size_t, size_t>, 3>{{
+            {16388_MiB, 717_MiB},
+            {43008_MiB, MAX_DEFAULT_DBCACHE},
+            {65528_MiB, MAX_DEFAULT_DBCACHE}
+        }}) {
+            BOOST_CHECK_EQUAL(GetDefaultDBCache(total_ram_64, /*ibd=*/false), expected);
+        }
+    }
+}
+
 BOOST_AUTO_TEST_CASE(default_dbcache_uses_current_total_ram)
 {
     BOOST_CHECK_EQUAL(GetDefaultDBCache(), GetDefaultDBCache(GetTotalRam()));
+    BOOST_CHECK_EQUAL(GetDefaultDBCache(/*total_ram=*/{}, /*ibd=*/false), GetDefaultDBCache(GetTotalRam(), /*ibd=*/false));
 }
 
 BOOST_AUTO_TEST_CASE(oversized_dbcache_warning)

--- a/src/test/system_ram_tests.cpp
+++ b/src/test/system_ram_tests.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/license/mit/.
 
-#include <common/system.h>
+#include <common/system_ram.h>
 #include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
@@ -14,18 +14,13 @@ BOOST_AUTO_TEST_SUITE(system_ram_tests)
 
 BOOST_AUTO_TEST_CASE(total_ram)
 {
-    const auto total{GetTotalRAM()};
-    if (!total) {
-        BOOST_WARN_MESSAGE(false, "skipping total_ram: total RAM unknown");
-        return;
-    }
-
-    BOOST_CHECK_GE(*total, 1000_MiB);
+    const auto total{*Assert(TryGetTotalRam())};
+    BOOST_CHECK_GE(total, 1024_MiB);
 
     if constexpr (SIZE_MAX == UINT64_MAX) {
         // Upper bound check only on 64-bit: 32-bit systems can reasonably have max memory,
         // but extremely large values on 64-bit likely indicate detection errors
-        BOOST_CHECK_LT(*total, 10'000'000_MiB); // >10 TiB memory is unlikely
+        BOOST_CHECK_LT(total, 10'000'000_MiB); // >10 TiB memory is unlikely
     }
 }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -30,6 +30,7 @@
 #include <kernel/warning.h>
 #include <logging/timer.h>
 #include <node/blockstorage.h>
+#include <node/dbcache.h>
 #include <node/utxo_snapshot.h>
 #include <policy/ephemeral_policy.h>
 #include <policy/policy.h>
@@ -6068,6 +6069,17 @@ Chainstate& ChainstateManager::ActiveChainstate() const
 void ChainstateManager::MaybeRebalanceCaches()
 {
     AssertLockHeld(::cs_main);
+    if (m_auto_dbcache) {
+        const size_t target_dbcache{node::GetDefaultDBCache(m_total_ram_bytes, IsInitialBlockDownload())};
+        const size_t target_kernel_cache{
+            target_dbcache > m_fixed_index_cache_bytes
+                ? std::max(target_dbcache - m_fixed_index_cache_bytes, MIN_DB_CACHE)
+                : MIN_DB_CACHE};
+        const kernel::CacheSizes cache_sizes{target_kernel_cache};
+        m_total_coinsdb_cache = cache_sizes.coins_db;
+        m_total_coinstip_cache = cache_sizes.coins;
+    }
+
     Chainstate& current_cs{CurrentChainstate()};
     Chainstate* historical_cs{HistoricalChainstate()};
     if (!historical_cs && !current_cs.m_from_snapshot_blockhash) {

--- a/src/validation.h
+++ b/src/validation.h
@@ -1084,6 +1084,12 @@ public:
     //! The total number of bytes available for us to use across all leveldb
     //! coins databases. This will be split somehow across chainstates.
     size_t m_total_coinsdb_cache{0};
+    //! Whether the current cache budget came from the automatic default instead of an explicit `-dbcache`.
+    bool m_auto_dbcache{true};
+    //! Total RAM used for automatic dbcache sizing.
+    size_t m_total_ram_bytes{0};
+    //! Dbcache bytes reserved for runtime-fixed index caches outside the chainstate split.
+    size_t m_fixed_index_cache_bytes{0};
 
     //! Instantiate a new chainstate.
     //!

--- a/test/functional/feature_dbcache_post_ibd.py
+++ b/test/functional/feature_dbcache_post_ibd.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test automatic dbcache reduction after initial block download."""
+
+import time
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_greater_than
+
+
+DEFAULT_MAX_TIP_AGE = 24 * 60 * 60
+MOCK_TOTAL_RAM_MIB = 8208
+
+
+class DBCachePostIBDTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+        self.extra_args = [[], [f"-mocktotalram={MOCK_TOTAL_RAM_MIB}"]]
+
+    def get_active_chainstate(self, node):
+        return node.getchainstates()["chainstates"][-1]
+
+    def run_test(self):
+        miner = self.nodes[0]
+        ibd_node = self.nodes[1]
+
+        now = int(time.time())
+        miner.setmocktime(now - DEFAULT_MAX_TIP_AGE - 1000)
+        ibd_node.setmocktime(now)
+        self.connect_nodes(0, 1)
+
+        self.log.info("Sync an old chain so the receiving node remains in IBD.")
+        self.generate(miner, 10)
+        self.wait_until(lambda: ibd_node.getblockcount() == 10)
+        assert ibd_node.getblockchaininfo()["initialblockdownload"]
+
+        before = self.get_active_chainstate(ibd_node)
+        before_total = before["coins_db_cache_bytes"] + before["coins_tip_cache_bytes"]
+        self.log.info(f"IBD cache sizes: coinsdb={before['coins_db_cache_bytes']} coinstip={before['coins_tip_cache_bytes']}")
+
+        self.log.info("Mine a recent block and verify automatic dbcache is reduced immediately after IBD.")
+        with ibd_node.assert_debug_log(
+            expected_msgs=[
+                "Leaving InitialBlockDownload (latching to false)",
+                "resized coinsdb cache",
+                "resized coinstip cache",
+            ],
+            timeout=10,
+        ):
+            miner.setmocktime(now)
+            self.generate(miner, 1)
+            self.wait_until(lambda: not ibd_node.getblockchaininfo()["initialblockdownload"])
+
+        after = self.get_active_chainstate(ibd_node)
+        after_total = after["coins_db_cache_bytes"] + after["coins_tip_cache_bytes"]
+        self.log.info(f"Post-IBD cache sizes: coinsdb={after['coins_db_cache_bytes']} coinstip={after['coins_tip_cache_bytes']}")
+
+        assert ibd_node.getmempoolinfo()["usage"] == 0
+        assert_greater_than(before_total, after_total)
+        assert_greater_than(before["coins_tip_cache_bytes"], after["coins_tip_cache_bytes"])
+
+
+if __name__ == "__main__":
+    DBCachePostIBDTest(__file__).main()


### PR DESCRIPTION
Automatic `-dbcache` sizing currently keeps the larger initial block download allocation after sync completes, even though steady-state validation needs less chainstate cache. This leaves memory tied up longer than necessary and makes the automatic setting less adaptive to the node's actual operating phase.

This series centralizes `dbcache` default selection, makes the automatic value RAM-aware, and teaches `ChainstateManager` to recompute the automatic target when leaving initial block download. The runtime reduction only applies when `-dbcache` was not set explicitly, preserves fixed index cache allocations, adds logging for the selected automatic value, and includes unit and functional test coverage using a debug-only `-mocktotalram` override.