### PR TITLE
bench: fix stateful benchmark setup and inputs

### DIFF
--- a/src/bench/chacha20.cpp
+++ b/src/bench/chacha20.cpp
@@ -8,8 +8,10 @@
 #include <crypto/chacha20poly1305.h>
 #include <span.h>
 
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <vector>
 
 /* Number of bytes to process per iteration */
@@ -20,25 +22,30 @@ static const uint64_t BUFFER_SIZE_LARGE = 1024*1024;
 static void CHACHA20(benchmark::Bench& bench, size_t buffersize)
 {
     std::vector<std::byte> key(32, {});
-    ChaCha20 ctx(key);
-    ctx.Seek({0, 0}, 0);
+    std::optional<ChaCha20> ctx;
     std::vector<std::byte> in(buffersize, {});
     std::vector<std::byte> out(buffersize, {});
-    bench.batch(in.size()).unit("byte").run([&] {
-        ctx.Crypt(in, out);
-    });
+    bench.batch(in.size()).unit("byte").epochIterations(1)
+        .setup([&] { ctx.emplace(key); })
+        .run([&] {
+            ctx->Crypt(in, out);
+            assert(out[0] == std::byte{0x76});
+        });
 }
 
 static void FSCHACHA20POLY1305(benchmark::Bench& bench, size_t buffersize)
 {
     std::vector<std::byte> key(32);
-    FSChaCha20Poly1305 ctx(key, 224);
+    std::optional<FSChaCha20Poly1305> ctx;
     std::vector<std::byte> in(buffersize);
     std::vector<std::byte> aad;
     std::vector<std::byte> out(buffersize + FSChaCha20Poly1305::EXPANSION);
-    bench.batch(in.size()).unit("byte").run([&] {
-        ctx.Encrypt(in, aad, out);
-    });
+    bench.batch(in.size()).unit("byte").epochIterations(1)
+        .setup([&] { ctx.emplace(key, 224); })
+        .run([&] {
+            ctx->Encrypt(in, aad, out);
+            assert(out[0] == std::byte{0x9f});
+        });
 }
 
 static void CHACHA20_64BYTES(benchmark::Bench& bench)

--- a/src/bench/mempool_ephemeral_spends.cpp
+++ b/src/bench/mempool_ephemeral_spends.cpp
@@ -59,8 +59,8 @@ static void MempoolCheckEphemeralSpends(benchmark::Bench& bench)
     CMutableTransaction tx2;
     tx2.vin.resize(tx1.vout.size());
     for (size_t i = 0; i < tx2.vin.size(); i++) {
-        tx2.vin[0].prevout.hash = parent_txid;
-        tx2.vin[0].prevout.n = i;
+        tx2.vin[i].prevout.hash = parent_txid;
+        tx2.vin[i].prevout.n = i;
     }
     tx2.vout.resize(1);
 
@@ -71,6 +71,7 @@ static void MempoolCheckEphemeralSpends(benchmark::Bench& bench)
     const CTransactionRef tx2_r{MakeTransactionRef(tx2)};
 
     AddTx(tx1_r, pool);
+    assert(tx2_r->vin.back().prevout == COutPoint(parent_txid, tx2_r->vin.size() - 1));
 
     uint32_t iteration{0};
 

--- a/src/bench/nanobench.h
+++ b/src/bench/nanobench.h
@@ -40,6 +40,7 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include <chrono>        // high_resolution_clock
+#include <cassert>       // assert
 #include <cstring>       // memcpy
 #include <iosfwd>        // for std::ostream* custom output target in Config
 #include <string>        // all names
@@ -1238,6 +1239,8 @@ public:
     template <typename Op>
     ANKERL_NANOBENCH_NO_SANITIZE("integer")
     Bench& run(Op&& op) {
+        assert(mBench.epochIterations() == 1 &&
+               "setup() runs once per epoch, not once per iteration; use epochIterations(1) when setup() must reset state for each timed call");
         return mBench.runImpl(mSetupOp, std::forward<Op>(op));
     }
 

--- a/src/bench/wallet_balance.cpp
+++ b/src/bench/wallet_balance.cpp
@@ -62,11 +62,9 @@ static void WalletBalance(benchmark::Bench& bench, const bool set_dirty, const b
 
 static void WalletBalanceDirty(benchmark::Bench& bench) { WalletBalance(bench, /*set_dirty=*/true, /*add_mine=*/true); }
 static void WalletBalanceClean(benchmark::Bench& bench) { WalletBalance(bench, /*set_dirty=*/false, /*add_mine=*/true); }
-static void WalletBalanceMine(benchmark::Bench& bench) { WalletBalance(bench, /*set_dirty=*/false, /*add_mine=*/true); }
 static void WalletBalanceWatch(benchmark::Bench& bench) { WalletBalance(bench, /*set_dirty=*/false, /*add_mine=*/false); }
 
 BENCHMARK(WalletBalanceDirty);
 BENCHMARK(WalletBalanceClean);
-BENCHMARK(WalletBalanceMine);
 BENCHMARK(WalletBalanceWatch);
 } // namespace wallet


### PR DESCRIPTION
### Problem
The `CHACHA20` and `FSCHACHA20POLY1305` benchmarks reused a single cipher object across timed calls.
That advanced the stream state across samples, so later samples no longer measured work from the same starting point.
A few other benchmarks could benefit from the same iteration-stability treatment, but that is outside the scope of this PR.

While investigating this, it also became clear that `MempoolCheckEphemeralSpends` only populated `vin[0]` in its loop, and that `WalletBalanceMine` duplicated `WalletBalanceClean`.
The same review also showed that nanobench `setup()` can be misused as though it runs once per timed call.

### Fix
Rebuild the `ChaCha` ciphers in `setup()` and pair that setup with `epochIterations(1)` so each timed call starts from the same state.
Add a nanobench assertion that `setup()` is only used with `epochIterations(1)`.
Also fix the ephemeral spend benchmark inputs and remove the duplicate wallet balance benchmark.

### Context
Found while reviewing https://github.com/bitcoin/bitcoin/pull/35018, which led to a few additional benchmark fixes.