### PR TITLE
dbwrapper: increase LevelDB bloom filter bits per key

### DIFF
--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -141,7 +141,7 @@ static leveldb::Options GetOptions(size_t nCacheSize)
     leveldb::Options options;
     options.block_cache = leveldb::NewLRUCache(nCacheSize / 2);
     options.write_buffer_size = nCacheSize / 4; // up to two write buffers may be held in memory simultaneously
-    options.filter_policy = leveldb::NewBloomFilterPolicy(10);
+    options.filter_policy = leveldb::NewBloomFilterPolicy(16);
     options.compression = leveldb::kNoCompression;
     options.info_log = new CBitcoinLevelDBLogger();
     if (leveldb::kMajorVersion > 1 || (leveldb::kMajorVersion == 1 && leveldb::kMinorVersion >= 16)) {


### PR DESCRIPTION
Reindex/import becomes dominated by random chainstate lookups once the in-memory UTXO cache no longer holds the working set. Increasing bits-per-key reduces bloom false positives, avoiding unnecessary table block reads and seeks.

Tradeoff: slightly larger filter blocks.
