### PR TITLE
validation: avoid precomputing txdata when script checks are skipped

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2502,15 +2502,16 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
 
     CBlockUndo blockundo;
 
-    // Precomputed transaction data pointers must not be invalidated
-    // until after `control` has run the script checks (potentially
-    // in multiple threads). Preallocate the vector size so a new allocation
-    // doesn't invalidate pointers into the vector, and keep txsdata in scope
-    // for as long as `control`.
+    // Precomputed transaction data pointers must not be invalidated until after
+    // `control` has run the script checks (potentially in multiple threads).
+    // Only allocate the per-tx data when script checks are enabled to avoid
+    // wasting time initializing it during IBD when script verification is
+    // skipped (assumevalid).
     std::optional<CCheckQueueControl<CScriptCheck>> control;
     if (auto& queue = m_chainman.GetCheckQueue(); queue.HasThreads() && fScriptChecks) control.emplace(queue);
 
-    std::vector<PrecomputedTransactionData> txsdata(block.vtx.size());
+    std::vector<PrecomputedTransactionData> txsdata;
+    if (fScriptChecks) txsdata.resize(block.vtx.size());
 
     std::vector<int> prevheights;
     CAmount nFees = 0;
@@ -2569,6 +2570,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
 
         if (!tx.IsCoinBase() && fScriptChecks)
         {
+            assert(!txsdata.empty());
             bool fCacheResults = fJustCheck; /* Don't cache results if we're actually connecting blocks (still consult the cache, though) */
             bool tx_ok;
             TxValidationState tx_state;


### PR DESCRIPTION
**Problem:** During assumevalid IBD and `-reindex-chainstate`, `ConnectBlock()` may skip script verification for old blocks, but it still allocated a fresh `txsdata` vector and default-constructed one `PrecomputedTransactionData` entry for every transaction in each connected block.
Because `CheckInputScripts()` is not called in that path, the vector is dropped at the end of the block without being used.

**Fix:** Leave `txsdata` empty unless `fScriptChecks` is true, then resize it before queued checks can take pointers into the vector.
Keep the existing lifetime comment and add an indexed-use assert that matches the real precondition.
