### PR TITLE
coins: use 1 MiB pool chunks for UTXO cache map

### DIFF
--- a/src/coins.h
+++ b/src/coins.h
@@ -14,9 +14,10 @@
 #include <serialize.h>
 #include <support/allocators/pool.h>
 #include <uint256.h>
+#include <util/byte_units.h>
 #include <util/check.h>
-#include <util/overflow.h>
 #include <util/hasher.h>
+#include <util/overflow.h>
 
 #include <cassert>
 #include <cstdint>
@@ -401,7 +402,7 @@ protected:
      * declared as "const".
      */
     mutable uint256 m_block_hash;
-    mutable CCoinsMapMemoryResource m_cache_coins_memory_resource{};
+    mutable CCoinsMapMemoryResource m_cache_coins_memory_resource{1_MiB};
     /* The starting sentinel of the flagged entry circular doubly linked list. */
     mutable CoinsCachePair m_sentinel;
     mutable CCoinsMap cacheCoins;

--- a/src/test/validation_flush_tests.cpp
+++ b/src/test/validation_flush_tests.cpp
@@ -23,12 +23,13 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
     LOCK(::cs_main);
     CCoinsViewCache& view{chainstate.CoinsTip()};
 
-    // Sanity: an empty cache should be ≲ 1 chunk (~ 256 KiB).
-    BOOST_CHECK_LT(view.DynamicMemoryUsage() / (256 * 1024.0), 1.1);
+    // Sanity: an empty cache should remain close to one pool chunk.
+    // With 1 MiB pool chunks this is ~4 x 256 KiB.
+    BOOST_CHECK_LT(view.DynamicMemoryUsage() / (256 * 1024.0), 4.5);
 
     constexpr size_t MAX_COINS_BYTES{8_MiB};
     constexpr size_t MAX_MEMPOOL_BYTES{4_MiB};
-    constexpr size_t MAX_ATTEMPTS{50'000};
+    constexpr size_t MAX_ATTEMPTS{200'000};
 
     // Run the same growth-path twice: first with 0 head-room, then with extra head-room
     for (size_t max_mempool_size_bytes : {size_t{0}, MAX_MEMPOOL_BYTES}) {
@@ -44,7 +45,9 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
         }
 
         // LARGE → CRITICAL
-        for (size_t i{0}; i < MAX_ATTEMPTS && int64_t(view.DynamicMemoryUsage()) <= full_cap; ++i) {
+        //
+        // The cache can remain LARGE slightly beyond full_cap due to overshoot allowance.
+        for (size_t i{0}; i < MAX_ATTEMPTS && state != CoinsCacheSizeState::CRITICAL; ++i) {
             BOOST_CHECK_EQUAL(state, CoinsCacheSizeState::LARGE);
             AddTestCoin(m_rng, view);
             state = chainstate.GetCoinsCacheSizeState(MAX_COINS_BYTES, max_mempool_size_bytes);


### PR DESCRIPTION
Perf profiles during offline validation show significant time in malloc/free (e.g. _int_malloc, malloc_consolidate) while the coins cache grows.

Construct the CCoinsViewCache node allocator resource with a larger chunk size (1 MiB vs the 256 KiB default) to reduce the frequency of aligned operator new() calls without changing the steady-state memory footprint.
