### PR TITLE
util: shorten thread names to avoid truncation

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -689,7 +689,7 @@ and its `cs_KeyStore` lock for example).
 - [HTTP worker threads (`b-http.x`)](https://doxygen.bitcoincore.org/httpserver_8cpp.html#a2ad0a49dc9b5e8117c0dee98c24187d8)
   : Threads to service RPC and REST requests.
 
-- [Indexer threads (`b-txindex`, etc)](https://doxygen.bitcoincore.org/class_base_index.html#a96a7407421fbf877509248bbe64f8d87)
+- [Indexer threads (`b-txindex`, `b-basicfltridx`, `b-coinstatsidx`, `b-txospenderidx`)](https://doxygen.bitcoincore.org/class_base_index.html#a96a7407421fbf877509248bbe64f8d87)
   : One thread per indexer.
 
 - [SchedulerThread (`b-scheduler`)](https://doxygen.bitcoincore.org/class_c_scheduler.html#a14d2800815da93577858ea078aed1fba)

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -164,7 +164,7 @@ To run clang-tidy on Ubuntu/Debian, install the dependencies:
 apt install clang-tidy clang
 ```
 
-Configure with clang as the compiler:
+Configure with clang as the compiler with the below command that should create a `compile_commands.json` file within the build directory:
 
 ```sh
 cmake -B build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
@@ -172,11 +172,18 @@ cmake -B build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_EXP
 
 The output is denoised of errors from external dependencies.
 
-To run clang-tidy on all source files:
+To run clang-tidy on all source files using the checks mentioned in the `./src/.clang-tidy` file:
 
 ```sh
 ( cd ./src/ && run-clang-tidy -p ../build -j $(nproc) )
 ```
+
+To run clang-tidy on one file:
+```sh
+( cd ./src/ && run-clang-tidy -p ../build -j $(nproc) ./path/to/single_file.cpp )
+```
+
+Optionally, append the `run-clang-tidy` command with the `-quiet` option to suppress printing of statistics and ignored warnings that can clutter the output. The `-fix` option also comes in handy to apply the fixes suggested by the tool but need to ensure that unrelated changes in the file are not committed.
 
 To run clang-tidy on the changed source lines:
 

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -686,7 +686,7 @@ and its `cs_KeyStore` lock for example).
 - [ThreadHTTP (`b-http`)](https://doxygen.bitcoincore.org/httpserver_8cpp.html#abb9f6ea8819672bd9a62d3695070709c)
   : Libevent thread to listen for RPC and REST connections.
 
-- [HTTP worker threads (`b-http_pool_x`)](https://doxygen.bitcoincore.org/httpserver_8cpp.html#a2ad0a49dc9b5e8117c0dee98c24187d8)
+- [HTTP worker threads (`b-http.x`)](https://doxygen.bitcoincore.org/httpserver_8cpp.html#a2ad0a49dc9b5e8117c0dee98c24187d8)
   : Threads to service RPC and REST requests.
 
 - [Indexer threads (`b-txindex`, etc)](https://doxygen.bitcoincore.org/class_base_index.html#a96a7407421fbf877509248bbe64f8d87)

--- a/doc/release-notes-34911.md
+++ b/doc/release-notes-34911.md
@@ -1,0 +1,12 @@
+### Mempool
+
+mempoolfullrbf=1 behaviour has been the default since v28 and the argument has
+been removed since v29 subsequently. The `getmempoolinfo` RPC stops returning the
+deprecated `fullrbf` key in the response unless the user requests it via the
+`-deprecatedrpc=fullrbf` node argument.
+
+Also, the `bip125-replaceable` key is removed from the mempool RPCs
+responses (because it, too, has been deprecated since v29) unless the user
+requests it via `-deprecatedrpc=bip125` node argument. Affected mempool RPCs
+are `getrawmempool`, `getmempoolancestors`, `getmempooldescendants`, and
+`getmempoolentry`.

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -92,8 +92,8 @@ void BaseIndex::DB::WriteBestBlock(CDBBatch& batch, const CBlockLocator& locator
     batch.Write(DB_BEST_BLOCK, locator);
 }
 
-BaseIndex::BaseIndex(std::unique_ptr<interfaces::Chain> chain, std::string name)
-    : m_chain{std::move(chain)}, m_name{std::move(name)} {}
+BaseIndex::BaseIndex(std::unique_ptr<interfaces::Chain> chain, std::string name, const std::string& thread_name)
+    : m_chain{std::move(chain)}, m_name{std::move(name)}, m_thread_name{thread_name.empty() ? m_name : thread_name} {}
 
 BaseIndex::~BaseIndex()
 {
@@ -460,7 +460,7 @@ bool BaseIndex::StartBackgroundSync()
 {
     if (!m_init) throw std::logic_error("Error: Cannot start a non-initialized index");
 
-    m_thread_sync = std::thread(&util::TraceThread, GetName(), [this] { Sync(); });
+    m_thread_sync = std::thread(&util::TraceThread, m_thread_name, [this] { Sync(); });
     return true;
 }
 

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -117,6 +117,7 @@ protected:
     std::unique_ptr<interfaces::Chain> m_chain;
     Chainstate* m_chainstate{nullptr};
     const std::string m_name;
+    const std::string m_thread_name;
 
     void BlockConnected(const kernel::ChainstateRole& role, const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindex) override;
 
@@ -141,7 +142,7 @@ protected:
     void SetBestBlockIndex(const CBlockIndex* block);
 
 public:
-    BaseIndex(std::unique_ptr<interfaces::Chain> chain, std::string name);
+    BaseIndex(std::unique_ptr<interfaces::Chain> chain, std::string name, const std::string& thread_name = "");
     /// Destructor interrupts sync thread if running and blocks until it exits.
     virtual ~BaseIndex();
 

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -75,7 +75,7 @@ static std::map<BlockFilterType, BlockFilterIndex> g_filter_indexes;
 
 BlockFilterIndex::BlockFilterIndex(std::unique_ptr<interfaces::Chain> chain, BlockFilterType filter_type,
                                    size_t n_cache_size, bool f_memory, bool f_wipe)
-    : BaseIndex(std::move(chain), BlockFilterTypeName(filter_type) + " block filter index")
+    : BaseIndex(std::move(chain), BlockFilterTypeName(filter_type) + " block filter index", BlockFilterTypeName(filter_type) + "fltridx")
     , m_filter_type(filter_type)
 {
     const std::string& filter_name = BlockFilterTypeName(filter_type);

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -87,7 +87,7 @@ struct DBVal {
 std::unique_ptr<CoinStatsIndex> g_coin_stats_index;
 
 CoinStatsIndex::CoinStatsIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory, bool f_wipe)
-    : BaseIndex(std::move(chain), "coinstatsindex")
+    : BaseIndex(std::move(chain), "coinstatsindex", "coinstatsidx")
 {
     // An earlier version of the index used "indexes/coinstats" but it contained
     // a bug and is superseded by a fixed version at "indexes/coinstatsindex".

--- a/src/index/txospenderindex.cpp
+++ b/src/index/txospenderindex.cpp
@@ -60,7 +60,7 @@ struct DBKey {
 };
 
 TxoSpenderIndex::TxoSpenderIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory, bool f_wipe)
-    : BaseIndex(std::move(chain), "txospenderindex"), m_db{std::make_unique<DB>(gArgs.GetDataDirNet() / "indexes" / "txospenderindex" / "db", n_cache_size, f_memory, f_wipe)}
+    : BaseIndex(std::move(chain), "txospenderindex", "txospenderidx"), m_db{std::make_unique<DB>(gArgs.GetDataDirNet() / "indexes" / "txospenderindex" / "db", n_cache_size, f_memory, f_wipe)}
 {
     if (!m_db->Read("siphash_key", m_siphash_key)) {
         FastRandomContext rng(false);

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -430,7 +430,7 @@ static std::vector<RPCResult> ClusterDescription()
 
 static std::vector<RPCResult> MempoolEntryDescription()
 {
-    return {
+    std::vector<RPCResult> list = {
         RPCResult{RPCResult::Type::NUM, "vsize", "virtual transaction size as defined in BIP 141. This is different from actual serialized size for witness transactions as witness data is discounted."},
         RPCResult{RPCResult::Type::NUM, "weight", "transaction weight as defined in BIP 141."},
         RPCResult{RPCResult::Type::NUM_TIME, "time", "local time transaction entered pool in seconds since 1 Jan 1970 GMT"},
@@ -453,9 +453,12 @@ static std::vector<RPCResult> MempoolEntryDescription()
             {RPCResult{RPCResult::Type::STR_HEX, "transactionid", "parent transaction id"}}},
         RPCResult{RPCResult::Type::ARR, "spentby", "unconfirmed transactions spending outputs from this transaction",
             {RPCResult{RPCResult::Type::STR_HEX, "transactionid", "child transaction id"}}},
-        RPCResult{RPCResult::Type::BOOL, "bip125-replaceable", "Whether this transaction signals BIP125 replaceability or has an unconfirmed ancestor signaling BIP125 replaceability. (DEPRECATED)\n"},
         RPCResult{RPCResult::Type::BOOL, "unbroadcast", "Whether this transaction is currently unbroadcast (initial broadcast not yet acknowledged by any peers)"},
     };
+    if (IsDeprecatedRPCEnabled("bip125")) {
+        list.emplace_back(RPCResult::Type::BOOL, "bip125-replaceable", "Whether this transaction signals BIP125 replaceability or has an unconfirmed ancestor signaling BIP125 replaceability. (DEPRECATED)\n");
+    }
+    return list;
 }
 
 void AppendChunkInfo(UniValue& all_chunks, FeePerWeight chunk_feerate, std::vector<const CTxMemPoolEntry *> chunk_txs)
@@ -554,18 +557,19 @@ static void entryToJSON(const CTxMemPool& pool, UniValue& info, const CTxMemPool
     }
 
     info.pushKV("spentby", std::move(spent));
+    info.pushKV("unbroadcast", pool.IsUnbroadcastTx(tx.GetHash()));
 
     // Add opt-in RBF status
-    bool rbfStatus = false;
-    RBFTransactionState rbfState = IsRBFOptIn(tx, pool);
-    if (rbfState == RBFTransactionState::UNKNOWN) {
-        throw JSONRPCError(RPC_MISC_ERROR, "Transaction is not in mempool");
-    } else if (rbfState == RBFTransactionState::REPLACEABLE_BIP125) {
-        rbfStatus = true;
+    if (IsDeprecatedRPCEnabled("bip125")) {
+        bool rbfStatus = false;
+        RBFTransactionState rbfState = IsRBFOptIn(tx, pool);
+        if (rbfState == RBFTransactionState::UNKNOWN) {
+            throw JSONRPCError(RPC_MISC_ERROR, "Transaction is not in mempool");
+        } else if (rbfState == RBFTransactionState::REPLACEABLE_BIP125) {
+            rbfStatus = true;
+        }
+        info.pushKV("bip125-replaceable", rbfStatus);
     }
-
-    info.pushKV("bip125-replaceable", rbfStatus);
-    info.pushKV("unbroadcast", pool.IsUnbroadcastTx(tx.GetHash()));
 }
 
 UniValue MempoolToJSON(const CTxMemPool& pool, bool verbose, bool include_mempool_sequence)

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -1055,12 +1055,14 @@ UniValue MempoolInfoToJSON(const CTxMemPool& pool)
     ret.pushKV("minrelaytxfee", ValueFromAmount(pool.m_opts.min_relay_feerate.GetFeePerK()));
     ret.pushKV("incrementalrelayfee", ValueFromAmount(pool.m_opts.incremental_relay_feerate.GetFeePerK()));
     ret.pushKV("unbroadcastcount", pool.GetUnbroadcastTxs().size());
-    ret.pushKV("fullrbf", true);
     ret.pushKV("permitbaremultisig", pool.m_opts.permit_bare_multisig);
     ret.pushKV("maxdatacarriersize", pool.m_opts.max_datacarrier_bytes.value_or(0));
     ret.pushKV("limitclustercount", pool.m_opts.limits.cluster_count);
     ret.pushKV("limitclustersize", pool.m_opts.limits.cluster_size_vbytes);
     ret.pushKV("optimal", pool.m_txgraph->DoWork(0)); // 0 work is a quick check for known optimality
+    if (IsDeprecatedRPCEnabled("fullrbf")) {
+        ret.pushKV("fullrbf", true);
+    }
     return ret;
 }
 
@@ -1071,24 +1073,30 @@ static RPCHelpMan getmempoolinfo()
         {},
         RPCResult{
             RPCResult::Type::OBJ, "", "",
-            {
-                {RPCResult::Type::BOOL, "loaded", "True if the initial load attempt of the persisted mempool finished"},
-                {RPCResult::Type::NUM, "size", "Current tx count"},
-                {RPCResult::Type::NUM, "bytes", "Sum of all virtual transaction sizes as defined in BIP 141. Differs from actual serialized size because witness data is discounted"},
-                {RPCResult::Type::NUM, "usage", "Total memory usage for the mempool"},
-                {RPCResult::Type::STR_AMOUNT, "total_fee", "Total fees for the mempool in " + CURRENCY_UNIT + ", ignoring modified fees through prioritisetransaction"},
-                {RPCResult::Type::NUM, "maxmempool", "Maximum memory usage for the mempool"},
-                {RPCResult::Type::STR_AMOUNT, "mempoolminfee", "Minimum fee rate in " + CURRENCY_UNIT + "/kvB for tx to be accepted. Is the maximum of minrelaytxfee and minimum mempool fee"},
-                {RPCResult::Type::STR_AMOUNT, "minrelaytxfee", "Current minimum relay fee for transactions"},
-                {RPCResult::Type::NUM, "incrementalrelayfee", "minimum fee rate increment for mempool limiting or replacement in " + CURRENCY_UNIT + "/kvB"},
-                {RPCResult::Type::NUM, "unbroadcastcount", "Current number of transactions that haven't passed initial broadcast yet"},
-                {RPCResult::Type::BOOL, "fullrbf", "True if the mempool accepts RBF without replaceability signaling inspection (DEPRECATED)"},
-                {RPCResult::Type::BOOL, "permitbaremultisig", "True if the mempool accepts transactions with bare multisig outputs"},
-                {RPCResult::Type::NUM, "maxdatacarriersize", "Maximum number of bytes that can be used by OP_RETURN outputs in the mempool"},
-                {RPCResult::Type::NUM, "limitclustercount", "Maximum number of transactions that can be in a cluster (configured by -limitclustercount)"},
-                {RPCResult::Type::NUM, "limitclustersize", "Maximum size of a cluster in virtual bytes (configured by -limitclustersize)"},
-                {RPCResult::Type::BOOL, "optimal", "If the mempool is in a known-optimal transaction ordering"},
-            }},
+            [](){
+                std::vector<RPCResult> list = {
+                    {RPCResult::Type::BOOL, "loaded", "True if the initial load attempt of the persisted mempool finished"},
+                    {RPCResult::Type::NUM, "size", "Current tx count"},
+                    {RPCResult::Type::NUM, "bytes", "Sum of all virtual transaction sizes as defined in BIP 141. Differs from actual serialized size because witness data is discounted"},
+                    {RPCResult::Type::NUM, "usage", "Total memory usage for the mempool"},
+                    {RPCResult::Type::STR_AMOUNT, "total_fee", "Total fees for the mempool in " + CURRENCY_UNIT + ", ignoring modified fees through prioritisetransaction"},
+                    {RPCResult::Type::NUM, "maxmempool", "Maximum memory usage for the mempool"},
+                    {RPCResult::Type::STR_AMOUNT, "mempoolminfee", "Minimum fee rate in " + CURRENCY_UNIT + "/kvB for tx to be accepted. Is the maximum of minrelaytxfee and minimum mempool fee"},
+                    {RPCResult::Type::STR_AMOUNT, "minrelaytxfee", "Current minimum relay fee for transactions"},
+                    {RPCResult::Type::NUM, "incrementalrelayfee", "minimum fee rate increment for mempool limiting or replacement in " + CURRENCY_UNIT + "/kvB"},
+                    {RPCResult::Type::NUM, "unbroadcastcount", "Current number of transactions that haven't passed initial broadcast yet"},
+                    {RPCResult::Type::BOOL, "permitbaremultisig", "True if the mempool accepts transactions with bare multisig outputs"},
+                    {RPCResult::Type::NUM, "maxdatacarriersize", "Maximum number of bytes that can be used by OP_RETURN outputs in the mempool"},
+                    {RPCResult::Type::NUM, "limitclustercount", "Maximum number of transactions that can be in a cluster (configured by -limitclustercount)"},
+                    {RPCResult::Type::NUM, "limitclustersize", "Maximum size of a cluster in virtual bytes (configured by -limitclustersize)"},
+                    {RPCResult::Type::BOOL, "optimal", "If the mempool is in a known-optimal transaction ordering"},
+                };
+                if (IsDeprecatedRPCEnabled("fullrbf")) {
+                    list.emplace_back(RPCResult::Type::BOOL, "fullrbf", "True if the mempool accepts RBF without replaceability signaling inspection (DEPRECATED)");
+                }
+                return list;
+            }()
+            },
         RPCExamples{
             HelpExampleCli("getmempoolinfo", "")
             + HelpExampleRpc("getmempoolinfo", "")

--- a/src/util/threadpool.h
+++ b/src/util/threadpool.h
@@ -112,7 +112,7 @@ public:
         // Create workers
         m_workers.reserve(num_workers);
         for (int i = 0; i < num_workers; i++) {
-            m_workers.emplace_back(&util::TraceThread, strprintf("%s_pool_%d", m_name, i), [this] { WorkerThread(); });
+            m_workers.emplace_back(&util::TraceThread, strprintf("%s.%d", m_name, i), [this] { WorkerThread(); });
         }
     }
 

--- a/test/functional/feature_init.py
+++ b/test/functional/feature_init.py
@@ -80,7 +80,7 @@ class InitTest(BitcoinTestFramework):
             b'txindex thread start',
             b'basicfltridx thread start',
             b'coinstatsidx thread start',
-            b'txospenderindex thread start',
+            b'txospenderidx thread start',
             b'msghand thread start',
             b'net thread start',
             b'addcon thread start',

--- a/test/functional/feature_init.py
+++ b/test/functional/feature_init.py
@@ -79,7 +79,7 @@ class InitTest(BitcoinTestFramework):
             b'initload thread start',
             b'txindex thread start',
             b'basicfltridx thread start',
-            b'coinstatsindex thread start',
+            b'coinstatsidx thread start',
             b'txospenderindex thread start',
             b'msghand thread start',
             b'net thread start',

--- a/test/functional/feature_init.py
+++ b/test/functional/feature_init.py
@@ -78,7 +78,7 @@ class InitTest(BitcoinTestFramework):
             b'addcon thread start',
             b'initload thread start',
             b'txindex thread start',
-            b'block filter index thread start',
+            b'basicfltridx thread start',
             b'coinstatsindex thread start',
             b'txospenderindex thread start',
             b'msghand thread start',

--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -28,7 +28,7 @@ class ReplaceByFeeTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
         self.uses_wallet = None
-        self.extra_args = [["-deprecatedrpc=fullrbf"], []]
+        self.extra_args = [["-deprecatedrpc=fullrbf", "-deprecatedrpc=bip125"], []]
 
     def run_test(self):
         self.wallet = MiniWallet(self.nodes[0])

--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -28,6 +28,7 @@ class ReplaceByFeeTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
         self.uses_wallet = None
+        self.extra_args = [["-deprecatedrpc=fullrbf"], []]
 
     def run_test(self):
         self.wallet = MiniWallet(self.nodes[0])


### PR DESCRIPTION
### Problem

Linux limits thread names set through [`PR_SET_NAME`](https://man7.org/linux/man-pages/man2/PR_GET_NAME.2const.html) to 16 bytes including the null terminator:

> The name can be up to 16 bytes long, including the terminating null byte.

Longer names are silently truncated. Bitcoin Core prefixes system thread names with `b-`, leaving only 13 bytes for readable names.
This makes longer names less useful in system tools, for example `b-coinstatsindex` and `b-txospenderindex`, and makes verbose suffixes like `b-http_pool_N` spend much of the available space.

The same limit is documented in the existing thread-name helper:
https://github.com/bitcoin/bitcoin/blob/8b49e2dd4eed93d08a3d9681d444aaf441ab0037/src/util/threadnames.cpp#L25

### Fix

Shorten the affected OS thread names while keeping them recognizable.

ThreadPool workers now use a dotted numeric suffix, so HTTP workers are named like `b-http.0`.

Indexer thread names are shortened to fit within the Linux limit after the `b-` prefix:

```
basic block filter index -> basicfltridx
coinstatsindex           -> coinstatsidx
txospenderindex          -> txospenderidx
```

Indexer display names, `getindexinfo` keys, command-line options, and on-disk index paths are unchanged.

### Testing

See https://godbolt.org/z/GhEsKehh9 for a simple reproducer.

The truncation can be reproduced on Linux by starting `bitcoind` with the affected indexes enabled and reading the kernel-visible thread names.

Before this change, the affected names are truncated or unnecessarily long:

```text
b-basic block f
b-coinstatsinde
b-http_pool_15
b-txospenderind
```

After this change, the same check shows compact, untruncated names:

```text
b-basicfltridx
b-coinstatsidx
b-http.15
b-txospenderidx
```