### PR TITLE
move-only: hide internal cache helpers

### DIFF
--- a/src/coins.h
+++ b/src/coins.h
@@ -392,8 +392,13 @@ public:
 /** CCoinsView that adds a memory cache for transactions to another CCoinsView */
 class CCoinsViewCache : public CCoinsViewBacked
 {
-private:
     const bool m_deterministic;
+
+    /**
+     * @note this is marked const, but may actually append to `cacheCoins`, increasing
+     * memory usage.
+     */
+    CCoinsMap::iterator FetchCoin(const COutPoint &outpoint) const;
 
 protected:
     /**
@@ -543,13 +548,6 @@ public:
 
     //! Create a scoped guard that will call `Reset()` on this cache when it goes out of scope.
     [[nodiscard]] ResetGuard CreateResetGuard() noexcept { return ResetGuard{*this}; }
-
-private:
-    /**
-     * @note this is marked const, but may actually append to `cacheCoins`, increasing
-     * memory usage.
-     */
-    CCoinsMap::iterator FetchCoin(const COutPoint &outpoint) const;
 };
 
 /**

--- a/src/coins.h
+++ b/src/coins.h
@@ -401,6 +401,22 @@ class CCoinsViewCache : public CCoinsViewBacked
     //! See: https://stackoverflow.com/questions/42114044/how-to-release-unordered-map-memory
     void ReallocateCache();
 
+    class ResetGuard
+    {
+    private:
+        friend CCoinsViewCache;
+        CCoinsViewCache& m_cache;
+        explicit ResetGuard(CCoinsViewCache& cache LIFETIMEBOUND) noexcept : m_cache{cache} {}
+
+    public:
+        ResetGuard(const ResetGuard&) = delete;
+        ResetGuard& operator=(const ResetGuard&) = delete;
+        ResetGuard(ResetGuard&&) = delete;
+        ResetGuard& operator=(ResetGuard&&) = delete;
+
+        ~ResetGuard() { m_cache.Reset(); }
+    };
+
     /**
      * @note this is marked const, but may actually append to `cacheCoins`, increasing
      * memory usage.
@@ -529,22 +545,6 @@ public:
 
     //! Run an internal sanity check on the cache data structure. */
     void SanityCheck() const;
-
-    class ResetGuard
-    {
-    private:
-        friend CCoinsViewCache;
-        CCoinsViewCache& m_cache;
-        explicit ResetGuard(CCoinsViewCache& cache LIFETIMEBOUND) noexcept : m_cache{cache} {}
-
-    public:
-        ResetGuard(const ResetGuard&) = delete;
-        ResetGuard& operator=(const ResetGuard&) = delete;
-        ResetGuard(ResetGuard&&) = delete;
-        ResetGuard& operator=(ResetGuard&&) = delete;
-
-        ~ResetGuard() { m_cache.Reset(); }
-    };
 
     //! Create a scoped guard that will call `Reset()` on this cache when it goes out of scope.
     [[nodiscard]] ResetGuard CreateResetGuard() noexcept { return ResetGuard{*this}; }

--- a/src/coins.h
+++ b/src/coins.h
@@ -394,6 +394,13 @@ class CCoinsViewCache : public CCoinsViewBacked
 {
     const bool m_deterministic;
 
+    //! Force a reallocation of the cache map. This is required when downsizing
+    //! the cache because the map's allocator may be hanging onto a lot of
+    //! memory despite having called .clear().
+    //!
+    //! See: https://stackoverflow.com/questions/42114044/how-to-release-unordered-map-memory
+    void ReallocateCache();
+
     /**
      * @note this is marked const, but may actually append to `cacheCoins`, increasing
      * memory usage.
@@ -519,13 +526,6 @@ public:
 
     //! Check whether all prevouts of the transaction are present in the UTXO set represented by this view
     bool HaveInputs(const CTransaction& tx) const;
-
-    //! Force a reallocation of the cache map. This is required when downsizing
-    //! the cache because the map's allocator may be hanging onto a lot of
-    //! memory despite having called .clear().
-    //!
-    //! See: https://stackoverflow.com/questions/42114044/how-to-release-unordered-map-memory
-    void ReallocateCache();
 
     //! Run an internal sanity check on the cache data structure. */
     void SanityCheck() const;


### PR DESCRIPTION
### Problem
`CCoinsViewCache` exposes a few implementation details that are only used to maintain its own cache state.
This makes the public interface broader than necessary, and leaves the class declaration split across repeated access sections.

### Fix
Group the internal declarations in the default-private part of `CCoinsViewCache`, then move `ReallocateCache()` and `ResetGuard` out of the public interface.

`CreateResetGuard()` remains public, so callers can still request scoped reset behavior without naming or constructing the guard type directly.
`Reset()` remains protected for subclass-facing reset hooks.