### PR TITLE
coins: split coins view cache and storage contracts

### DIFF
--- a/src/bench/ccoins_caching.cpp
+++ b/src/bench/ccoins_caching.cpp
@@ -26,7 +26,7 @@ static void CCoinsCaching(benchmark::Bench& bench)
     ECC_Context ecc_context{};
 
     FillableSigningProvider keystore;
-    CCoinsViewCache coins{&CoinsViewEmpty::Get()};
+    CCoinsViewCache coins{CoinsViewEmpty::Get()};
     std::vector<CMutableTransaction> dummyTransactions =
         SetupDummyInputs(keystore, coins, {11 * COIN, 50 * COIN, 21 * COIN, 22 * COIN});
 

--- a/src/bench/connectblock.cpp
+++ b/src/bench/connectblock.cpp
@@ -98,7 +98,8 @@ void BenchmarkConnectBlock(benchmark::Bench& bench, std::vector<CKey>& keys, std
         auto& chainstate{chainman->ActiveChainstate()};
         BlockValidationState test_block_state;
         auto* pindex{chainman->m_blockman.AddToBlockIndex(test_block, chainman->m_best_header)}; // Doing this here doesn't impact the benchmark
-        CCoinsViewCache viewNew{&chainstate.CoinsTip()};
+        CCoinsView& coins_backend{chainstate.CoinsTip()};
+        CCoinsViewCache viewNew{coins_backend};
 
         assert(chainstate.ConnectBlock(test_block, test_block_state, pindex, viewNew));
     });

--- a/src/bench/connectblock.cpp
+++ b/src/bench/connectblock.cpp
@@ -98,8 +98,7 @@ void BenchmarkConnectBlock(benchmark::Bench& bench, std::vector<CKey>& keys, std
         auto& chainstate{chainman->ActiveChainstate()};
         BlockValidationState test_block_state;
         auto* pindex{chainman->m_blockman.AddToBlockIndex(test_block, chainman->m_best_header)}; // Doing this here doesn't impact the benchmark
-        CCoinsViewCacheBackend& coins_backend{chainstate.CoinsTip()};
-        CCoinsViewCache viewNew{coins_backend};
+        CCoinsViewCache viewNew{chainstate.CoinsTip()};
 
         assert(chainstate.ConnectBlock(test_block, test_block_state, pindex, viewNew));
     });

--- a/src/bench/connectblock.cpp
+++ b/src/bench/connectblock.cpp
@@ -98,7 +98,7 @@ void BenchmarkConnectBlock(benchmark::Bench& bench, std::vector<CKey>& keys, std
         auto& chainstate{chainman->ActiveChainstate()};
         BlockValidationState test_block_state;
         auto* pindex{chainman->m_blockman.AddToBlockIndex(test_block, chainman->m_best_header)}; // Doing this here doesn't impact the benchmark
-        CCoinsView& coins_backend{chainstate.CoinsTip()};
+        CCoinsViewCacheBackend& coins_backend{chainstate.CoinsTip()};
         CCoinsViewCache viewNew{coins_backend};
 
         assert(chainstate.ConnectBlock(test_block, test_block_state, pindex, viewNew));

--- a/src/bench/mempool_stress.cpp
+++ b/src/bench/mempool_stress.cpp
@@ -200,7 +200,7 @@ static void MempoolCheck(benchmark::Bench& bench)
     CTxMemPool& pool = *testing_setup.get()->m_node.mempool;
     LOCK2(cs_main, pool.cs);
     testing_setup->PopulateMempool(det_rand, 400, true);
-    const CCoinsViewCache& coins_tip = testing_setup.get()->m_node.chainman->ActiveChainstate().CoinsTip();
+    CCoinsViewCache& coins_tip = testing_setup.get()->m_node.chainman->ActiveChainstate().CoinsTip();
 
     bench.run([&]() NO_THREAD_SAFETY_ANALYSIS {
         // Bump up the spendheight so we don't hit premature coinbase spend errors.

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -586,7 +586,7 @@ static void MutateTxSign(CMutableTransaction& tx, const std::string& flagStr)
     // starts as a clone of the raw tx:
     CMutableTransaction mergedTx{tx};
     const CMutableTransaction txv{tx};
-    CCoinsViewCache view{&CoinsViewEmpty::Get()};
+    CCoinsViewCache view{CoinsViewEmpty::Get()};
 
     if (!registers.contains("privatekeys"))
         throw std::runtime_error("privatekeys register variable must be set.");

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -28,8 +28,8 @@ std::optional<Coin> CCoinsViewCache::PeekCoin(const COutPoint& outpoint) const
     return base->PeekCoin(outpoint);
 }
 
-CCoinsViewCache::CCoinsViewCache(CCoinsView* in_base, bool deterministic) :
-    m_deterministic(deterministic), base{Assert(in_base)},
+CCoinsViewCache::CCoinsViewCache(CCoinsView& in_base, bool deterministic) :
+    m_deterministic(deterministic), base{&in_base},
     cacheCoins(0, SaltedOutpointHasher(/*deterministic=*/deterministic), CCoinsMap::key_equal{}, &m_cache_coins_memory_resource)
 {
     m_sentinel.second.SelfRef(m_sentinel);

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -28,7 +28,7 @@ std::optional<Coin> CCoinsViewCache::PeekCoin(const COutPoint& outpoint) const
     return base->PeekCoin(outpoint);
 }
 
-CCoinsViewCache::CCoinsViewCache(CCoinsView& in_base, bool deterministic) :
+CCoinsViewCache::CCoinsViewCache(CCoinsViewCacheBackend& in_base, bool deterministic) :
     m_deterministic(deterministic), base{&in_base},
     cacheCoins(0, SaltedOutpointHasher(/*deterministic=*/deterministic), CCoinsMap::key_equal{}, &m_cache_coins_memory_resource)
 {

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -28,11 +28,21 @@ std::optional<Coin> CCoinsViewCache::PeekCoin(const COutPoint& outpoint) const
     return base->PeekCoin(outpoint);
 }
 
-CCoinsViewCache::CCoinsViewCache(CCoinsViewCacheBackend& in_base, bool deterministic) :
+CCoinsViewCache::CCoinsViewCache(BackendTag, CCoinsViewCacheBackend& in_base, bool deterministic) :
     m_deterministic(deterministic), base{&in_base},
     cacheCoins(0, SaltedOutpointHasher(/*deterministic=*/deterministic), CCoinsMap::key_equal{}, &m_cache_coins_memory_resource)
 {
     m_sentinel.second.SelfRef(m_sentinel);
+}
+
+CCoinsViewCache::CCoinsViewCache(CCoinsViewCacheBackend& in_base, bool deterministic) :
+    CCoinsViewCache(BackendTag{}, in_base, deterministic)
+{
+}
+
+CCoinsViewCache::CCoinsViewCache(CCoinsViewCache& in_base, bool deterministic) :
+    CCoinsViewCache(BackendTag{}, in_base, deterministic)
+{
 }
 
 size_t CCoinsViewCache::DynamicMemoryUsage() const {

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -29,7 +29,7 @@ std::optional<Coin> CCoinsViewCache::PeekCoin(const COutPoint& outpoint) const
 }
 
 CCoinsViewCache::CCoinsViewCache(CCoinsView* in_base, bool deterministic) :
-    CCoinsViewBacked(in_base), m_deterministic(deterministic),
+    m_deterministic(deterministic), base{Assert(in_base)},
     cacheCoins(0, SaltedOutpointHasher(/*deterministic=*/deterministic), CCoinsMap::key_equal{}, &m_cache_coins_memory_resource)
 {
     m_sentinel.second.SelfRef(m_sentinel);
@@ -395,15 +395,15 @@ static ReturnType ExecuteBackedWrapper(Func func, const std::vector<std::functio
 
 std::optional<Coin> CCoinsViewErrorCatcher::GetCoin(const COutPoint& outpoint) const
 {
-    return ExecuteBackedWrapper<std::optional<Coin>>([&]() { return CCoinsViewBacked::GetCoin(outpoint); }, m_err_callbacks);
+    return ExecuteBackedWrapper<std::optional<Coin>>([&]() { return base->GetCoin(outpoint); }, m_err_callbacks);
 }
 
 bool CCoinsViewErrorCatcher::HaveCoin(const COutPoint& outpoint) const
 {
-    return ExecuteBackedWrapper<bool>([&]() { return CCoinsViewBacked::HaveCoin(outpoint); }, m_err_callbacks);
+    return ExecuteBackedWrapper<bool>([&]() { return base->HaveCoin(outpoint); }, m_err_callbacks);
 }
 
 std::optional<Coin> CCoinsViewErrorCatcher::PeekCoin(const COutPoint& outpoint) const
 {
-    return ExecuteBackedWrapper<std::optional<Coin>>([&]() { return CCoinsViewBacked::PeekCoin(outpoint); }, m_err_callbacks);
+    return ExecuteBackedWrapper<std::optional<Coin>>([&]() { return base->PeekCoin(outpoint); }, m_err_callbacks);
 }

--- a/src/coins.h
+++ b/src/coins.h
@@ -386,6 +386,10 @@ public:
 class CCoinsViewCache : public CCoinsViewCacheBackend
 {
 private:
+    struct BackendTag {};
+
+    CCoinsViewCache(BackendTag, CCoinsViewCacheBackend& in_base, bool deterministic);
+
     const bool m_deterministic;
 
 protected:
@@ -417,9 +421,11 @@ protected:
 
 public:
     CCoinsViewCache(CCoinsViewCacheBackend& in_base, bool deterministic = false);
+    explicit CCoinsViewCache(CCoinsViewCache& in_base, bool deterministic = false);
 
     /**
-     * By deleting the copy constructor, we prevent accidentally using it when one intends to create a cache on top of a base cache.
+     * By deleting the copy constructor, we prevent accidentally copying a cache.
+     * Construct from a non-const parent cache to create a cache on top of it.
      */
     CCoinsViewCache(const CCoinsViewCache &) = delete;
 

--- a/src/coins.h
+++ b/src/coins.h
@@ -409,7 +409,7 @@ protected:
     virtual std::optional<Coin> FetchCoinFromBase(const COutPoint& outpoint) const;
 
 public:
-    CCoinsViewCache(CCoinsView* in_base, bool deterministic = false);
+    CCoinsViewCache(CCoinsView& in_base, bool deterministic = false);
 
     /**
      * By deleting the copy constructor, we prevent accidentally using it when one intends to create a cache on top of a base cache.

--- a/src/coins.h
+++ b/src/coins.h
@@ -324,6 +324,13 @@ public:
 
     //! Retrieve the block hash whose state this CCoinsView currently represents
     virtual uint256 GetBestBlock() const = 0;
+};
+
+/** Pure abstract interface for a same-state reader and batch-write target. */
+class CCoinsViewCacheBackend : public CCoinsView
+{
+public:
+    virtual ~CCoinsViewCacheBackend() override = default;
 
     //! Do a bulk modification (multiple Coin changes + BestBlock change).
     //! The passed cursor is used to iterate through the coins.
@@ -354,7 +361,7 @@ public:
 };
 
 /** Noop coins view. */
-class CoinsViewEmpty : public CCoinsView
+class CoinsViewEmpty : public CCoinsViewCacheBackend
 {
 protected:
     CoinsViewEmpty() = default;
@@ -376,13 +383,13 @@ public:
 };
 
 /** CCoinsView that adds a memory cache for transactions to another CCoinsView */
-class CCoinsViewCache : public CCoinsView
+class CCoinsViewCache : public CCoinsViewCacheBackend
 {
 private:
     const bool m_deterministic;
 
 protected:
-    CCoinsView* base;
+    CCoinsViewCacheBackend* base;
 
     /**
      * Make mutable so that we can "fill the cache" even from Get-methods
@@ -409,7 +416,7 @@ protected:
     virtual std::optional<Coin> FetchCoinFromBase(const COutPoint& outpoint) const;
 
 public:
-    CCoinsViewCache(CCoinsView& in_base, bool deterministic = false);
+    CCoinsViewCache(CCoinsViewCacheBackend& in_base, bool deterministic = false);
 
     /**
      * By deleting the copy constructor, we prevent accidentally using it when one intends to create a cache on top of a base cache.
@@ -417,7 +424,7 @@ public:
     CCoinsViewCache(const CCoinsViewCache &) = delete;
 
     // Backend management
-    void SetBackend(CCoinsView& in_view) { base = &in_view; }
+    void SetBackend(CCoinsViewCacheBackend& in_view) { base = &in_view; }
 
     // Standard CCoinsView methods
     std::optional<Coin> GetCoin(const COutPoint& outpoint) const override;
@@ -582,10 +589,10 @@ const Coin& AccessByTxid(const CCoinsViewCache& cache, const Txid& txid);
  *
  * Writes do not need similar protection, as failure to write is handled by the caller.
 */
-class CCoinsViewErrorCatcher final : public CCoinsView
+class CCoinsViewErrorCatcher final : public CCoinsViewCacheBackend
 {
 public:
-    explicit CCoinsViewErrorCatcher(CCoinsView& view) : base{&view} {}
+    explicit CCoinsViewErrorCatcher(CCoinsViewCacheBackend& view) : base{&view} {}
 
     void AddReadErrCallback(std::function<void()> f) {
         m_err_callbacks.emplace_back(std::move(f));
@@ -598,7 +605,7 @@ public:
     void BatchWrite(CoinsViewCacheCursor& cursor, const uint256& block_hash) override { base->BatchWrite(cursor, block_hash); }
 
 private:
-    CCoinsView* base;
+    CCoinsViewCacheBackend* base;
 
     /** A list of callbacks to execute upon leveldb read error. */
     std::vector<std::function<void()>> m_err_callbacks;

--- a/src/coins.h
+++ b/src/coins.h
@@ -325,15 +325,26 @@ public:
     //! Retrieve the block hash whose state this CCoinsView currently represents
     virtual uint256 GetBestBlock() const = 0;
 
+    //! Do a bulk modification (multiple Coin changes + BestBlock change).
+    //! The passed cursor is used to iterate through the coins.
+    virtual void BatchWrite(CoinsViewCacheCursor& cursor, const uint256& block_hash) = 0;
+};
+
+/** Pure abstract interface for iterating and sizing persistent coins storage. */
+class CCoinsViewStorage
+{
+public:
+    virtual ~CCoinsViewStorage() = default;
+
+    //! Retrieve the block hash whose state this coins storage currently represents.
+    //! Deliberately duplicated here so storage users do not depend on coin lookup.
+    virtual uint256 GetBestBlock() const = 0;
+
     //! Retrieve the range of blocks that may have been only partially written.
     //! If the database is in a consistent state, the result is the empty vector.
     //! Otherwise, a two-element vector is returned consisting of the new and
     //! the old block hash, in that order.
     virtual std::vector<uint256> GetHeadBlocks() const = 0;
-
-    //! Do a bulk modification (multiple Coin changes + BestBlock change).
-    //! The passed cursor is used to iterate through the coins.
-    virtual void BatchWrite(CoinsViewCacheCursor& cursor, const uint256& block_hash) = 0;
 
     //! Get a cursor to iterate over the whole state. Implementations may return nullptr.
     virtual std::unique_ptr<CCoinsViewCursor> Cursor() const = 0;
@@ -358,13 +369,10 @@ public:
     std::optional<Coin> PeekCoin(const COutPoint& outpoint) const override { return GetCoin(outpoint); }
     bool HaveCoin(const COutPoint& outpoint) const override { return !!GetCoin(outpoint); }
     uint256 GetBestBlock() const override { return {}; }
-    std::vector<uint256> GetHeadBlocks() const override { return {}; }
     void BatchWrite(CoinsViewCacheCursor& cursor, const uint256&) override
     {
         for (auto it{cursor.Begin()}; it != cursor.End(); it = cursor.NextAndMaybeErase(*it)) { }
     }
-    std::unique_ptr<CCoinsViewCursor> Cursor() const override { return {}; }
-    size_t EstimateSize() const override { return 0; }
 };
 
 /** CCoinsView backed by another CCoinsView */
@@ -382,10 +390,7 @@ public:
     std::optional<Coin> PeekCoin(const COutPoint& outpoint) const override { return base->PeekCoin(outpoint); }
     bool HaveCoin(const COutPoint& outpoint) const override { return base->HaveCoin(outpoint); }
     uint256 GetBestBlock() const override { return base->GetBestBlock(); }
-    std::vector<uint256> GetHeadBlocks() const override { return base->GetHeadBlocks(); }
     void BatchWrite(CoinsViewCacheCursor& cursor, const uint256& block_hash) override { base->BatchWrite(cursor, block_hash); }
-    std::unique_ptr<CCoinsViewCursor> Cursor() const override { return base->Cursor(); }
-    size_t EstimateSize() const override { return base->EstimateSize(); }
 };
 
 
@@ -435,9 +440,6 @@ public:
     uint256 GetBestBlock() const override;
     void SetBestBlock(const uint256& block_hash);
     void BatchWrite(CoinsViewCacheCursor& cursor, const uint256& block_hash) override;
-    std::unique_ptr<CCoinsViewCursor> Cursor() const override {
-        throw std::logic_error("CCoinsViewCache cursor iteration not supported.");
-    }
 
     /**
      * Check if we have the given utxo already loaded in this cache.

--- a/src/coins.h
+++ b/src/coins.h
@@ -375,32 +375,15 @@ public:
     }
 };
 
-/** CCoinsView backed by another CCoinsView */
-class CCoinsViewBacked : public CCoinsView
-{
-protected:
-    CCoinsView* base;
-
-public:
-    explicit CCoinsViewBacked(CCoinsView* in_view) : base{Assert(in_view)} {}
-
-    void SetBackend(CCoinsView& in_view) { base = &in_view; }
-
-    std::optional<Coin> GetCoin(const COutPoint& outpoint) const override { return base->GetCoin(outpoint); }
-    std::optional<Coin> PeekCoin(const COutPoint& outpoint) const override { return base->PeekCoin(outpoint); }
-    bool HaveCoin(const COutPoint& outpoint) const override { return base->HaveCoin(outpoint); }
-    uint256 GetBestBlock() const override { return base->GetBestBlock(); }
-    void BatchWrite(CoinsViewCacheCursor& cursor, const uint256& block_hash) override { base->BatchWrite(cursor, block_hash); }
-};
-
-
 /** CCoinsView that adds a memory cache for transactions to another CCoinsView */
-class CCoinsViewCache : public CCoinsViewBacked
+class CCoinsViewCache : public CCoinsView
 {
 private:
     const bool m_deterministic;
 
 protected:
+    CCoinsView* base;
+
     /**
      * Make mutable so that we can "fill the cache" even from Get-methods
      * declared as "const".
@@ -432,6 +415,9 @@ public:
      * By deleting the copy constructor, we prevent accidentally using it when one intends to create a cache on top of a base cache.
      */
     CCoinsViewCache(const CCoinsViewCache &) = delete;
+
+    // Backend management
+    void SetBackend(CCoinsView& in_view) { base = &in_view; }
 
     // Standard CCoinsView methods
     std::optional<Coin> GetCoin(const COutPoint& outpoint) const override;
@@ -596,10 +582,10 @@ const Coin& AccessByTxid(const CCoinsViewCache& cache, const Txid& txid);
  *
  * Writes do not need similar protection, as failure to write is handled by the caller.
 */
-class CCoinsViewErrorCatcher final : public CCoinsViewBacked
+class CCoinsViewErrorCatcher final : public CCoinsView
 {
 public:
-    explicit CCoinsViewErrorCatcher(CCoinsView* view) : CCoinsViewBacked(view) {}
+    explicit CCoinsViewErrorCatcher(CCoinsView& view) : base{&view} {}
 
     void AddReadErrCallback(std::function<void()> f) {
         m_err_callbacks.emplace_back(std::move(f));
@@ -608,8 +594,12 @@ public:
     std::optional<Coin> GetCoin(const COutPoint& outpoint) const override;
     bool HaveCoin(const COutPoint& outpoint) const override;
     std::optional<Coin> PeekCoin(const COutPoint& outpoint) const override;
+    uint256 GetBestBlock() const override { return base->GetBestBlock(); }
+    void BatchWrite(CoinsViewCacheCursor& cursor, const uint256& block_hash) override { base->BatchWrite(cursor, block_hash); }
 
 private:
+    CCoinsView* base;
+
     /** A list of callbacks to execute upon leveldb read error. */
     std::vector<std::function<void()>> m_err_callbacks;
 

--- a/src/kernel/coinstats.cpp
+++ b/src/kernel/coinstats.cpp
@@ -108,13 +108,13 @@ static void ApplyStats(CCoinsStats& stats, const std::map<uint32_t, Coin>& outpu
 
 //! Calculate statistics about the unspent transaction output set
 template <typename T>
-static std::optional<CCoinsStats> ComputeUTXOStats(T hash_obj, CCoinsView* view, node::BlockManager& blockman, const std::function<void()>& interruption_point)
+static std::optional<CCoinsStats> ComputeUTXOStats(T hash_obj, const CCoinsViewStorage& view, node::BlockManager& blockman, const std::function<void()>& interruption_point)
 {
     std::unique_ptr<CCoinsViewCursor> pcursor;
     CBlockIndex* pindex;
     {
         LOCK(::cs_main);
-        pcursor = view->Cursor();
+        pcursor = view.Cursor();
         pindex = blockman.LookupBlockIndex(pcursor->GetBestBlock());
     }
     assert(pcursor);
@@ -148,11 +148,11 @@ static std::optional<CCoinsStats> ComputeUTXOStats(T hash_obj, CCoinsView* view,
 
     FinalizeHash(hash_obj, stats);
 
-    stats.nDiskSize = view->EstimateSize();
+    stats.nDiskSize = view.EstimateSize();
     return stats;
 }
 
-std::optional<CCoinsStats> ComputeUTXOStats(CoinStatsHashType hash_type, CCoinsView* view, node::BlockManager& blockman, const std::function<void()>& interruption_point)
+std::optional<CCoinsStats> ComputeUTXOStats(CoinStatsHashType hash_type, const CCoinsViewStorage& view, node::BlockManager& blockman, const std::function<void()>& interruption_point)
 {
     return [&]() -> std::optional<CCoinsStats> {
         switch (hash_type) {

--- a/src/kernel/coinstats.h
+++ b/src/kernel/coinstats.h
@@ -13,7 +13,7 @@
 #include <functional>
 #include <optional>
 
-class CCoinsView;
+class CCoinsViewStorage;
 class Coin;
 class COutPoint;
 class CScript;
@@ -77,7 +77,7 @@ uint64_t GetBogoSize(const CScript& script_pub_key);
 void ApplyCoinHash(MuHash3072& muhash, const COutPoint& outpoint, const Coin& coin);
 void RemoveCoinHash(MuHash3072& muhash, const COutPoint& outpoint, const Coin& coin);
 
-std::optional<CCoinsStats> ComputeUTXOStats(CoinStatsHashType hash_type, CCoinsView* view, node::BlockManager& blockman, const std::function<void()>& interruption_point = {});
+std::optional<CCoinsStats> ComputeUTXOStats(CoinStatsHashType hash_type, const CCoinsViewStorage& view, node::BlockManager& blockman, const std::function<void()>& interruption_point = {});
 } // namespace kernel
 
 #endif // BITCOIN_KERNEL_COINSTATS_H

--- a/src/node/coin.cpp
+++ b/src/node/coin.cpp
@@ -15,7 +15,7 @@ void FindCoins(const NodeContext& node, std::map<COutPoint, Coin>& coins)
     assert(node.chainman);
     LOCK2(cs_main, node.mempool->cs);
     CCoinsViewCache& chain_view = node.chainman->ActiveChainstate().CoinsTip();
-    CCoinsViewMemPool mempool_view(&chain_view, *node.mempool);
+    CCoinsViewMemPool mempool_view{chain_view, *node.mempool};
     for (auto& [outpoint, coin] : coins) {
         if (auto c{mempool_view.GetCoin(outpoint)}) {
             coin = std::move(*c);

--- a/src/node/psbt.cpp
+++ b/src/node/psbt.cpp
@@ -116,7 +116,7 @@ PSBTAnalysis AnalyzePSBT(PartiallySignedTransaction psbtx)
 
         // Estimate the size
         CMutableTransaction mtx(*psbtx.tx);
-        CCoinsViewCache view{&CoinsViewEmpty::Get()};
+        CCoinsViewCache view{CoinsViewEmpty::Get()};
         bool success = true;
 
         for (unsigned int i = 0; i < psbtx.tx->vin.size(); ++i) {

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -1017,7 +1017,7 @@ static bool rest_getutxos(const std::any& context, HTTPRequest* req, const std::
             // use db+mempool as cache backend in case user likes to query mempool
             LOCK2(cs_main, mempool->cs);
             CCoinsViewCache& viewChain = chainman.ActiveChainstate().CoinsTip();
-            CCoinsViewMemPool viewMempool(&viewChain, *mempool);
+            CCoinsViewMemPool viewMempool{viewChain, *mempool};
             process_utxos(viewMempool, mempool);
         } else {
             LOCK(cs_main);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2915,7 +2915,7 @@ static RPCMethod getdescriptoractivity()
         const CTxMemPool& mempool = EnsureMemPool(node);
         LOCK(::cs_main);
         LOCK(mempool.cs);
-        CCoinsView& coins_backend{active_chainstate.CoinsTip()};
+        CCoinsViewCacheBackend& coins_backend{active_chainstate.CoinsTip()};
         const CCoinsViewCache coins_view{coins_backend};
 
         for (const CTxMemPoolEntry& e : mempool.entryAll()) {

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -995,7 +995,7 @@ CoinStatsHashType ParseHashType(std::string_view hash_type_input)
  *
  * @param[in] index_requested Signals if the coinstatsindex should be used (when available).
  */
-static std::optional<kernel::CCoinsStats> GetUTXOStats(CCoinsView* view, node::BlockManager& blockman,
+static std::optional<kernel::CCoinsStats> GetUTXOStats(const CCoinsViewStorage& view, node::BlockManager& blockman,
                                                        kernel::CoinStatsHashType hash_type,
                                                        const std::function<void()>& interruption_point = {},
                                                        const CBlockIndex* pindex = nullptr,
@@ -1006,7 +1006,7 @@ static std::optional<kernel::CCoinsStats> GetUTXOStats(CCoinsView* view, node::B
         if (pindex) {
             return g_coin_stats_index->LookUpStats(*pindex);
         } else {
-            CBlockIndex& block_index = *CHECK_NONFATAL(WITH_LOCK(::cs_main, return blockman.LookupBlockIndex(view->GetBestBlock())));
+            CBlockIndex& block_index = *CHECK_NONFATAL(WITH_LOCK(::cs_main, return blockman.LookupBlockIndex(view.GetBestBlock())));
             return g_coin_stats_index->LookUpStats(block_index);
         }
     }
@@ -1015,7 +1015,7 @@ static std::optional<kernel::CCoinsStats> GetUTXOStats(CCoinsView* view, node::B
     // pindex should either be null or equal to the view's best block. This is
     // because without the coinstats index we can only get coinstats about the
     // best block.
-    CHECK_NONFATAL(!pindex || pindex->GetBlockHash() == view->GetBestBlock());
+    CHECK_NONFATAL(!pindex || pindex->GetBlockHash() == view.GetBestBlock());
 
     return kernel::ComputeUTXOStats(hash_type, view, blockman, interruption_point);
 }
@@ -1086,7 +1086,7 @@ static RPCMethod gettxoutsetinfo()
     Chainstate& active_chainstate = chainman.ActiveChainstate();
     active_chainstate.ForceFlushStateToDisk(/*wipe_cache=*/false);
 
-    CCoinsView* coins_view;
+    CCoinsViewStorage* coins_view;
     BlockManager* blockman;
     {
         LOCK(::cs_main);
@@ -1122,7 +1122,7 @@ static RPCMethod gettxoutsetinfo()
         }
     }
 
-    const std::optional<CCoinsStats> maybe_stats = GetUTXOStats(coins_view, *blockman, hash_type, node.rpc_interruption_point, pindex, index_requested);
+    const std::optional<CCoinsStats> maybe_stats = GetUTXOStats(*coins_view, *blockman, hash_type, node.rpc_interruption_point, pindex, index_requested);
     if (maybe_stats.has_value()) {
         const CCoinsStats& stats = maybe_stats.value();
         ret.pushKV("height", stats.nHeight);
@@ -1144,7 +1144,7 @@ static RPCMethod gettxoutsetinfo()
             CCoinsStats prev_stats{};
             if (stats.nHeight > 0) {
                 const CBlockIndex& block_index = *CHECK_NONFATAL(WITH_LOCK(::cs_main, return blockman->LookupBlockIndex(stats.hashBlock)));
-                const std::optional<CCoinsStats> maybe_prev_stats = GetUTXOStats(coins_view, *blockman, hash_type, node.rpc_interruption_point, block_index.pprev, index_requested);
+                const std::optional<CCoinsStats> maybe_prev_stats = GetUTXOStats(*coins_view, *blockman, hash_type, node.rpc_interruption_point, block_index.pprev, index_requested);
                 if (!maybe_prev_stats) {
                     throw JSONRPCError(RPC_INTERNAL_ERROR, "Unable to read UTXO set");
                 }
@@ -3326,7 +3326,7 @@ UniValue CreateRolledBackUTXOSnapshot(
     rollback_cache.Flush();
 
     LogInfo("Rollback complete. Computing UTXO statistics for created txoutset dump.");
-    std::optional<CCoinsStats> maybe_stats = GetUTXOStats(temp_db.get(),
+    std::optional<CCoinsStats> maybe_stats = GetUTXOStats(*temp_db,
                                                           chainstate.m_blockman,
                                                           CoinStatsHashType::HASH_SERIALIZED,
                                                           node.rpc_interruption_point);
@@ -3377,7 +3377,7 @@ PrepareUTXOSnapshot(
 
         chainstate.ForceFlushStateToDisk(/*wipe_cache=*/false);
 
-        maybe_stats = GetUTXOStats(&chainstate.CoinsDB(), chainstate.m_blockman, CoinStatsHashType::HASH_SERIALIZED, interruption_point);
+        maybe_stats = GetUTXOStats(chainstate.CoinsDB(), chainstate.m_blockman, CoinStatsHashType::HASH_SERIALIZED, interruption_point);
         if (!maybe_stats) {
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Unable to read UTXO set");
         }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2915,8 +2915,7 @@ static RPCMethod getdescriptoractivity()
         const CTxMemPool& mempool = EnsureMemPool(node);
         LOCK(::cs_main);
         LOCK(mempool.cs);
-        CCoinsViewCacheBackend& coins_backend{active_chainstate.CoinsTip()};
-        const CCoinsViewCache coins_view{coins_backend};
+        const CCoinsViewCache coins_view{active_chainstate.CoinsTip()};
 
         for (const CTxMemPoolEntry& e : mempool.entryAll()) {
             const auto& tx = e.GetSharedTx();

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1247,7 +1247,7 @@ static RPCMethod gettxout()
     if (fMempool) {
         const CTxMemPool& mempool = EnsureMemPool(node);
         LOCK(mempool.cs);
-        CCoinsViewMemPool view(coins_view, mempool);
+        CCoinsViewMemPool view{*coins_view, mempool};
         if (!mempool.isSpent(out)) coin = view.GetCoin(out);
     } else {
         coin = coins_view->GetCoin(out);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2915,7 +2915,8 @@ static RPCMethod getdescriptoractivity()
         const CTxMemPool& mempool = EnsureMemPool(node);
         LOCK(::cs_main);
         LOCK(mempool.cs);
-        const CCoinsViewCache& coins_view = &active_chainstate.CoinsTip();
+        CCoinsView& coins_backend{active_chainstate.CoinsTip()};
+        const CCoinsViewCache coins_view{coins_backend};
 
         for (const CTxMemPoolEntry& e : mempool.entryAll()) {
             const auto& tx = e.GetSharedTx();
@@ -3249,7 +3250,7 @@ UniValue CreateRolledBackUTXOSnapshot(
     const CBlockIndex* tip = nullptr;
     LogInfo("Copying current UTXO set to temporary database.");
     {
-        CCoinsViewCache temp_cache(temp_db.get());
+        CCoinsViewCache temp_cache{*temp_db};
         std::unique_ptr<CCoinsViewCursor> cursor;
         {
             LOCK(::cs_main);
@@ -3290,7 +3291,7 @@ UniValue CreateRolledBackUTXOSnapshot(
 
     const CBlockIndex* block_index{tip};
     const size_t total_blocks{static_cast<size_t>(block_index->nHeight - target->nHeight)};
-    CCoinsViewCache rollback_cache(temp_db.get());
+    CCoinsViewCache rollback_cache{*temp_db};
     rollback_cache.SetBestBlock(block_index->GetBlockHash());
     size_t blocks_processed = 0;
     int last_progress{0};

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -630,7 +630,7 @@ static RPCMethod combinerawtransaction()
         ChainstateManager& chainman = EnsureChainman(node);
         LOCK2(cs_main, mempool.cs);
         CCoinsViewCache &viewChain = chainman.ActiveChainstate().CoinsTip();
-        CCoinsViewMemPool viewMempool(&viewChain, mempool);
+        CCoinsViewMemPool viewMempool{viewChain, mempool};
         view.SetBackend(viewMempool); // temporarily switch cache backend to db+mempool view
 
         for (const CTxIn& txin : mergedTx.vin) {

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -623,7 +623,7 @@ static RPCMethod combinerawtransaction()
     CMutableTransaction mergedTx(txVariants[0]);
 
     // Fetch previous transactions (inputs):
-    CCoinsViewCache view{&CoinsViewEmpty::Get()};
+    CCoinsViewCache view{CoinsViewEmpty::Get()};
     {
         NodeContext& node = EnsureAnyNodeContext(request.context);
         const CTxMemPool& mempool = EnsureMemPool(node);

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -76,7 +76,7 @@ public:
 class CCoinsViewCacheTest : public CCoinsViewCache
 {
 public:
-    explicit CCoinsViewCacheTest(CCoinsView* _base) : CCoinsViewCache(_base) {}
+    explicit CCoinsViewCacheTest(CCoinsView& _base) : CCoinsViewCache(_base) {}
 
     void SelfTest(bool sanity_check = true) const
     {
@@ -138,7 +138,7 @@ void SimulationTest(CCoinsView* base, bool fake_best_block)
 
     // The cache stack.
     std::vector<std::unique_ptr<CCoinsViewCacheTest>> stack; // A stack of CCoinsViewCaches on top.
-    stack.push_back(std::make_unique<CCoinsViewCacheTest>(base)); // Start with one cache.
+    stack.push_back(std::make_unique<CCoinsViewCacheTest>(*base)); // Start with one cache.
 
     // Use a limited set of random transaction ids, so we do test overwriting entries.
     std::vector<Txid> txids;
@@ -260,7 +260,7 @@ void SimulationTest(CCoinsView* base, bool fake_best_block)
                 } else {
                     removed_all_caches = true;
                 }
-                stack.push_back(std::make_unique<CCoinsViewCacheTest>(tip));
+                stack.push_back(std::make_unique<CCoinsViewCacheTest>(*tip));
                 if (stack.size() == 4) {
                     reached_4_caches = true;
                 }
@@ -339,7 +339,7 @@ BOOST_FIXTURE_TEST_CASE(updatecoins_simulation_test, UpdateTest)
     // The cache stack.
     CCoinsViewTest base{m_rng}; // A CCoinsViewTest at the bottom.
     std::vector<std::unique_ptr<CCoinsViewCacheTest>> stack; // A stack of CCoinsViewCaches on top.
-    stack.push_back(std::make_unique<CCoinsViewCacheTest>(&base)); // Start with one cache.
+    stack.push_back(std::make_unique<CCoinsViewCacheTest>(base)); // Start with one cache.
 
     // Track the txids we've used in various sets
     std::set<COutPoint> coinbase_coins;
@@ -511,7 +511,7 @@ BOOST_FIXTURE_TEST_CASE(updatecoins_simulation_test, UpdateTest)
                 if (stack.size() > 0) {
                     tip = stack.back().get();
                 }
-                stack.push_back(std::make_unique<CCoinsViewCacheTest>(tip));
+                stack.push_back(std::make_unique<CCoinsViewCacheTest>(*tip));
             }
         }
     }
@@ -678,8 +678,9 @@ public:
         }
     }
 
-    CCoinsViewCacheTest base{&CoinsViewEmpty::Get()};
-    CCoinsViewCacheTest cache{&base};
+    CCoinsViewCacheTest base{CoinsViewEmpty::Get()};
+    CCoinsView& cache_base{base};
+    CCoinsViewCacheTest cache{cache_base};
 };
 
 static void CheckAccessCoin(const CAmount base_value, const MaybeCoin& cache_coin, const MaybeCoin& expected)
@@ -1051,8 +1052,9 @@ BOOST_FIXTURE_TEST_CASE(ccoins_flush_behavior, FlushTest)
     // Create two in-memory caches atop a leveldb view.
     CCoinsViewDB base{{.path = "test", .cache_bytes = 8_MiB, .memory_only = true}, {}};
     std::vector<std::unique_ptr<CCoinsViewCacheTest>> caches;
-    caches.push_back(std::make_unique<CCoinsViewCacheTest>(&base));
-    caches.push_back(std::make_unique<CCoinsViewCacheTest>(caches.back().get()));
+    caches.push_back(std::make_unique<CCoinsViewCacheTest>(base));
+    CCoinsView& cache_base{*caches.back()};
+    caches.push_back(std::make_unique<CCoinsViewCacheTest>(cache_base));
 
     for (const auto& view : caches) {
         TestFlushBehavior(view.get(), base, caches, /*do_erasing_flush=*/false);
@@ -1087,7 +1089,7 @@ BOOST_AUTO_TEST_CASE(coins_resource_is_used)
 
 BOOST_AUTO_TEST_CASE(ccoins_addcoin_exception_keeps_usage_balanced)
 {
-    CCoinsViewCacheTest cache{&CoinsViewEmpty::Get()};
+    CCoinsViewCacheTest cache{CoinsViewEmpty::Get()};
 
     const COutPoint outpoint{Txid::FromUint256(m_rng.rand256()), m_rng.rand32()};
 
@@ -1104,7 +1106,7 @@ BOOST_AUTO_TEST_CASE(ccoins_addcoin_exception_keeps_usage_balanced)
 
 BOOST_AUTO_TEST_CASE(ccoins_emplace_duplicate_keeps_usage_balanced)
 {
-    CCoinsViewCacheTest cache{&CoinsViewEmpty::Get()};
+    CCoinsViewCacheTest cache{CoinsViewEmpty::Get()};
 
     const COutPoint outpoint{Txid::FromUint256(m_rng.rand256()), m_rng.rand32()};
 
@@ -1122,12 +1124,12 @@ BOOST_AUTO_TEST_CASE(ccoins_emplace_duplicate_keeps_usage_balanced)
 BOOST_AUTO_TEST_CASE(ccoins_reset_guard)
 {
     CCoinsViewTest root{m_rng};
-    CCoinsViewCache root_cache{&root};
+    CCoinsViewCache root_cache{root};
     uint256 base_best_block{m_rng.rand256()};
     root_cache.SetBestBlock(base_best_block);
     root_cache.Flush();
 
-    CCoinsViewCache cache{&root};
+    CCoinsViewCache cache{root};
 
     const COutPoint outpoint{Txid::FromUint256(m_rng.rand256()), m_rng.rand32()};
 
@@ -1178,13 +1180,13 @@ BOOST_AUTO_TEST_CASE(ccoins_peekcoin)
     const COutPoint outpoint{Txid::FromUint256(m_rng.rand256()), m_rng.rand32()};
     const Coin coin{CTxOut{m_rng.randrange(10), CScript{}}, 1, false};
     {
-        CCoinsViewCache cache{&base};
+        CCoinsViewCache cache{base};
         cache.AddCoin(outpoint, Coin{coin}, /*possible_overwrite=*/false);
         cache.Flush();
     }
 
     // Verify PeekCoin can read through the cache stack without mutating the intermediate cache.
-    CCoinsViewCacheTest main_cache{&base};
+    CCoinsViewCacheTest main_cache{base};
     const auto fetched{main_cache.PeekCoin(outpoint)};
     BOOST_CHECK(fetched.has_value());
     BOOST_CHECK(*fetched == coin);

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -76,7 +76,7 @@ public:
 class CCoinsViewCacheTest : public CCoinsViewCache
 {
 public:
-    explicit CCoinsViewCacheTest(CCoinsView& _base) : CCoinsViewCache(_base) {}
+    explicit CCoinsViewCacheTest(CCoinsViewCacheBackend& _base) : CCoinsViewCache(_base) {}
 
     void SelfTest(bool sanity_check = true) const
     {
@@ -119,7 +119,7 @@ struct CacheTest : BasicTestingSetup {
 // of best block on flush. This is necessary when using CCoinsViewDB as the base,
 // otherwise we'll hit an assertion in BatchWrite.
 //
-void SimulationTest(CCoinsView* base, bool fake_best_block)
+void SimulationTest(CCoinsViewCacheBackend* base, bool fake_best_block)
 {
     // Various coverage trackers.
     bool removed_all_caches = false;
@@ -254,7 +254,7 @@ void SimulationTest(CCoinsView* base, bool fake_best_block)
             }
             if (stack.size() == 0 || (stack.size() < 4 && m_rng.randbool())) {
                 //Add a new cache
-                CCoinsView* tip = base;
+                CCoinsViewCacheBackend* tip = base;
                 if (stack.size() > 0) {
                     tip = stack.back().get();
                 } else {
@@ -507,7 +507,7 @@ BOOST_FIXTURE_TEST_CASE(updatecoins_simulation_test, UpdateTest)
                 stack.pop_back();
             }
             if (stack.size() == 0 || (stack.size() < 4 && m_rng.randbool())) {
-                CCoinsView* tip = &base;
+                CCoinsViewCacheBackend* tip = &base;
                 if (stack.size() > 0) {
                     tip = stack.back().get();
                 }
@@ -652,7 +652,7 @@ static MaybeCoin GetCoinsMapEntry(const CCoinsMap& map, const COutPoint& outp = 
     return MISSING;
 }
 
-static void WriteCoinsViewEntry(CCoinsView& view, const MaybeCoin& cache_coin)
+static void WriteCoinsViewEntry(CCoinsViewCacheBackend& view, const MaybeCoin& cache_coin)
 {
     CoinsCachePair sentinel{};
     sentinel.second.SelfRef(sentinel);
@@ -679,7 +679,7 @@ public:
     }
 
     CCoinsViewCacheTest base{CoinsViewEmpty::Get()};
-    CCoinsView& cache_base{base};
+    CCoinsViewCacheBackend& cache_base{base};
     CCoinsViewCacheTest cache{cache_base};
 };
 
@@ -1053,7 +1053,7 @@ BOOST_FIXTURE_TEST_CASE(ccoins_flush_behavior, FlushTest)
     CCoinsViewDB base{{.path = "test", .cache_bytes = 8_MiB, .memory_only = true}, {}};
     std::vector<std::unique_ptr<CCoinsViewCacheTest>> caches;
     caches.push_back(std::make_unique<CCoinsViewCacheTest>(base));
-    CCoinsView& cache_base{*caches.back()};
+    CCoinsViewCacheBackend& cache_base{*caches.back()};
     caches.push_back(std::make_unique<CCoinsViewCacheTest>(cache_base));
 
     for (const auto& view : caches) {

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -76,7 +76,8 @@ public:
 class CCoinsViewCacheTest : public CCoinsViewCache
 {
 public:
-    explicit CCoinsViewCacheTest(CCoinsViewCacheBackend& _base) : CCoinsViewCache(_base) {}
+    using CCoinsViewCache::CCoinsViewCache;
+    explicit CCoinsViewCacheTest(CCoinsViewCacheTest& _base) : CCoinsViewCache(_base) {}
 
     void SelfTest(bool sanity_check = true) const
     {
@@ -679,8 +680,7 @@ public:
     }
 
     CCoinsViewCacheTest base{CoinsViewEmpty::Get()};
-    CCoinsViewCacheBackend& cache_base{base};
-    CCoinsViewCacheTest cache{cache_base};
+    CCoinsViewCacheTest cache{base};
 };
 
 static void CheckAccessCoin(const CAmount base_value, const MaybeCoin& cache_coin, const MaybeCoin& expected)
@@ -1053,8 +1053,7 @@ BOOST_FIXTURE_TEST_CASE(ccoins_flush_behavior, FlushTest)
     CCoinsViewDB base{{.path = "test", .cache_bytes = 8_MiB, .memory_only = true}, {}};
     std::vector<std::unique_ptr<CCoinsViewCacheTest>> caches;
     caches.push_back(std::make_unique<CCoinsViewCacheTest>(base));
-    CCoinsViewCacheBackend& cache_base{*caches.back()};
-    caches.push_back(std::make_unique<CCoinsViewCacheTest>(cache_base));
+    caches.push_back(std::make_unique<CCoinsViewCacheTest>(*caches.back()));
 
     for (const auto& view : caches) {
         TestFlushBehavior(view.get(), base, caches, /*do_erasing_flush=*/false);

--- a/src/test/coinstatsindex_tests.cpp
+++ b/src/test/coinstatsindex_tests.cpp
@@ -91,7 +91,8 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_unclean_shutdown, TestChain100Setup)
             BlockValidationState state;
             BOOST_CHECK(CheckBlock(block, state, params.GetConsensus()));
             BOOST_CHECK(m_node.chainman->AcceptBlock(new_block, state, &new_block_index, true, nullptr, nullptr, true));
-            CCoinsViewCache view(&chainstate.CoinsTip());
+            CCoinsView& coins_backend{chainstate.CoinsTip()};
+            CCoinsViewCache view{coins_backend};
             BOOST_CHECK(chainstate.ConnectBlock(block, state, new_block_index, view));
         }
         // Send block connected notification, then stop the index without

--- a/src/test/coinstatsindex_tests.cpp
+++ b/src/test/coinstatsindex_tests.cpp
@@ -91,8 +91,7 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_unclean_shutdown, TestChain100Setup)
             BlockValidationState state;
             BOOST_CHECK(CheckBlock(block, state, params.GetConsensus()));
             BOOST_CHECK(m_node.chainman->AcceptBlock(new_block, state, &new_block_index, true, nullptr, nullptr, true));
-            CCoinsViewCacheBackend& coins_backend{chainstate.CoinsTip()};
-            CCoinsViewCache view{coins_backend};
+            CCoinsViewCache view{chainstate.CoinsTip()};
             BOOST_CHECK(chainstate.ConnectBlock(block, state, new_block_index, view));
         }
         // Send block connected notification, then stop the index without

--- a/src/test/coinstatsindex_tests.cpp
+++ b/src/test/coinstatsindex_tests.cpp
@@ -91,7 +91,7 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_unclean_shutdown, TestChain100Setup)
             BlockValidationState state;
             BOOST_CHECK(CheckBlock(block, state, params.GetConsensus()));
             BOOST_CHECK(m_node.chainman->AcceptBlock(new_block, state, &new_block_index, true, nullptr, nullptr, true));
-            CCoinsView& coins_backend{chainstate.CoinsTip()};
+            CCoinsViewCacheBackend& coins_backend{chainstate.CoinsTip()};
             CCoinsViewCache view{coins_backend};
             BOOST_CHECK(chainstate.ConnectBlock(block, state, new_block_index, view));
         }

--- a/src/test/coinsviewoverlay_tests.cpp
+++ b/src/test/coinsviewoverlay_tests.cpp
@@ -41,7 +41,7 @@ CBlock CreateBlock() noexcept
 
 void PopulateView(const CBlock& block, CCoinsView& view, bool spent = false)
 {
-    CCoinsViewCache cache{&view};
+    CCoinsViewCache cache{view};
     cache.SetBestBlock(uint256::ONE);
 
     for (const auto& tx : block.vtx | std::views::drop(1)) {
@@ -83,8 +83,8 @@ BOOST_AUTO_TEST_CASE(fetch_inputs_from_db)
     const auto block{CreateBlock()};
     CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
     PopulateView(block, db);
-    CCoinsViewCache main_cache{&db};
-    CoinsViewOverlay view{&main_cache};
+    CCoinsViewCache main_cache{db};
+    CoinsViewOverlay view{main_cache};
     const auto& outpoint{block.vtx[1]->vin[0].prevout};
 
     BOOST_CHECK(view.HaveCoin(outpoint));
@@ -109,9 +109,9 @@ BOOST_AUTO_TEST_CASE(fetch_inputs_from_cache)
 {
     const auto block{CreateBlock()};
     CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
-    CCoinsViewCache main_cache{&db};
+    CCoinsViewCache main_cache{db};
     PopulateView(block, main_cache);
-    CoinsViewOverlay view{&main_cache};
+    CoinsViewOverlay view{main_cache};
     CheckCache(block, view);
 
     const auto& outpoint{block.vtx[1]->vin[0].prevout};
@@ -128,10 +128,10 @@ BOOST_AUTO_TEST_CASE(fetch_no_double_spend)
     const auto block{CreateBlock()};
     CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
     PopulateView(block, db);
-    CCoinsViewCache main_cache{&db};
+    CCoinsViewCache main_cache{db};
     // Add all inputs as spent already in cache
     PopulateView(block, main_cache, /*spent=*/true);
-    CoinsViewOverlay view{&main_cache};
+    CoinsViewOverlay view{main_cache};
     for (const auto& tx : block.vtx) {
         for (const auto& in : tx->vin) {
             const auto& c{view.AccessCoin(in.prevout)};
@@ -148,8 +148,8 @@ BOOST_AUTO_TEST_CASE(fetch_no_inputs)
 {
     const auto block{CreateBlock()};
     CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
-    CCoinsViewCache main_cache{&db};
-    CoinsViewOverlay view{&main_cache};
+    CCoinsViewCache main_cache{db};
+    CoinsViewOverlay view{main_cache};
     for (const auto& tx : block.vtx) {
         for (const auto& in : tx->vin) {
             const auto& c{view.AccessCoin(in.prevout)};
@@ -162,4 +162,3 @@ BOOST_AUTO_TEST_CASE(fetch_no_inputs)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-

--- a/src/test/coinsviewoverlay_tests.cpp
+++ b/src/test/coinsviewoverlay_tests.cpp
@@ -39,7 +39,7 @@ CBlock CreateBlock() noexcept
     return block;
 }
 
-void PopulateView(const CBlock& block, CCoinsView& view, bool spent = false)
+void PopulateView(const CBlock& block, CCoinsViewCacheBackend& view, bool spent = false)
 {
     CCoinsViewCache cache{view};
     cache.SetBestBlock(uint256::ONE);

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -334,7 +334,7 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& co
 FUZZ_TARGET(coins_view, .init = initialize_coins_view)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
-    CCoinsViewCache coins_view_cache{&CoinsViewEmpty::Get(), /*deterministic=*/true};
+    CCoinsViewCache coins_view_cache{CoinsViewEmpty::Get(), /*deterministic=*/true};
     TestCoinsView(fuzzed_data_provider, coins_view_cache, CoinsViewEmpty::Get(), /*require_non_null_best_block=*/false);
 }
 
@@ -347,7 +347,7 @@ FUZZ_TARGET(coins_view_db, .init = initialize_coins_view)
         .memory_only = true,
     };
     CCoinsViewDB backend_coins_view{std::move(db_params), CoinsViewOptions{}};
-    CCoinsViewCache coins_view_cache{&backend_coins_view, /*deterministic=*/true};
+    CCoinsViewCache coins_view_cache{backend_coins_view, /*deterministic=*/true};
     TestCoinsView(fuzzed_data_provider, coins_view_cache, backend_coins_view, /*require_non_null_best_block=*/true);
     assert(backend_coins_view.Cursor());
     (void)backend_coins_view.EstimateSize();
@@ -361,7 +361,7 @@ FUZZ_TARGET(coins_view_db, .init = initialize_coins_view)
 FUZZ_TARGET(coins_view_overlay, .init = initialize_coins_view)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
-    MutationGuardCoinsViewCache backend_cache{&CoinsViewEmpty::Get(), /*deterministic=*/true};
-    CoinsViewOverlay coins_view_cache{&backend_cache, /*deterministic=*/true};
+    MutationGuardCoinsViewCache backend_cache{CoinsViewEmpty::Get(), /*deterministic=*/true};
+    CoinsViewOverlay coins_view_cache{backend_cache, /*deterministic=*/true};
     TestCoinsView(fuzzed_data_provider, coins_view_cache, backend_cache, /*require_non_null_best_block=*/false);
 }

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -25,7 +25,6 @@
 #include <memory>
 #include <optional>
 #include <ranges>
-#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -90,13 +89,12 @@ void initialize_coins_view()
     static const auto testing_setup = MakeNoLogFileContext<>();
 }
 
-void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& coins_view_cache, CCoinsView* backend_coins_view)
+void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& coins_view_cache, CCoinsView& original_backend, bool require_non_null_best_block)
 {
-    const bool is_db{dynamic_cast<CCoinsViewDB*>(backend_coins_view) != nullptr};
     bool good_data{true};
-    auto* original_backend{backend_coins_view};
+    CCoinsView* backend_coins_view{&original_backend};
 
-    if (is_db) coins_view_cache.SetBestBlock(uint256::ONE);
+    if (require_non_null_best_block) coins_view_cache.SetBestBlock(uint256::ONE);
     COutPoint random_out_point;
     Coin random_coin;
     CMutableTransaction random_mutable_transaction;
@@ -127,13 +125,13 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& co
             [&] {
                 uint256 best_block{ConsumeUInt256(fuzzed_data_provider)};
                 // `CCoinsViewDB::BatchWrite()` requires a non-null best block.
-                if (is_db && best_block.IsNull()) best_block = uint256::ONE;
+                if (require_non_null_best_block && best_block.IsNull()) best_block = uint256::ONE;
                 coins_view_cache.SetBestBlock(best_block);
             },
             [&] {
                 (void)coins_view_cache.CreateResetGuard();
                 // Reset() clears the best block, so reseed db-backed caches.
-                if (is_db) {
+                if (require_non_null_best_block) {
                     const uint256 best_block{ConsumeUInt256(fuzzed_data_provider)};
                     if (best_block.IsNull()) {
                         good_data = false;
@@ -151,14 +149,14 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& co
             },
             [&] {
                 const bool use_original_backend{fuzzed_data_provider.ConsumeBool()};
-                if (use_original_backend && backend_coins_view != original_backend) {
+                if (use_original_backend && backend_coins_view != &original_backend) {
                     // FRESH flags valid against the empty backend may be invalid
                     // against the original backend, so reset before restoring it.
                     (void)coins_view_cache.CreateResetGuard();
                     // Reset() clears the best block; db backends require a non-null hash.
-                    if (is_db) coins_view_cache.SetBestBlock(uint256::ONE);
+                    if (require_non_null_best_block) coins_view_cache.SetBestBlock(uint256::ONE);
                 }
-                backend_coins_view = use_original_backend ? original_backend : &CoinsViewEmpty::Get();
+                backend_coins_view = use_original_backend ? &original_backend : &CoinsViewEmpty::Get();
                 coins_view_cache.SetBackend(*backend_coins_view);
             },
             [&] {
@@ -216,34 +214,20 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& co
                 uint256 best_block{coins_view_cache.GetBestBlock()};
                 if (fuzzed_data_provider.ConsumeBool()) best_block = ConsumeUInt256(fuzzed_data_provider);
                 // Set best block hash to non-null to satisfy the assertion in CCoinsViewDB::BatchWrite().
-                if (is_db && best_block.IsNull()) best_block = uint256::ONE;
+                if (require_non_null_best_block && best_block.IsNull()) best_block = uint256::ONE;
                 coins_view_cache.BatchWrite(cursor, best_block);
             });
     }
 
     {
-        bool expected_code_path = false;
-        try {
-            (void)coins_view_cache.Cursor();
-        } catch (const std::logic_error&) {
-            expected_code_path = true;
-        }
-        assert(expected_code_path);
         (void)coins_view_cache.DynamicMemoryUsage();
-        (void)coins_view_cache.EstimateSize();
         (void)coins_view_cache.GetBestBlock();
         (void)coins_view_cache.GetCacheSize();
-        (void)coins_view_cache.GetHeadBlocks();
         (void)coins_view_cache.HaveInputs(CTransaction{random_mutable_transaction});
     }
 
     {
-        if (is_db && backend_coins_view == original_backend) {
-            assert(backend_coins_view->Cursor());
-        }
-        (void)backend_coins_view->EstimateSize();
         (void)backend_coins_view->GetBestBlock();
-        (void)backend_coins_view->GetHeadBlocks();
     }
 
     if (fuzzed_data_provider.ConsumeBool()) {
@@ -351,7 +335,7 @@ FUZZ_TARGET(coins_view, .init = initialize_coins_view)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     CCoinsViewCache coins_view_cache{&CoinsViewEmpty::Get(), /*deterministic=*/true};
-    TestCoinsView(fuzzed_data_provider, coins_view_cache, &CoinsViewEmpty::Get());
+    TestCoinsView(fuzzed_data_provider, coins_view_cache, CoinsViewEmpty::Get(), /*require_non_null_best_block=*/false);
 }
 
 FUZZ_TARGET(coins_view_db, .init = initialize_coins_view)
@@ -364,7 +348,10 @@ FUZZ_TARGET(coins_view_db, .init = initialize_coins_view)
     };
     CCoinsViewDB backend_coins_view{std::move(db_params), CoinsViewOptions{}};
     CCoinsViewCache coins_view_cache{&backend_coins_view, /*deterministic=*/true};
-    TestCoinsView(fuzzed_data_provider, coins_view_cache, &backend_coins_view);
+    TestCoinsView(fuzzed_data_provider, coins_view_cache, backend_coins_view, /*require_non_null_best_block=*/true);
+    assert(backend_coins_view.Cursor());
+    (void)backend_coins_view.EstimateSize();
+    (void)backend_coins_view.GetHeadBlocks();
 }
 
 // Creates a CoinsViewOverlay and a MutationGuardCoinsViewCache as the base.
@@ -376,5 +363,5 @@ FUZZ_TARGET(coins_view_overlay, .init = initialize_coins_view)
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     MutationGuardCoinsViewCache backend_cache{&CoinsViewEmpty::Get(), /*deterministic=*/true};
     CoinsViewOverlay coins_view_cache{&backend_cache, /*deterministic=*/true};
-    TestCoinsView(fuzzed_data_provider, coins_view_cache, &backend_cache);
+    TestCoinsView(fuzzed_data_provider, coins_view_cache, backend_cache, /*require_non_null_best_block=*/false);
 }

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -89,10 +89,10 @@ void initialize_coins_view()
     static const auto testing_setup = MakeNoLogFileContext<>();
 }
 
-void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& coins_view_cache, CCoinsView& original_backend, bool require_non_null_best_block)
+void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& coins_view_cache, CCoinsViewCacheBackend& original_backend, bool require_non_null_best_block)
 {
     bool good_data{true};
-    CCoinsView* backend_coins_view{&original_backend};
+    CCoinsViewCacheBackend* backend_coins_view{&original_backend};
 
     if (require_non_null_best_block) coins_view_cache.SetBestBlock(uint256::ONE);
     COutPoint random_out_point;

--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -239,7 +239,7 @@ FUZZ_TARGET(coinscache_sim)
         ++current_height;
         // Make sure there is always at least one CCoinsViewCache.
         if (caches.empty()) {
-            caches.emplace_back(new CCoinsViewCache(&bottom, /*deterministic=*/true));
+            caches.emplace_back(new CCoinsViewCache(bottom, /*deterministic=*/true));
             sim_caches[caches.size()].Wipe();
         }
 
@@ -370,9 +370,9 @@ FUZZ_TARGET(coinscache_sim)
                 if (caches.size() != MAX_CACHES) {
                     // Apply to real caches.
                     if (provider.ConsumeBool()) {
-                        caches.emplace_back(new CCoinsViewCache(&*caches.back(), /*deterministic=*/true));
+                        caches.emplace_back(new CCoinsViewCache(*caches.back(), /*deterministic=*/true));
                     } else {
-                        caches.emplace_back(new CoinsViewOverlay(&*caches.back(), /*deterministic=*/true));
+                        caches.emplace_back(new CoinsViewOverlay(*caches.back(), /*deterministic=*/true));
                     }
                     // Apply to simulation data.
                     sim_caches[caches.size()].Wipe();

--- a/src/test/fuzz/transaction.cpp
+++ b/src/test/fuzz/transaction.cpp
@@ -86,7 +86,7 @@ FUZZ_TARGET(transaction, .init = initialize_transaction)
     (void)RecursiveDynamicUsage(tx);
     (void)SignalsOptInRBF(tx);
 
-    const CCoinsViewCache coins_view_cache{&CoinsViewEmpty::Get()};
+    const CCoinsViewCache coins_view_cache{CoinsViewEmpty::Get()};
     (void)ValidateInputsStandardness(tx, coins_view_cache);
     (void)IsWitnessStandard(tx, coins_view_cache);
 

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -242,7 +242,7 @@ FUZZ_TARGET(tx_pool_standard, .init = initialize_tx_pool)
     chainstate.SetMempool(&tx_pool);
 
     // Helper to query an amount
-    const CCoinsViewMemPool amount_view{WITH_LOCK(::cs_main, return &chainstate.CoinsTip()), tx_pool};
+    const CCoinsViewMemPool amount_view{WITH_LOCK(::cs_main, return chainstate.CoinsTip()), tx_pool};
     const auto GetAmount = [&](const COutPoint& outpoint) {
         auto coin{amount_view.GetCoin(outpoint).value()};
         return coin.out.nValue;

--- a/src/test/fuzz/utxo_snapshot.cpp
+++ b/src/test/fuzz/utxo_snapshot.cpp
@@ -59,7 +59,7 @@ void sanity_check_snapshot()
     LOCK(cs_main);
     auto& cs{node.chainman->ActiveChainstate()};
     cs.ForceFlushStateToDisk(/*wipe_cache=*/false);
-    const auto stats{*Assert(kernel::ComputeUTXOStats(kernel::CoinStatsHashType::HASH_SERIALIZED, &cs.CoinsDB(), node.chainman->m_blockman))};
+    const auto stats{*Assert(kernel::ComputeUTXOStats(kernel::CoinStatsHashType::HASH_SERIALIZED, cs.CoinsDB(), node.chainman->m_blockman))};
     const auto cp_au_data{*Assert(node.chainman->GetParams().AssumeutxoForHeight(2 * COINBASE_MATURITY))};
     Assert(stats.nHeight == cp_au_data.height);
     Assert(stats.nTransactions + 1 == cp_au_data.m_chain_tx_count); // +1 for the genesis tx.

--- a/src/test/fuzz/utxo_total_supply.cpp
+++ b/src/test/fuzz/utxo_total_supply.cpp
@@ -93,7 +93,7 @@ FUZZ_TARGET(utxo_total_supply)
         LOCK(chainman.GetMutex());
         chainman.ActiveChainstate().ForceFlushStateToDisk(wipe_cache);
         utxo_stats = std::move(
-            *Assert(kernel::ComputeUTXOStats(kernel::CoinStatsHashType::NONE, &chainman.ActiveChainstate().CoinsDB(), chainman.m_blockman, {})));
+            *Assert(kernel::ComputeUTXOStats(kernel::CoinStatsHashType::NONE, chainman.ActiveChainstate().CoinsDB(), chainman.m_blockman, {})));
         // Check that miner can't print more money than they are allowed to
         assert(circulation == utxo_stats.total_amount);
     };

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -45,7 +45,7 @@ struct MinerTestingSetup : public TestingSetup {
     void TestPrioritisedMining(const CScript& scriptPubKey, const std::vector<CTransactionRef>& txFirst) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     bool TestSequenceLocks(const CTransaction& tx, CTxMemPool& tx_mempool) EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
     {
-        CCoinsViewMemPool view_mempool{&m_node.chainman->ActiveChainstate().CoinsTip(), tx_mempool};
+        CCoinsViewMemPool view_mempool{m_node.chainman->ActiveChainstate().CoinsTip(), tx_mempool};
         CBlockIndex* tip{m_node.chainman->ActiveChain().Tip()};
         const std::optional<LockPoints> lock_points{CalculateLockPointsAtTip(tip, view_mempool, tx)};
         return lock_points.has_value() && CheckSequenceLocksAtTip(tip, *lock_points);

--- a/src/test/script_p2sh_tests.cpp
+++ b/src/test/script_p2sh_tests.cpp
@@ -277,7 +277,7 @@ BOOST_AUTO_TEST_CASE(switchover)
 
 BOOST_AUTO_TEST_CASE(ValidateInputsStandardness)
 {
-    CCoinsViewCache coins{&CoinsViewEmpty::Get()};
+    CCoinsViewCache coins{CoinsViewEmpty::Get()};
     FillableSigningProvider keystore;
     CKey key[6];
     for (int i = 0; i < 6; i++)

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -116,7 +116,7 @@ BOOST_AUTO_TEST_CASE(GetTxSigOpCost)
     CMutableTransaction spendingTx;
 
     // Create utxo set
-    CCoinsViewCache coins{&CoinsViewEmpty::Get()};
+    CCoinsViewCache coins{CoinsViewEmpty::Get()};
     // Create key
     CKey key = GenerateRandomKey();
     CPubKey pubkey = key.GetPubKey();

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -392,7 +392,7 @@ BOOST_AUTO_TEST_CASE(basic_transaction_tests)
 BOOST_AUTO_TEST_CASE(test_Get)
 {
     FillableSigningProvider keystore;
-    CCoinsViewCache coins{&CoinsViewEmpty::Get()};
+    CCoinsViewCache coins{CoinsViewEmpty::Get()};
     std::vector<CMutableTransaction> dummyTransactions =
         SetupDummyInputs(keystore, coins, {11*CENT, 50*CENT, 21*CENT, 22*CENT});
 
@@ -748,7 +748,7 @@ BOOST_AUTO_TEST_CASE(test_witness)
 BOOST_AUTO_TEST_CASE(test_IsStandard)
 {
     FillableSigningProvider keystore;
-    CCoinsViewCache coins{&CoinsViewEmpty::Get()};
+    CCoinsViewCache coins{CoinsViewEmpty::Get()};
     std::vector<CMutableTransaction> dummyTransactions =
         SetupDummyInputs(keystore, coins, {11*CENT, 50*CENT, 21*CENT, 22*CENT});
 
@@ -1020,7 +1020,7 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
 
 BOOST_AUTO_TEST_CASE(max_standard_legacy_sigops)
 {
-    CCoinsViewCache coins{&CoinsViewEmpty::Get()};
+    CCoinsViewCache coins{CoinsViewEmpty::Get()};
     CKey key;
     key.MakeNewKey(true);
 
@@ -1129,7 +1129,7 @@ BOOST_AUTO_TEST_CASE(max_standard_legacy_sigops)
 BOOST_AUTO_TEST_CASE(checktxinputs_invalid_transactions_test)
 {
     auto check_invalid{[](CAmount input_value, CAmount output_value, bool coinbase, int spend_height, TxValidationResult expected_result, std::string_view expected_reason) {
-        CCoinsViewCache inputs{&CoinsViewEmpty::Get()};
+        CCoinsViewCache inputs{CoinsViewEmpty::Get()};
 
         const COutPoint prevout{Txid::FromUint256(uint256::ONE), 0};
         inputs.AddCoin(prevout, Coin{{input_value, CScript() << OP_TRUE}, /*nHeightIn=*/1, coinbase}, /*possible_overwrite=*/false);
@@ -1177,7 +1177,7 @@ BOOST_AUTO_TEST_CASE(getvalueout_out_of_range_throws)
 /** Sanity check the return value of SpendsNonAnchorWitnessProg for various output types. */
 BOOST_AUTO_TEST_CASE(spends_witness_prog)
 {
-    CCoinsViewCache coins{&CoinsViewEmpty::Get()};
+    CCoinsViewCache coins{CoinsViewEmpty::Get()};
     CKey key;
     key.MakeNewKey(true);
     const CPubKey pubkey{key.GetPubKey()};

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -142,7 +142,7 @@ static void ValidateCheckInputsForAllFlags(const CTransaction &tx, script_verify
             // WITNESS requires P2SH
             test_flags |= SCRIPT_VERIFY_P2SH;
         }
-        bool ret = CheckInputScripts(tx, state, &active_coins_tip, test_flags, true, add_to_cache, txdata, validation_cache, nullptr);
+        bool ret = CheckInputScripts(tx, state, active_coins_tip, test_flags, true, add_to_cache, txdata, validation_cache, nullptr);
         // CheckInputScripts should succeed iff test_flags doesn't intersect with
         // failing_flags
         bool expected_return_value = !(test_flags & failing_flags);
@@ -152,13 +152,13 @@ static void ValidateCheckInputsForAllFlags(const CTransaction &tx, script_verify
         if (ret && add_to_cache) {
             // Check that we get a cache hit if the tx was valid
             std::vector<CScriptCheck> scriptchecks;
-            BOOST_CHECK(CheckInputScripts(tx, state, &active_coins_tip, test_flags, true, add_to_cache, txdata, validation_cache, &scriptchecks));
+            BOOST_CHECK(CheckInputScripts(tx, state, active_coins_tip, test_flags, true, add_to_cache, txdata, validation_cache, &scriptchecks));
             BOOST_CHECK(scriptchecks.empty());
         } else {
             // Check that we get script executions to check, if the transaction
             // was invalid, or we didn't add to cache.
             std::vector<CScriptCheck> scriptchecks;
-            BOOST_CHECK(CheckInputScripts(tx, state, &active_coins_tip, test_flags, true, add_to_cache, txdata, validation_cache, &scriptchecks));
+            BOOST_CHECK(CheckInputScripts(tx, state, active_coins_tip, test_flags, true, add_to_cache, txdata, validation_cache, &scriptchecks));
             BOOST_CHECK_EQUAL(scriptchecks.size(), tx.vin.size());
         }
     }
@@ -216,13 +216,13 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
         TxValidationState state;
         PrecomputedTransactionData ptd_spend_tx;
 
-        BOOST_CHECK(!CheckInputScripts(CTransaction(spend_tx), state, &m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_DERSIG, true, true, ptd_spend_tx, m_node.chainman->m_validation_cache, nullptr));
+        BOOST_CHECK(!CheckInputScripts(CTransaction(spend_tx), state, m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_DERSIG, true, true, ptd_spend_tx, m_node.chainman->m_validation_cache, nullptr));
 
         // If we call again asking for scriptchecks (as happens in
         // ConnectBlock), we should add a script check object for this -- we're
         // not caching invalidity (if that changes, delete this test case).
         std::vector<CScriptCheck> scriptchecks;
-        BOOST_CHECK(CheckInputScripts(CTransaction(spend_tx), state, &m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_DERSIG, true, true, ptd_spend_tx, m_node.chainman->m_validation_cache, &scriptchecks));
+        BOOST_CHECK(CheckInputScripts(CTransaction(spend_tx), state, m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_DERSIG, true, true, ptd_spend_tx, m_node.chainman->m_validation_cache, &scriptchecks));
         BOOST_CHECK_EQUAL(scriptchecks.size(), 1U);
 
         // Test that CheckInputScripts returns true iff DERSIG-enforcing flags are
@@ -312,7 +312,7 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
         invalid_with_csv_tx.vin[0].scriptSig = CScript() << vchSig << 100;
         TxValidationState state;
         PrecomputedTransactionData txdata;
-        BOOST_CHECK(CheckInputScripts(CTransaction(invalid_with_csv_tx), state, &m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_CHECKSEQUENCEVERIFY, true, true, txdata, m_node.chainman->m_validation_cache, nullptr));
+        BOOST_CHECK(CheckInputScripts(CTransaction(invalid_with_csv_tx), state, m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_CHECKSEQUENCEVERIFY, true, true, txdata, m_node.chainman->m_validation_cache, nullptr));
     }
 
     // TODO: add tests for remaining script flags
@@ -374,12 +374,12 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
         TxValidationState state;
         PrecomputedTransactionData txdata;
         // This transaction is now invalid under segwit, because of the second input.
-        BOOST_CHECK(!CheckInputScripts(CTransaction(tx), state, &m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS, true, true, txdata, m_node.chainman->m_validation_cache, nullptr));
+        BOOST_CHECK(!CheckInputScripts(CTransaction(tx), state, m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS, true, true, txdata, m_node.chainman->m_validation_cache, nullptr));
 
         std::vector<CScriptCheck> scriptchecks;
         // Make sure this transaction was not cached (ie because the first
         // input was valid)
-        BOOST_CHECK(CheckInputScripts(CTransaction(tx), state, &m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS, true, true, txdata, m_node.chainman->m_validation_cache, &scriptchecks));
+        BOOST_CHECK(CheckInputScripts(CTransaction(tx), state, m_node.chainman->ActiveChainstate().CoinsTip(), SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS, true, true, txdata, m_node.chainman->m_validation_cache, &scriptchecks));
         // Should get 2 script checks back -- caching is on a whole-transaction basis.
         BOOST_CHECK_EQUAL(scriptchecks.size(), 2U);
     }

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -465,7 +465,7 @@ std::pair<CMutableTransaction, CAmount> TestChain100Setup::CreateValidTransactio
         keystore.AddKey(input_signing_key);
     }
     // - Populate a CoinsViewCache with the unspent output
-    CCoinsViewCache coins_cache{&CoinsViewEmpty::Get()};
+    CCoinsViewCache coins_cache{CoinsViewEmpty::Get()};
     for (const auto& input_transaction : input_transactions) {
         AddCoins(coins_cache, *input_transaction.get(), input_height);
     }

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -31,7 +31,7 @@ struct CoinsViewOptions {
 };
 
 /** CCoinsView backed by the coin database (chainstate/) */
-class CCoinsViewDB final : public CCoinsView
+class CCoinsViewDB final : public CCoinsView, public CCoinsViewStorage
 {
 protected:
     DBParams m_db_params;

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -31,7 +31,7 @@ struct CoinsViewOptions {
 };
 
 /** CCoinsView backed by the coin database (chainstate/) */
-class CCoinsViewDB final : public CCoinsView, public CCoinsViewStorage
+class CCoinsViewDB final : public CCoinsViewCacheBackend, public CCoinsViewStorage
 {
 protected:
     DBParams m_db_params;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -430,7 +430,7 @@ void CTxMemPool::removeForBlock(const std::vector<CTransactionRef>& vtx, unsigne
     }
 }
 
-void CTxMemPool::check(const CCoinsViewCache& active_coins_tip, int64_t spendheight) const
+void CTxMemPool::check(CCoinsViewCache& active_coins_tip, int64_t spendheight) const
 {
     if (m_opts.check_ratio == 0) return;
 
@@ -449,7 +449,8 @@ void CTxMemPool::check(const CCoinsViewCache& active_coins_tip, int64_t spendhei
     assert(!m_txgraph->IsOversized(TxGraph::Level::MAIN));
     m_txgraph->SanityCheck();
 
-    CCoinsViewCache mempoolDuplicate(const_cast<CCoinsViewCache*>(&active_coins_tip));
+    CCoinsView& active_coins_backend{active_coins_tip};
+    CCoinsViewCache mempoolDuplicate{active_coins_backend};
 
     const auto score_with_topo{GetSortedScoreWithTopology()};
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -449,7 +449,7 @@ void CTxMemPool::check(CCoinsViewCache& active_coins_tip, int64_t spendheight) c
     assert(!m_txgraph->IsOversized(TxGraph::Level::MAIN));
     m_txgraph->SanityCheck();
 
-    CCoinsView& active_coins_backend{active_coins_tip};
+    CCoinsViewCacheBackend& active_coins_backend{active_coins_tip};
     CCoinsViewCache mempoolDuplicate{active_coins_backend};
 
     const auto score_with_topo{GetSortedScoreWithTopology()};
@@ -738,7 +738,7 @@ bool CTxMemPool::HasNoInputsOf(const CTransaction &tx) const
     return true;
 }
 
-CCoinsViewMemPool::CCoinsViewMemPool(CCoinsView& baseIn, const CTxMemPool& mempoolIn) : base{&baseIn}, mempool(mempoolIn) { }
+CCoinsViewMemPool::CCoinsViewMemPool(CCoinsViewCacheBackend& baseIn, const CTxMemPool& mempoolIn) : base{&baseIn}, mempool(mempoolIn) { }
 
 std::optional<Coin> CCoinsViewMemPool::GetCoin(const COutPoint& outpoint) const
 {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -737,7 +737,7 @@ bool CTxMemPool::HasNoInputsOf(const CTransaction &tx) const
     return true;
 }
 
-CCoinsViewMemPool::CCoinsViewMemPool(CCoinsView* baseIn, const CTxMemPool& mempoolIn) : CCoinsViewBacked(baseIn), mempool(mempoolIn) { }
+CCoinsViewMemPool::CCoinsViewMemPool(CCoinsView& baseIn, const CTxMemPool& mempoolIn) : base{&baseIn}, mempool(mempoolIn) { }
 
 std::optional<Coin> CCoinsViewMemPool::GetCoin(const COutPoint& outpoint) const
 {

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -747,9 +747,9 @@ public:
  * signrawtransactionwithkey and signrawtransactionwithwallet,
  * as long as the conflicting transaction is not yet confirmed.
  */
-class CCoinsViewMemPool : public CCoinsView
+class CCoinsViewMemPool : public CCoinsViewCacheBackend
 {
-    CCoinsView* base;
+    CCoinsViewCacheBackend* base;
 
     /**
     * Coins made available by transactions being validated. Tracking these allows for package
@@ -766,7 +766,7 @@ protected:
     const CTxMemPool& mempool;
 
 public:
-    CCoinsViewMemPool(CCoinsView& baseIn, const CTxMemPool& mempoolIn);
+    CCoinsViewMemPool(CCoinsViewCacheBackend& baseIn, const CTxMemPool& mempoolIn);
     /** GetCoin, returning whether it exists and is not spent. Also updates m_non_base_coins if the
      * coin is not fetched from base. May populate the base view on cache misses. */
     std::optional<Coin> GetCoin(const COutPoint& outpoint) const override;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -313,7 +313,7 @@ public:
      * all inputs are in the mapNextTx array). If sanity-checking is turned off,
      * check does nothing.
      */
-    void check(const CCoinsViewCache& active_coins_tip, int64_t spendheight) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    void check(CCoinsViewCache& active_coins_tip, int64_t spendheight) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /**
      * Remove a transaction from the mempool along with any descendants.

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -747,8 +747,10 @@ public:
  * signrawtransactionwithkey and signrawtransactionwithwallet,
  * as long as the conflicting transaction is not yet confirmed.
  */
-class CCoinsViewMemPool : public CCoinsViewBacked
+class CCoinsViewMemPool : public CCoinsView
 {
+    CCoinsView* base;
+
     /**
     * Coins made available by transactions being validated. Tracking these allows for package
     * validation, since we can access transaction outputs without submitting them to mempool.
@@ -764,10 +766,14 @@ protected:
     const CTxMemPool& mempool;
 
 public:
-    CCoinsViewMemPool(CCoinsView* baseIn, const CTxMemPool& mempoolIn);
+    CCoinsViewMemPool(CCoinsView& baseIn, const CTxMemPool& mempoolIn);
     /** GetCoin, returning whether it exists and is not spent. Also updates m_non_base_coins if the
      * coin is not fetched from base. May populate the base view on cache misses. */
     std::optional<Coin> GetCoin(const COutPoint& outpoint) const override;
+    std::optional<Coin> PeekCoin(const COutPoint& outpoint) const override { return base->PeekCoin(outpoint); }
+    bool HaveCoin(const COutPoint& outpoint) const override { return base->HaveCoin(outpoint); }
+    uint256 GetBestBlock() const override { return base->GetBestBlock(); }
+    void BatchWrite(CoinsViewCacheCursor& cursor, const uint256& block_hash) override { base->BatchWrite(cursor, block_hash); }
     /** Add the coins created by this transaction. These coins are only temporarily stored in
      * m_temp_added and cannot be flushed to the back end. Only used for package validation. */
     void PackageAddTransaction(const CTransactionRef& tx);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -356,7 +356,7 @@ void Chainstate::MaybeUpdateMempoolForReorg(
                 return true;
             }
         } else {
-            const CCoinsViewMemPool view_mempool{&CoinsTip(), *m_mempool};
+            const CCoinsViewMemPool view_mempool{CoinsTip(), *m_mempool};
             const std::optional<LockPoints> new_lock_points{CalculateLockPointsAtTip(m_chain.Tip(), view_mempool, tx)};
             if (new_lock_points.has_value() && CheckSequenceLocksAtTip(m_chain.Tip(), *new_lock_points)) {
                 // Now update the mempool entry lockpoints as well.
@@ -439,7 +439,7 @@ public:
     explicit MemPoolAccept(CTxMemPool& mempool, Chainstate& active_chainstate) :
         m_pool(mempool),
         m_view(&CoinsViewEmpty::Get()),
-        m_viewmempool(&active_chainstate.CoinsTip(), m_pool),
+        m_viewmempool(active_chainstate.CoinsTip(), m_pool),
         m_active_chainstate(active_chainstate)
     {
     }
@@ -1848,7 +1848,7 @@ CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
 
 CoinsViews::CoinsViews(DBParams db_params, CoinsViewOptions options)
     : m_dbview{std::move(db_params), std::move(options)},
-      m_catcherview(&m_dbview) {}
+      m_catcherview{m_dbview} {}
 
 void CoinsViews::InitCache()
 {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2941,8 +2941,7 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
     // Apply the block atomically to the chain state.
     const auto time_start{SteadyClock::now()};
     {
-        CCoinsViewCacheBackend& coins_backend{CoinsTip()};
-        CCoinsViewCache view{coins_backend};
+        CCoinsViewCache view{CoinsTip()};
         assert(view.GetBestBlock() == pindexDelete->GetBlockHash());
         if (DisconnectBlock(block, pindexDelete, view) != DISCONNECT_OK) {
             LogError("DisconnectTip(): DisconnectBlock %s failed\n", pindexDelete->GetBlockHash().ToString());
@@ -4510,8 +4509,7 @@ BlockValidationState TestBlockValidity(
     index_dummy.pprev = tip;
     index_dummy.nHeight = tip->nHeight + 1;
     index_dummy.phashBlock = &block_hash;
-    CCoinsViewCacheBackend& coins_backend{chainstate.CoinsTip()};
-    CCoinsViewCache view_dummy{coins_backend};
+    CCoinsViewCache view_dummy{chainstate.CoinsTip()};
 
     // Set fJustCheck to true in order to update, and not clear, validation caches.
     if(!chainstate.ConnectBlock(block, state, &index_dummy, view_dummy, /*fJustCheck=*/true)) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2941,7 +2941,7 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
     // Apply the block atomically to the chain state.
     const auto time_start{SteadyClock::now()};
     {
-        CCoinsView& coins_backend{CoinsTip()};
+        CCoinsViewCacheBackend& coins_backend{CoinsTip()};
         CCoinsViewCache view{coins_backend};
         assert(view.GetBestBlock() == pindexDelete->GetBlockHash());
         if (DisconnectBlock(block, pindexDelete, view) != DISCONNECT_OK) {
@@ -4510,7 +4510,7 @@ BlockValidationState TestBlockValidity(
     index_dummy.pprev = tip;
     index_dummy.nHeight = tip->nHeight + 1;
     index_dummy.phashBlock = &block_hash;
-    CCoinsView& coins_backend{chainstate.CoinsTip()};
+    CCoinsViewCacheBackend& coins_backend{chainstate.CoinsTip()};
     CCoinsViewCache view_dummy{coins_backend};
 
     // Set fJustCheck to true in order to update, and not clear, validation caches.
@@ -4603,7 +4603,7 @@ CVerifyDB::~CVerifyDB()
 VerifyDBResult CVerifyDB::VerifyDB(
     Chainstate& chainstate,
     const Consensus::Params& consensus_params,
-    CCoinsView& coinsview,
+    CCoinsViewCacheBackend& coinsview,
     int nCheckLevel, int nCheckDepth)
 {
     AssertLockHeld(cs_main);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -438,7 +438,7 @@ class MemPoolAccept
 public:
     explicit MemPoolAccept(CTxMemPool& mempool, Chainstate& active_chainstate) :
         m_pool(mempool),
-        m_view(&CoinsViewEmpty::Get()),
+        m_view(CoinsViewEmpty::Get()),
         m_viewmempool(active_chainstate.CoinsTip(), m_pool),
         m_active_chainstate(active_chainstate)
     {
@@ -1853,8 +1853,8 @@ CoinsViews::CoinsViews(DBParams db_params, CoinsViewOptions options)
 void CoinsViews::InitCache()
 {
     AssertLockHeld(::cs_main);
-    m_cacheview = std::make_unique<CCoinsViewCache>(&m_catcherview);
-    m_connect_block_view = std::make_unique<CoinsViewOverlay>(&*m_cacheview);
+    m_cacheview = std::make_unique<CCoinsViewCache>(m_catcherview);
+    m_connect_block_view = std::make_unique<CoinsViewOverlay>(*m_cacheview);
 }
 
 Chainstate::Chainstate(
@@ -2941,7 +2941,8 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
     // Apply the block atomically to the chain state.
     const auto time_start{SteadyClock::now()};
     {
-        CCoinsViewCache view(&CoinsTip());
+        CCoinsView& coins_backend{CoinsTip()};
+        CCoinsViewCache view{coins_backend};
         assert(view.GetBestBlock() == pindexDelete->GetBlockHash());
         if (DisconnectBlock(block, pindexDelete, view) != DISCONNECT_OK) {
             LogError("DisconnectTip(): DisconnectBlock %s failed\n", pindexDelete->GetBlockHash().ToString());
@@ -4509,7 +4510,8 @@ BlockValidationState TestBlockValidity(
     index_dummy.pprev = tip;
     index_dummy.nHeight = tip->nHeight + 1;
     index_dummy.phashBlock = &block_hash;
-    CCoinsViewCache view_dummy(&chainstate.CoinsTip());
+    CCoinsView& coins_backend{chainstate.CoinsTip()};
+    CCoinsViewCache view_dummy{coins_backend};
 
     // Set fJustCheck to true in order to update, and not clear, validation caches.
     if(!chainstate.ConnectBlock(block, state, &index_dummy, view_dummy, /*fJustCheck=*/true)) {
@@ -4616,7 +4618,7 @@ VerifyDBResult CVerifyDB::VerifyDB(
     }
     nCheckLevel = std::max(0, std::min(4, nCheckLevel));
     LogInfo("Verifying last %i blocks at level %i", nCheckDepth, nCheckLevel);
-    CCoinsViewCache coins(&coinsview);
+    CCoinsViewCache coins{coinsview};
     CBlockIndex* pindex;
     CBlockIndex* pindexFailure = nullptr;
     int nGoodTransactions = 0;
@@ -4765,7 +4767,7 @@ bool Chainstate::ReplayBlocks()
     LOCK(cs_main);
 
     CCoinsViewDB& db = this->CoinsDB();
-    CCoinsViewCache cache(&db);
+    CCoinsViewCache cache{db};
 
     std::vector<uint256> hashHeads = db.GetHeadBlocks();
     if (hashHeads.empty()) return true; // We're already in a consistent state.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4764,7 +4764,7 @@ bool Chainstate::ReplayBlocks()
 {
     LOCK(cs_main);
 
-    CCoinsView& db = this->CoinsDB();
+    CCoinsViewDB& db = this->CoinsDB();
     CCoinsViewCache cache(&db);
 
     std::vector<uint256> hashHeads = db.GetHeadBlocks();
@@ -5890,7 +5890,7 @@ util::Result<void> ChainstateManager::PopulateAndValidateSnapshot(
 
     try {
         maybe_stats = ComputeUTXOStats(
-            CoinStatsHashType::HASH_SERIALIZED, snapshot_coinsdb, m_blockman, [&interrupt = m_interrupt] { SnapshotUTXOHashBreakpoint(interrupt); });
+            CoinStatsHashType::HASH_SERIALIZED, *snapshot_coinsdb, m_blockman, [&interrupt = m_interrupt] { SnapshotUTXOHashBreakpoint(interrupt); });
     } catch (StopHashingException const&) {
         return util::Error{Untranslated("Aborting after an interrupt was requested")};
     }
@@ -6025,7 +6025,7 @@ SnapshotCompletionResult ChainstateManager::MaybeValidateSnapshot(Chainstate& va
     try {
         validated_cs_stats = ComputeUTXOStats(
             CoinStatsHashType::HASH_SERIALIZED,
-            &validated_coins_db,
+            validated_coins_db,
             m_blockman,
             [&interrupt = m_interrupt] { SnapshotUTXOHashBreakpoint(interrupt); });
     } catch (StopHashingException const&) {

--- a/src/validation.h
+++ b/src/validation.h
@@ -443,7 +443,7 @@ public:
     [[nodiscard]] VerifyDBResult VerifyDB(
         Chainstate& chainstate,
         const Consensus::Params& consensus_params,
-        CCoinsView& coinsview,
+        CCoinsViewCacheBackend& coinsview,
         int nCheckLevel,
         int nCheckDepth) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 };


### PR DESCRIPTION
### Problem
`CCoinsView` currently exposes coin lookup, cache flushing, persistent storage traversal, storage sizing, and backend switching through the same base interface.
This makes cache overlays, mempool views, error-catching views, and database-backed storage advertise capabilities that only some of them naturally own.
It also leaves the cache backend contract implicit: a cache must read misses and flush writes through the same state object, not through separate reader and writer instances.

### Fix
This PR narrows `CCoinsView` to coin lookup and best-block reads, introduces `CCoinsViewStorage` for persistent storage traversal and sizing, and introduces `CCoinsViewCacheBackend` for same-object cache backends that can also receive `BatchWrite`.

Backend switching moves down to `CCoinsViewCache`, the generic `CCoinsViewBacked` forwarding adapter is removed, and cache construction now takes live backend references.
The stack also removes the stale `CTxMemPool::check` `const_cast` by making its cache-populating read side effect explicit in the parameter type.

`GetCoin` and `PeekCoin` intentionally remain separate because `CoinsViewOverlay` still needs a non-caching lookup path.
A further split that lets temporary mempool overlays be read-only cache backends would be a natural follow-up, but this PR keeps the current flush behavior unchanged.