### PR TITLE
util: treat broken token pipe as end-of-stream

### DIFF
--- a/src/util/tokenpipe.cpp
+++ b/src/util/tokenpipe.cpp
@@ -45,6 +45,9 @@ int TokenPipeEnd::TokenWrite(uint8_t token)
         if (result < 0) {
             // Failure. It's possible that the write was interrupted by a signal,
             // in that case retry.
+            if (errno == EPIPE) {
+                return TS_EOS;
+            }
             if (errno != EINTR) {
                 return TS_ERR;
             }


### PR DESCRIPTION
### Problem
`TokenPipeEnd::TokenWrite()` currently maps `EPIPE` to the generic `TS_ERR` status.

POSIX specifies `EPIPE` for writes to a pipe with no reader, and `bitcoind` ignores `SIGPIPE` during init, so this return path can be observed instead of terminating the process.

### Fix
Return `TS_EOS` for `EPIPE`, matching the existing `TokenPipeEnd` contract that end-of-stream conditions are reported as `TS_EOS`.

This is consistent with the existing zero-byte write handling and keeps generic I/O errors separate from closed-pipe conditions.

### Review
Relevant references:

- POSIX `write()`: https://pubs.opengroup.org/onlinepubs/9699919799/functions/write.html
- Linux `write(2)`: https://man7.org/linux/man-pages/man2/write.2.html
