### PR TITLE
wallet: check the final BDB page LSN during migration

### DIFF
--- a/src/wallet/migrate.cpp
+++ b/src/wallet/migrate.cpp
@@ -567,7 +567,7 @@ void BerkeleyRODatabase::Open()
 
     // Check all Log Sequence Numbers (LSN) point to file 0 and offset 1 which indicates that the LSNs were
     // reset and that the log files are not necessary to get all of the data in the database.
-    for (uint32_t i = 0; i < outer_meta.last_page; ++i) {
+    for (uint32_t i = 0; i <= outer_meta.last_page; ++i) {
         // The LSN is composed of 2 32-bit ints, the first is a file id, the second an offset
         // It will always be the first 8 bytes of a page, so we deserialize it directly for every page
         uint32_t file;


### PR DESCRIPTION
### Problem

Legacy wallet migration uses the read-only BDB parser to verify that every page LSN is reset before reading records without BDB log files.

The BDB `last_page` metadata field stores the last valid page number, but the parser treated it like a page count and scanned only `0..<last_page`.
This skipped the final page, so a database whose last page still depended on BDB logs could be accepted.

### Fix

Scan LSNs through `last_page` inclusively.

A new unit test builds a minimal BDB fixture and corrupts only the final page LSN.
The fixture is rejected with the existing incomplete-flush error after the fix, but opens successfully with the previous loop.