### PR TITLE
wallet: forward outpoint to MaxInputWeight when sizing external inputs

### DIFF
--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -94,7 +94,7 @@ int CalculateMaximumSignedInputSize(const CTxOut& txout, const COutPoint outpoin
     if (!provider) return -1;
 
     if (const auto desc = InferDescriptor(txout.scriptPubKey, *provider)) {
-        if (const auto weight = MaxInputWeight(*desc, {}, coin_control, true, can_grind_r)) {
+        if (const auto weight = MaxInputWeight(*desc, {CTxIn{outpoint}}, coin_control, true, can_grind_r)) {
             return static_cast<int>(GetVirtualTransactionSize(*weight, 0, 0));
         }
     }

--- a/src/wallet/test/spend_tests.cpp
+++ b/src/wallet/test/spend_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <consensus/amount.h>
+#include <key.h>
 #include <policy/fees/block_policy_estimator.h>
 #include <script/solver.h>
 #include <validation.h>
@@ -15,6 +16,22 @@
 
 namespace wallet {
 BOOST_FIXTURE_TEST_SUITE(spend_tests, WalletTestingSetup)
+
+BOOST_AUTO_TEST_CASE(max_signed_input_size_uses_external_outpoint)
+{
+    const CKey key{GenerateRandomKey()};
+    FillableSigningProvider provider;
+    BOOST_REQUIRE(provider.AddKey(key));
+
+    const CTxOut txout{COIN, GetScriptForDestination(PKHash{key.GetPubKey()})};
+    const COutPoint outpoint{Txid{}, 0};
+    CCoinControl coin_control;
+    coin_control.Select(outpoint).SetTxOut(txout);
+
+    const int low_r{CalculateMaximumSignedInputSize(txout, COutPoint{}, &provider, /*can_grind_r=*/true, &coin_control)};
+    const int high_r{CalculateMaximumSignedInputSize(txout, outpoint, &provider, /*can_grind_r=*/true, &coin_control)};
+    BOOST_CHECK_EQUAL(high_r, low_r + 1);
+}
 
 BOOST_FIXTURE_TEST_CASE(SubtractFee, TestChain100Setup)
 {


### PR DESCRIPTION
### Problem
`CalculateMaximumSignedInputSize(txout, outpoint, provider, can_grind_r, coin_control)` accepted an `outpoint` argument, but did not pass a `CTxIn` to `MaxInputWeight()`.

`UseMaxSig()` decides whether to assume max-size ECDSA signatures by checking `coin_control->IsExternalSelected(txin->prevout)`. Without the input prevout, externally-selected inputs were sized as if low-R grinding could be relied on, underestimating legacy ECDSA inputs by 1 vbyte.

### Fix
Wrap the provided outpoint in a `CTxIn` before calling `MaxInputWeight()`, matching the existing signed-transaction sizing path.

A new unit test covers the external-input case by marking a P2PKH outpoint as external in `CCoinControl` and checking that the helper returns the high-R estimate for the matching outpoint.