### PR TITLE
coins: cache CCoinsMap outpoint hashes

### DIFF
--- a/src/bench/pool.cpp
+++ b/src/bench/pool.cpp
@@ -41,7 +41,7 @@ static void PoolAllocator_StdUnorderedMapWithPoolResource(benchmark::Bench& benc
                                    std::hash<uint64_t>,
                                    std::equal_to<uint64_t>,
                                    PoolAllocator<std::pair<const uint64_t, uint64_t>,
-                                                 sizeof(std::pair<const uint64_t, uint64_t>) + 4 * sizeof(void*)>>;
+                                                 sizeof(std::pair<const uint64_t, uint64_t>) + 3 * sizeof(void*)>>;
 
     // make sure the resource supports large enough pools to hold the node. We do this by adding the size of a few pointers to it.
     auto pool_resource = Map::allocator_type::ResourceType();

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -30,7 +30,7 @@ std::optional<Coin> CCoinsViewCache::PeekCoin(const COutPoint& outpoint) const
 
 CCoinsViewCache::CCoinsViewCache(CCoinsView* in_base, bool deterministic) :
     CCoinsViewBacked(in_base), m_deterministic(deterministic),
-    cacheCoins(0, SaltedOutpointHasher(/*deterministic=*/deterministic), CCoinsMap::key_equal{}, &m_cache_coins_memory_resource)
+    cacheCoins(0, CCoinsMap::hasher{/*deterministic=*/deterministic}, CCoinsMap::key_equal{}, &m_cache_coins_memory_resource)
 {
     m_sentinel.second.SelfRef(m_sentinel);
 }
@@ -326,7 +326,7 @@ void CCoinsViewCache::ReallocateCache()
     cacheCoins.~CCoinsMap();
     m_cache_coins_memory_resource.~CCoinsMapMemoryResource();
     ::new (&m_cache_coins_memory_resource) CCoinsMapMemoryResource{};
-    ::new (&cacheCoins) CCoinsMap{0, SaltedOutpointHasher{/*deterministic=*/m_deterministic}, CCoinsMap::key_equal{}, &m_cache_coins_memory_resource};
+    ::new (&cacheCoins) CCoinsMap{0, CCoinsMap::hasher{/*deterministic=*/m_deterministic}, CCoinsMap::key_equal{}, &m_cache_coins_memory_resource};
 }
 
 void CCoinsViewCache::SanityCheck() const

--- a/src/coins.h
+++ b/src/coins.h
@@ -210,10 +210,10 @@ public:
 
 /**
  * PoolAllocator's MAX_BLOCK_SIZE_BYTES parameter here uses sizeof the data, and adds the size
- * of 4 pointers. We do not know the exact node size used in the std::unordered_node implementation
+ * of 3 pointers. We do not know the exact node size used in the std::unordered_node implementation
  * because it is implementation defined. Most implementations have an overhead of 1 or 2 pointers,
- * so nodes can be connected in a linked list, and in some cases the hash value is stored as well.
- * Using an additional sizeof(void*)*4 for MAX_BLOCK_SIZE_BYTES should thus be sufficient so that
+ * so nodes can be connected in a linked list.
+ * Using an additional 3 * sizeof(void*) for MAX_BLOCK_SIZE_BYTES should thus be sufficient so that
  * all implementations can allocate the nodes from the PoolAllocator.
  */
 using CCoinsMap = std::unordered_map<COutPoint,
@@ -221,7 +221,7 @@ using CCoinsMap = std::unordered_map<COutPoint,
                                      SaltedOutpointHasher,
                                      std::equal_to<COutPoint>,
                                      PoolAllocator<CoinsCachePair,
-                                                   sizeof(CoinsCachePair) + sizeof(void*) * 4>>;
+                                                   sizeof(CoinsCachePair) + 3 * sizeof(void*)>>;
 
 using CCoinsMapMemoryResource = CCoinsMap::allocator_type::ResourceType;
 

--- a/src/coins.h
+++ b/src/coins.h
@@ -18,6 +18,7 @@
 #include <util/overflow.h>
 #include <util/hasher.h>
 
+#include <atomic>
 #include <cassert>
 #include <cstdint>
 
@@ -86,6 +87,36 @@ public:
 
     size_t DynamicMemoryUsage() const {
         return memusage::DynamicUsage(out.scriptPubKey);
+    }
+};
+
+class CCoinsCacheHasher
+{
+    static const SaltedOutpointHasher& StableRandomHasher()
+    {
+        static const SaltedOutpointHasher hasher{/*deterministic=*/false};
+        return hasher;
+    }
+
+    SaltedOutpointHasher m_hasher;
+
+public:
+    explicit CCoinsCacheHasher(bool deterministic = false) :
+        m_hasher{deterministic ? SaltedOutpointHasher{/*deterministic=*/true} : StableRandomHasher()}
+    {
+    }
+
+    size_t operator()(const COutPoint& outpoint) const noexcept
+    {
+        std::atomic_ref<size_t> cached_hash{outpoint.m_cached_salted_hash};
+        if (const size_t hash{cached_hash.load(std::memory_order_relaxed)}) {
+            return hash;
+        }
+        const size_t hash{m_hasher(outpoint)};
+        // Reserve 0 as the empty-cache marker.
+        const size_t cached{hash == 0 ? 1 : hash};
+        size_t expected{0};
+        return cached_hash.compare_exchange_strong(expected, cached, std::memory_order_relaxed) ? cached : expected;
     }
 };
 
@@ -210,18 +241,18 @@ public:
 
 /**
  * PoolAllocator's MAX_BLOCK_SIZE_BYTES parameter here uses sizeof the data, and adds the size
- * of 3 pointers. We do not know the exact node size used in the std::unordered_node implementation
+ * of 4 pointers. We do not know the exact node size used in the std::unordered_node implementation
  * because it is implementation defined. Most implementations have an overhead of 1 or 2 pointers,
  * so nodes can be connected in a linked list.
- * Using an additional 3 * sizeof(void*) for MAX_BLOCK_SIZE_BYTES should thus be sufficient so that
+ * Using an additional 4 * sizeof(void*) for MAX_BLOCK_SIZE_BYTES should thus be sufficient so that
  * all implementations can allocate the nodes from the PoolAllocator.
  */
 using CCoinsMap = std::unordered_map<COutPoint,
                                      CCoinsCacheEntry,
-                                     SaltedOutpointHasher,
+                                     CCoinsCacheHasher,
                                      std::equal_to<COutPoint>,
                                      PoolAllocator<CoinsCachePair,
-                                                   sizeof(CoinsCachePair) + 3 * sizeof(void*)>>;
+                                                   sizeof(CoinsCachePair) + 4 * sizeof(void*)>>;
 
 using CCoinsMapMemoryResource = CCoinsMap::allocator_type::ResourceType;
 

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -24,9 +24,15 @@
 #include <utility>
 #include <vector>
 
+class CCoinsCacheHasher;
+
 /** An outpoint - a combination of a transaction hash and an index n into its vout */
 class COutPoint
 {
+    //! CCoinsMap hash cache, filled atomically by CCoinsCacheHasher.
+    mutable size_t m_cached_salted_hash{0};
+    friend class CCoinsCacheHasher;
+
 public:
     Txid hash;
     uint32_t n;

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -190,7 +190,7 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& co
                 sentinel.second.SelfRef(sentinel);
                 size_t dirty_count{0};
                 CCoinsMapMemoryResource resource;
-                CCoinsMap coins_map{0, SaltedOutpointHasher{/*deterministic=*/true}, CCoinsMap::key_equal{}, &resource};
+                CCoinsMap coins_map{0, CCoinsMap::hasher{/*deterministic=*/true}, CCoinsMap::key_equal{}, &resource};
                 LIMITED_WHILE(good_data && fuzzed_data_provider.ConsumeBool(), 10'000)
                 {
                     CCoinsCacheEntry coins_cache_entry;

--- a/src/test/pool_tests.cpp
+++ b/src/test/pool_tests.cpp
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE(memusage_test)
                                    std::hash<int64_t>,
                                    std::equal_to<int64_t>,
                                    PoolAllocator<std::pair<const int64_t, int64_t>,
-                                                 sizeof(std::pair<const int64_t, int64_t>) + sizeof(void*) * 4>>;
+                                                 sizeof(std::pair<const int64_t, int64_t>) + 3 * sizeof(void*)>>;
     auto resource = Map::allocator_type::ResourceType(1024);
 
     PoolResourceTester::CheckAllDataAccountedFor(resource);


### PR DESCRIPTION
Keep SaltedOutpointHasher noexcept so normal unordered containers do not ask libstdc++ to store hash codes in every node.

CCoinsMap still benefits from avoiding repeated salted outpoint hashing. Cache the hash in COutPoint and let CCoinsMap use a map-specific hasher id so copied cache entries do not reuse a hash from a different map salt.

The cached hash is now part of the key object itself, so restore the pool allocator budget to four pointer-sized fields.