### PR TITLE
reorg: ignore duplicate disconnected txids

### DIFF
--- a/src/kernel/disconnected_transactions.cpp
+++ b/src/kernel/disconnected_transactions.cpp
@@ -8,6 +8,7 @@
 #include <core_memusage.h>
 #include <memusage.h>
 #include <primitives/transaction.h>
+#include <util/check.h>
 #include <util/hasher.h>
 
 #include <memory>
@@ -52,7 +53,7 @@ size_t DisconnectedBlockTransactions::DynamicMemoryUsage() const
     for (auto block_it = vtx.rbegin(); block_it != vtx.rend(); ++block_it) {
         auto it = queuedTx.insert(queuedTx.end(), *block_it);
         auto [_, inserted] = iters_by_txid.emplace((*block_it)->GetHash(), it);
-        assert(inserted); // callers may never pass multiple transactions with the same txid
+        Assert(inserted); // callers may never pass multiple transactions with the same txid
         cachedInnerUsage += RecursiveDynamicUsage(*block_it);
     }
     return LimitMemoryUsage();

--- a/src/kernel/disconnected_transactions.cpp
+++ b/src/kernel/disconnected_transactions.cpp
@@ -8,10 +8,10 @@
 #include <core_memusage.h>
 #include <memusage.h>
 #include <primitives/transaction.h>
-#include <util/check.h>
 #include <util/hasher.h>
 
 #include <memory>
+#include <ranges>
 #include <utility>
 
 // It's almost certainly a logic bug if we don't clear out queuedTx before
@@ -50,11 +50,11 @@ size_t DisconnectedBlockTransactions::DynamicMemoryUsage() const
 [[nodiscard]] std::vector<CTransactionRef> DisconnectedBlockTransactions::AddTransactionsFromBlock(const std::vector<CTransactionRef>& vtx)
 {
     iters_by_txid.reserve(iters_by_txid.size() + vtx.size());
-    for (auto block_it = vtx.rbegin(); block_it != vtx.rend(); ++block_it) {
-        auto it = queuedTx.insert(queuedTx.end(), *block_it);
-        auto [_, inserted] = iters_by_txid.emplace((*block_it)->GetHash(), it);
-        Assert(inserted); // callers may never pass multiple transactions with the same txid
-        cachedInnerUsage += RecursiveDynamicUsage(*block_it);
+    for (auto& tx : vtx | std::views::reverse) {
+        if (auto [it, inserted]{iters_by_txid.try_emplace(tx->GetHash())}; inserted) {
+            it->second = queuedTx.insert(queuedTx.end(), tx);
+            cachedInnerUsage += RecursiveDynamicUsage(tx);
+        }
     }
     return LimitMemoryUsage();
 }

--- a/src/kernel/disconnected_transactions.h
+++ b/src/kernel/disconnected_transactions.h
@@ -58,9 +58,7 @@ public:
 
     /** Add transactions from the block, iterating through vtx in reverse order. Callers should call
      * this function for blocks in descending order by block height.
-     * We assume that callers never pass multiple transactions with the same txid, otherwise things
-     * can go very wrong in removeForBlock due to queuedTx containing an item without a
-     * corresponding entry in iters_by_txid.
+     * BIP30 duplicate coinbase txids are ignored.
      * @returns vector of transactions that were evicted for size-limiting.
      */
     [[nodiscard]] std::vector<CTransactionRef> AddTransactionsFromBlock(const std::vector<CTransactionRef>& vtx);

--- a/src/test/disconnected_transactions.cpp
+++ b/src/test/disconnected_transactions.cpp
@@ -6,23 +6,21 @@
 #include <core_memusage.h>
 #include <kernel/disconnected_transactions.h>
 #include <test/util/setup_common.h>
-#include <util/check.h>
 
 BOOST_AUTO_TEST_SUITE(disconnected_transactions)
 
 BOOST_AUTO_TEST_CASE(disconnectpool_duplicate_txids_across_blocks)
 {
-    test_only_CheckFailuresAreExceptionsNotAborts failed_asserts_throw{};
     DisconnectedBlockTransactions disconnectpool{MAX_DISCONNECTED_TX_POOL_BYTES};
     auto tx{MakeTransactionRef(CMutableTransaction{})};
 
     BOOST_CHECK(disconnectpool.AddTransactionsFromBlock({tx}).empty());
-    BOOST_CHECK_THROW((void)disconnectpool.AddTransactionsFromBlock({tx}).empty(), NonFatalCheckError); // TODO: Ignore txids already queued from another block.
-    BOOST_CHECK_EQUAL(disconnectpool.size(), 2); // TODO: Keep only the indexed transaction.
+    BOOST_CHECK(disconnectpool.AddTransactionsFromBlock({tx}).empty());
+    BOOST_CHECK_EQUAL(disconnectpool.size(), 1);
 
     disconnectpool.removeForBlock({tx});
-    BOOST_CHECK_EQUAL(disconnectpool.size(), 1); // TODO: Leave no unindexed duplicate behind.
-    BOOST_CHECK_EQUAL(disconnectpool.take().size(), 1); // TODO: Leave the pool empty after removal.
+    BOOST_CHECK_EQUAL(disconnectpool.size(), 0);
+    BOOST_CHECK_EQUAL(disconnectpool.take().size(), 0);
 }
 
 //! Tests that DisconnectedBlockTransactions limits its own memory properly

--- a/src/test/disconnected_transactions.cpp
+++ b/src/test/disconnected_transactions.cpp
@@ -6,8 +6,24 @@
 #include <core_memusage.h>
 #include <kernel/disconnected_transactions.h>
 #include <test/util/setup_common.h>
+#include <util/check.h>
 
 BOOST_AUTO_TEST_SUITE(disconnected_transactions)
+
+BOOST_AUTO_TEST_CASE(disconnectpool_duplicate_txids_across_blocks)
+{
+    test_only_CheckFailuresAreExceptionsNotAborts failed_asserts_throw{};
+    DisconnectedBlockTransactions disconnectpool{MAX_DISCONNECTED_TX_POOL_BYTES};
+    auto tx{MakeTransactionRef(CMutableTransaction{})};
+
+    BOOST_CHECK(disconnectpool.AddTransactionsFromBlock({tx}).empty());
+    BOOST_CHECK_THROW((void)disconnectpool.AddTransactionsFromBlock({tx}).empty(), NonFatalCheckError); // TODO: Ignore txids already queued from another block.
+    BOOST_CHECK_EQUAL(disconnectpool.size(), 2); // TODO: Keep only the indexed transaction.
+
+    disconnectpool.removeForBlock({tx});
+    BOOST_CHECK_EQUAL(disconnectpool.size(), 1); // TODO: Leave no unindexed duplicate behind.
+    BOOST_CHECK_EQUAL(disconnectpool.take().size(), 1); // TODO: Leave the pool empty after removal.
+}
 
 //! Tests that DisconnectedBlockTransactions limits its own memory properly
 BOOST_FIXTURE_TEST_CASE(disconnectpool_memory_limits, TestChain100Setup)

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -14,6 +14,7 @@ from test_framework.blocktools import (
     get_legacy_sigopcount_block,
     MAX_BLOCK_SIGOPS,
     REGTEST_N_BITS,
+    script_BIP34_coinbase_height,
 )
 from test_framework.messages import (
     CBlock,
@@ -83,7 +84,8 @@ class CBrokenBlock(CBlock):
         return super().serialize()
 
 
-DUPLICATE_COINBASE_SCRIPT_SIG = b'\x01\x78'  # Valid for block at height 120
+DUPLICATE_COINBASE_HEIGHT = 120
+DUPLICATE_COINBASE_SCRIPT_SIG = script_BIP34_coinbase_height(DUPLICATE_COINBASE_HEIGHT)
 
 
 class FullBlockTest(BitcoinTestFramework):
@@ -885,6 +887,14 @@ class FullBlockTest(BitcoinTestFramework):
         self.send_blocks([b_spend_dup_cb, b_dup_2], success=True)
         # The duplicate has less confirmations
         assert_equal(self.nodes[0].gettxout(txid=duplicate_tx.txid_hex, n=0)['confirmations'], 1)
+
+        self.log.info("Submit a genesis fork")
+        self.tip = None
+        fork_blocks = [self.next_block("fork" + str(h)) for h in range(1, DUPLICATE_COINBASE_HEIGHT + 2)]
+        self.send_blocks(fork_blocks[:-1], success=False)  # TODO: A stronger fork aborts on duplicate coinbase txids.
+        # Invalidate the base so no equal-work fork block remains
+        node.invalidateblock(fork_blocks[0].hash_hex)
+        assert_equal(node.getbestblockhash(), b_dup_2.hash_hex)
 
         # Test tx.isFinal is properly rejected (not an exhaustive tx.isFinal test, that should be in data-driven transaction tests)
         #

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -891,7 +891,7 @@ class FullBlockTest(BitcoinTestFramework):
         self.log.info("Submit a genesis fork")
         self.tip = None
         fork_blocks = [self.next_block("fork" + str(h)) for h in range(1, DUPLICATE_COINBASE_HEIGHT + 2)]
-        self.send_blocks(fork_blocks[:-1], success=False)  # TODO: A stronger fork aborts on duplicate coinbase txids.
+        self.send_blocks(fork_blocks, success=True)
         # Invalidate the base so no equal-work fork block remains
         node.invalidateblock(fork_blocks[0].hash_hex)
         assert_equal(node.getbestblockhash(), b_dup_2.hash_hex)


### PR DESCRIPTION
**Problem:** A reorg that disconnects BIP30 duplicate coinbases can crash a node.
`queuedTx` receives both transactions, while `iters_by_txid` keeps only the first txid entry.
#35793 would prevent the mainnet collision at height 1,983,702 on mainnet (in about 20 years), but custom chains with delayed BIP34 can trigger it now.

**Fix:** Insert the txid into `iters_by_txid` first, then append to `queuedTx` only when it is new.
This keeps the list, index, and cached memory usage synchronized when duplicate txids are encountered.