### PR TITLE
validation: compact chainstate after minimum chain work

### DIFF
--- a/doc/release-notes-35463.md
+++ b/doc/release-notes-35463.md
@@ -1,0 +1,7 @@
+Performance
+-----------
+
+- After a node connects its configured assumevalid block (the default value is
+  updated as part of each major release), Bitcoin Core now compacts the
+  chainstate LevelDB database. This may temporarily increase disk activity, but
+  can reduce chainstate disk usage after the initial sync completes.

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -301,6 +301,13 @@ void CDBWrapper::WriteBatch(CDBBatch& batch, bool fSync)
     }
 }
 
+std::optional<std::string> CDBWrapper::GetProperty(const std::string& property) const
+{
+    std::string value;
+    if (!DBContext().pdb->GetProperty(property, &value)) return std::nullopt;
+    return value;
+}
+
 size_t CDBWrapper::DynamicMemoryUsage() const
 {
     std::string memory;

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -256,7 +256,7 @@ CDBWrapper::CDBWrapper(const DBParams& params)
 
     if (params.options.force_compact) {
         LogInfo("Starting database compaction of %s", fs::PathToString(params.path));
-        DBContext().pdb->CompactRange(nullptr, nullptr);
+        CompactFull();
         LogInfo("Finished database compaction of %s", fs::PathToString(params.path));
     }
 
@@ -306,6 +306,11 @@ std::optional<std::string> CDBWrapper::GetProperty(const std::string& property) 
     std::string value;
     if (!DBContext().pdb->GetProperty(property, &value)) return std::nullopt;
     return value;
+}
+
+void CDBWrapper::CompactFull()
+{
+    DBContext().pdb->CompactRange(nullptr, nullptr);
 }
 
 size_t CDBWrapper::DynamicMemoryUsage() const

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -258,6 +258,9 @@ public:
 
     void WriteBatch(CDBBatch& batch, bool fSync = false);
 
+    //! Return a LevelDB property value, if available.
+    std::optional<std::string> GetProperty(const std::string& property) const;
+
     // Get an estimate of LevelDB memory usage (in bytes).
     size_t DynamicMemoryUsage() const;
 

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -258,6 +258,9 @@ public:
 
     void WriteBatch(CDBBatch& batch, bool fSync = false);
 
+    //! Perform a blocking full compaction of the underlying LevelDB.
+    void CompactFull();
+
     //! Return a LevelDB property value, if available.
     std::optional<std::string> GetProperty(const std::string& property) const;
 

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -1085,6 +1085,13 @@ BOOST_FIXTURE_TEST_CASE(coins_db_flush_baseline, FlushTest)
         BOOST_CHECK(*flushed_coin == coin);
         BOOST_CHECK_EQUAL(base.GetBestBlock(), block_hash);
     }
+
+    CCoinsViewDB compacted_base{{.path = path, .cache_bytes = 1_MiB, .options = {.force_compact = true}}, {}};
+    BOOST_CHECK_GE(level2_files(compacted_base), 1);
+    const auto compacted_coin{compacted_base.GetCoin(outpoint)};
+    BOOST_REQUIRE(compacted_coin);
+    BOOST_CHECK(*compacted_coin == coin);
+    BOOST_CHECK_EQUAL(compacted_base.GetBestBlock(), block_hash);
 }
 
 BOOST_AUTO_TEST_CASE(coins_resource_is_used)

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -14,6 +14,7 @@
 #include <uint256.h>
 #include <undo.h>
 #include <util/byte_units.h>
+#include <util/check.h>
 #include <util/strencodings.h>
 
 #include <map>
@@ -1057,6 +1058,32 @@ BOOST_FIXTURE_TEST_CASE(ccoins_flush_behavior, FlushTest)
     for (const auto& view : caches) {
         TestFlushBehavior(view.get(), base, caches, /*do_erasing_flush=*/false);
         TestFlushBehavior(view.get(), base, caches, /*do_erasing_flush=*/true);
+    }
+}
+
+BOOST_FIXTURE_TEST_CASE(coins_db_flush_baseline, FlushTest)
+{
+    const auto path{m_args.GetDataDirBase() / "coins_db_flush_baseline"};
+    auto level2_files{[](CCoinsViewDB& base) {
+        return *Assert(ToIntegral<int>(*Assert(base.GetDBProperty("leveldb.num-files-at-level2"))));
+    }};
+    const COutPoint outpoint{Txid::FromUint256(m_rng.rand256()), 0};
+    const Coin coin{MakeCoin()};
+    const uint256 block_hash{m_rng.rand256()};
+
+    {
+        CCoinsViewDB base{{.path = path, .cache_bytes = 1_MiB, .wipe_data = true}, {}};
+        CCoinsViewCache cache{&base};
+
+        cache.AddCoin(outpoint, Coin{coin}, /*possible_overwrite=*/false);
+        cache.SetBestBlock(block_hash);
+        cache.Flush();
+
+        BOOST_CHECK_EQUAL(level2_files(base), 0);
+        const auto flushed_coin{base.GetCoin(outpoint)};
+        BOOST_REQUIRE(flushed_coin);
+        BOOST_CHECK(*flushed_coin == coin);
+        BOOST_CHECK_EQUAL(base.GetBestBlock(), block_hash);
     }
 }
 

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -1079,19 +1079,15 @@ BOOST_FIXTURE_TEST_CASE(coins_db_flush_baseline, FlushTest)
         cache.SetBestBlock(block_hash);
         cache.Flush();
 
-        BOOST_CHECK_EQUAL(level2_files(base), 0);
+        const int files_before{level2_files(base)};
+        base.CompactFull();
+        BOOST_CHECK_EQUAL(files_before, 0);
+        BOOST_CHECK_GT(level2_files(base), files_before);
         const auto flushed_coin{base.GetCoin(outpoint)};
         BOOST_REQUIRE(flushed_coin);
         BOOST_CHECK(*flushed_coin == coin);
         BOOST_CHECK_EQUAL(base.GetBestBlock(), block_hash);
     }
-
-    CCoinsViewDB compacted_base{{.path = path, .cache_bytes = 1_MiB, .options = {.force_compact = true}}, {}};
-    BOOST_CHECK_GE(level2_files(compacted_base), 1);
-    const auto compacted_coin{compacted_base.GetCoin(outpoint)};
-    BOOST_REQUIRE(compacted_coin);
-    BOOST_CHECK(*compacted_coin == coin);
-    BOOST_CHECK_EQUAL(compacted_base.GetBestBlock(), block_hash);
 }
 
 BOOST_AUTO_TEST_CASE(coins_resource_is_used)

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -61,6 +61,7 @@ void CCoinsViewDB::ResizeCache(size_t new_cache_size)
     // We can't do this operation with an in-memory DB since we'll lose all the coins upon
     // reset.
     if (!m_db_params.memory_only) {
+        LOCK(m_db_mutex);
         // Have to do a reset first to get the original `m_db` state to release its
         // filesystem lock.
         m_db.reset();
@@ -173,6 +174,12 @@ void CCoinsViewDB::BatchWrite(CoinsViewCacheCursor& cursor, const uint256& block
 size_t CCoinsViewDB::EstimateSize() const
 {
     return m_db->EstimateSize(DB_COIN, uint8_t(DB_COIN + 1));
+}
+
+std::optional<std::string> CCoinsViewDB::GetDBProperty(const std::string& property)
+{
+    LOCK(m_db_mutex);
+    return m_db->GetProperty(property);
 }
 
 /** Specialization of CCoinsViewCursor to iterate over a CCoinsViewDB */

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -182,6 +182,16 @@ std::optional<std::string> CCoinsViewDB::GetDBProperty(const std::string& proper
     return m_db->GetProperty(property);
 }
 
+void CCoinsViewDB::CompactFull()
+{
+    AssertLockNotHeld(::cs_main);
+
+    LOCK(m_db_mutex);
+    LogInfo("Starting chainstate compaction of %s", fs::PathToString(m_db_params.path));
+    m_db->CompactFull();
+    LogInfo("Finished chainstate compaction of %s", fs::PathToString(m_db_params.path));
+}
+
 /** Specialization of CCoinsViewCursor to iterate over a CCoinsViewDB */
 class CCoinsViewDBCursor: public CCoinsViewCursor
 {

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <string>
 #include <vector>
 
 class COutPoint;
@@ -36,6 +37,8 @@ class CCoinsViewDB final : public CCoinsView
 protected:
     DBParams m_db_params;
     CoinsViewOptions m_options;
+    //! Prevents using m_db while ResizeCache() is replacing it.
+    Mutex m_db_mutex;
     std::unique_ptr<CDBWrapper> m_db;
 public:
     explicit CCoinsViewDB(DBParams db_params, CoinsViewOptions options);
@@ -53,7 +56,10 @@ public:
     size_t EstimateSize() const override;
 
     //! Dynamically alter the underlying leveldb cache size.
-    void ResizeCache(size_t new_cache_size) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    void ResizeCache(size_t new_cache_size) EXCLUSIVE_LOCKS_REQUIRED(cs_main, !m_db_mutex);
+
+    //! Return an underlying LevelDB property value, if available.
+    std::optional<std::string> GetDBProperty(const std::string& property) EXCLUSIVE_LOCKS_REQUIRED(!m_db_mutex);
 };
 
 #endif // BITCOIN_TXDB_H

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -58,6 +58,9 @@ public:
     //! Dynamically alter the underlying leveldb cache size.
     void ResizeCache(size_t new_cache_size) EXCLUSIVE_LOCKS_REQUIRED(cs_main, !m_db_mutex);
 
+    //! Perform a blocking full compaction of the underlying LevelDB.
+    void CompactFull() EXCLUSIVE_LOCKS_REQUIRED(!m_db_mutex) LOCKS_EXCLUDED(cs_main);
+
     //! Return an underlying LevelDB property value, if available.
     std::optional<std::string> GetDBProperty(const std::string& property) EXCLUSIVE_LOCKS_REQUIRED(!m_db_mutex);
 };

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -69,6 +69,7 @@
 #include <cassert>
 #include <chrono>
 #include <deque>
+#include <exception>
 #include <numeric>
 #include <optional>
 #include <ranges>
@@ -1935,6 +1936,34 @@ void Chainstate::InitCoinsCache(size_t cache_size_bytes)
     m_coins_views->InitCache();
 }
 
+void Chainstate::ScheduleChainstateCompaction()
+{
+    AssertLockNotHeld(::cs_main);
+
+    CCoinsViewDB* coins_db;
+    {
+        LOCK(::cs_main);
+        if (m_chainman.m_chainstates.size() != 1) return; // Skip assumeutxo.
+        Assert(this == &m_chainman.CurrentChainstate());
+        coins_db = &CoinsDB();
+    }
+
+    if (BlockValidationState state; !FlushStateToDisk(state, FlushStateMode::FORCE_FLUSH)) { // Ensure compaction reflects the latest chainstate.
+        LogWarning("Skipping chainstate compaction after failed force flush (%s)", state.ToString());
+        return;
+    }
+
+    if (m_chainman.m_options.signals) {
+        m_chainman.m_options.signals->CallFunctionInValidationInterfaceQueue([coins_db, &interrupt = m_chainman.m_interrupt] {
+            try {
+                if (!interrupt) coins_db->CompactFull();
+            } catch (const std::exception& e) {
+                LogWarning("Failed chainstate compaction (%s)", e.what());
+            }
+        });
+    }
+}
+
 // Lock-free: depends on `m_cached_is_ibd`, which is latched by `UpdateIBDStatus()`.
 bool ChainstateManager::IsInitialBlockDownload() const noexcept
 {
@@ -3338,6 +3367,7 @@ bool Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<
     CBlockIndex *pindexNewTip = nullptr;
     bool exited_ibd{false};
     do {
+        bool force_compaction{false};
         // Block until the validation queue drains. This should largely
         // never happen in normal operation, however may happen during
         // reindex, causing memory blowup if we run too far ahead.
@@ -3385,6 +3415,7 @@ bool Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<
                     pindexMostWork = nullptr;
                 }
                 pindexNewTip = m_chain.Tip();
+                force_compaction |= pindexNewTip->GetBlockHash() == m_chainman.AssumedValidBlock();
 
                 for (auto& [index, block] : std::move(connected_blocks)) {
                     if (m_chainman.m_options.signals) {
@@ -3451,6 +3482,8 @@ bool Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<
 
             reached_target = ReachedTarget();
         }
+
+        if (force_compaction) ScheduleChainstateCompaction();
 
         if (reached_target) {
             // Chainstate has reached the target block, so exit.

--- a/src/validation.h
+++ b/src/validation.h
@@ -741,6 +741,9 @@ public:
         FlushStateMode mode,
         int nManualPruneHeight = 0);
 
+    //! Flush and schedule a chainstate compaction.
+    void ScheduleChainstateCompaction() LOCKS_EXCLUDED(::cs_main);
+
     //! Flush all changes to disk.
     void ForceFlushStateToDisk(bool wipe_cache = true);
 

--- a/test/functional/feature_compactchainstate.py
+++ b/test/functional/feature_compactchainstate.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test chainstate compaction after connecting the assumevalid block."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+
+NODE_ARGS = ["-debug=coindb"]
+STALE_TIP_AGE = 25 * 60 * 60
+FORCE_FLUSH_MSG = "Writing chainstate to disk: flush mode=FORCE_FLUSH"
+IBD_EXIT_MSG = "Leaving InitialBlockDownload"
+COMPACTION_MSGS = [
+    "Starting chainstate compaction",
+    "Finished chainstate compaction",
+]
+COMPACTION_TRIGGER_MSGS = [FORCE_FLUSH_MSG, *COMPACTION_MSGS]
+
+
+class CompactChainstateTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+        self.extra_args = [NODE_ARGS.copy(), NODE_ARGS.copy()]
+
+    def setup_network(self):
+        self.add_nodes(self.num_nodes, self.extra_args)
+        self.start_node(0)
+
+    def run_test(self):
+        miner = self.nodes[0]
+        compact_node = self.nodes[1]
+
+        self.log.info("Mine the assumevalid target block")
+        blocks = self.generate(miner, 3, sync_fun=self.no_op)
+        assumed_valid_block = blocks[1]
+
+        self.log.info("Compact chainstate after connecting the assumevalid block")
+        self.start_node(1, extra_args=NODE_ARGS + [f"-assumevalid={assumed_valid_block}"])
+        assert_equal(compact_node.getblockchaininfo()["initialblockdownload"], True)
+        with compact_node.assert_debug_log(COMPACTION_TRIGGER_MSGS, timeout=30):
+            self.connect_nodes(0, 1)
+            self.sync_blocks([miner, compact_node])
+            compact_node.syncwithvalidationinterfacequeue()
+        assert_equal(compact_node.getbestblockhash(), miner.getbestblockhash())
+
+        self.log.info("Do not compact again after the assumevalid block has been connected")
+        with compact_node.assert_debug_log([], unexpected_msgs=[FORCE_FLUSH_MSG, *COMPACTION_MSGS]):
+            self.generate(compact_node, 1, sync_fun=self.no_op)
+            compact_node.syncwithvalidationinterfacequeue()
+
+        self.log.info("Do not compact again after a stale restart exits IBD")
+        tip_time = compact_node.getblock(compact_node.getbestblockhash())["time"]
+        self.restart_node(1, extra_args=NODE_ARGS + [f"-assumevalid={assumed_valid_block}", f"-mocktime={tip_time + STALE_TIP_AGE}"])
+        compact_node = self.nodes[1]
+        assert_equal(compact_node.getblockchaininfo()["initialblockdownload"], True)
+        with compact_node.assert_debug_log([IBD_EXIT_MSG], unexpected_msgs=[FORCE_FLUSH_MSG, *COMPACTION_MSGS], timeout=30):
+            self.generate(compact_node, 1, sync_fun=self.no_op)
+            compact_node.syncwithvalidationinterfacequeue()
+        assert_equal(compact_node.getblockchaininfo()["initialblockdownload"], False)
+
+
+if __name__ == "__main__":
+    CompactChainstateTest(__file__).main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -154,6 +154,7 @@ BASE_SCRIPTS = [
     'wallet_deprecated_rbf.py',
     'p2p_invalid_messages.py',
     'rpc_createmultisig.py',
+    'feature_compactchainstate.py',
     'p2p_timeouts.py --v1transport',
     'p2p_timeouts.py --v2transport',
     'rpc_signer.py',


### PR DESCRIPTION
**Problem:** [bitcoin-core/leveldb-subtree#61](https://github.com/bitcoin-core/leveldb-subtree/pull/61) disables read-triggered seek compactions because chainstate's random UTXO lookup workload can
make small upper-level LevelDB files repeatedly trigger large lower-level rewrites.
That removes a source of steady-state write amplification, but the same discussion notes that upper levels can stay fuller until size or manual compaction catches up.

**Fix:** Add a blocking full chainstate compaction path and queue it once when the active chain crosses the configured `MinimumChainWork()` threshold.
The default threshold is updated as part of each major release, so this gives newly synced or upgraded nodes one release-local cleanup point without recurring scheduled compactions or persistent
bookkeeping.
The compaction is queued after a force flush, runs outside validation locks, and is skipped when multiple chainstates are active.

**Benchmark evidence:** In an earlier IBD-triggered prototype, a `reindex-chainstate` run to height `950059` with `-dbcache=1000` on an i9-9900K SSD completed in `14989.055 s`.
After the queued compaction finished, the chainstate was `10823 MiB` across `339` files, with the LevelDB layout compacted into L5 (`level=5 files=335`).


-------

<img width="2384" height="740" alt="image" src="https://github.com/user-attachments/assets/df19f403-e5fe-425e-9a5a-fe4be9b6ea10" />


```
for DBCACHE in 1000; do   COMMITS="eab74f278d4735877af85cd8544c6971a8e9759d";   STOP=950059; CC=gcc; CXX=g++;   BASE_DIR="/mnt/my_storage"; DATA_DIR="$BASE_DIR/BitcoinData"; LOG_DIR="$BASE_DIR/logs";   mkdir -p "$LOG_DIR";   rm -f "$LOG_DIR"/chainstate-*.txt;   (echo ""; for c in $COMMITS; do git fetch -q origin "$c" 2>/dev/null || true; git log -1 --pretty='%h %s' "$c" || exit 1; done) &&   (echo "" && echo "$(date -I) | reindex-chainstate | ${STOP} blocks | dbcache ${DBCACHE} | $(hostname) | $(uname -m) | $(lscpu | grep 'Model name' | head -1 | cut -d: -f2 | xargs) | $(nproc) cores | $(free -h | awk '/^Mem:/{print $2}') RAM | $(lsblk -no ROTA $(df --output=source "$BASE_DIR" | tail -1) | grep -q 1 && echo HDD || echo SSD)"; echo "") &&   hyperfine     --sort command     --runs 1     --export-json "$BASE_DIR/rdx-$(sed -E 's/[^ ]+/\L&/g;s/[.]/_/g;s/ /-/g'<<<"$COMMITS")-$STOP-$DBCACHE-$CC.json"     --parameter-list COMMIT ${COMMITS// /,}     --prepare "killall -9 bitcoind 2>/dev/null; rm -f ./build/bin/bitcoind; git clean -fxd; git reset --hard {COMMIT} && \                                                                             
      cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release && ninja -C build bitcoind -j1 && \
      ./build/bin/bitcoind -datadir=$DATA_DIR -stopatheight=$STOP -dbcache=1000 -printtoconsole=0; sleep 20; rm -f $DATA_DIR/debug.log; rm -rfd $DATA_DIR/indexes;"     --conclude "killall bitcoind || true; sleep 5; \
      grep -q 'height=0' $DATA_DIR/debug.log && \
      grep -q 'Disabling script verification at block #1' $DATA_DIR/debug.log && \
      grep -q 'height=$STOP' $DATA_DIR/debug.log && \
      grep -q 'Leaving InitialBlockDownload' $DATA_DIR/debug.log && \
      grep 'Bitcoin Core version' $DATA_DIR/debug.log | grep -q \"\$(git rev-parse --short=12 {COMMIT})\" && \
      if [ \"{COMMIT}\" = \"3f80bfad47c8ac94ba17eb989d9a45567418685b\" ]; then grep -q 'Finished post-IBD chainstate database compaction' $DATA_DIR/debug.log; fi; \
      { echo \"{COMMIT} \$(du -sm $DATA_DIR/chainstate | cut -f1) MiB \$(find $DATA_DIR/chainstate -type f | wc -l | xargs) files\"; \
        grep -E 'Leaving InitialBlockDownload|Checking chainstate database compaction after leaving IBD|Starting post-IBD chainstate database compaction|Finished post-IBD chainstate database compaction' $DATA_DIR/debug.log || true; \
        grep -A30 'chainstate-leveldb-files level=0' $DATA_DIR/debug.log; \
      } > $LOG_DIR/chainstate-{COMMIT}.txt; \
      cp $DATA_DIR/debug.log $LOG_DIR/debug-{COMMIT}-\$(date +%s).log"     "COMPILER=$CC ./build/bin/bitcoind -datadir=$DATA_DIR -stopatheight=$STOP -maxtipage=315360000 -dbcache=$DBCACHE -reindex-chainstate -blocksonly -connect=0 -debug=coindb -printtoconsole=0";   echo ""; echo "chainstate usage by commit:"; cat "$LOG_DIR"/chainstate-*.txt; done

eab74f278d Flush and compact after IBD

2026-05-25 | reindex-chainstate | 950059 blocks | dbcache 1000 | i9-ssd | x86_64 | Intel(R) Core(TM) i9-9900K CPU @ 3.60GHz | 16 cores | 62Gi RAM | SSD

Benchmark 1: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=950059 -maxtipage=315360000 -dbcache=1000 -reindex-chainstate -blocksonly -connect=0 -debug=coindb -printtoconsole=0 (COMMIT = eab74f278d4735877af85cd8544c6971a8e9759d)
  Time (abs ≡):        14989.055 s               [User: 33840.307 s, System: 1278.824 s]
 

chainstate usage by commit:
eab74f278d4735877af85cd8544c6971a8e9759d 10823 MiB 339 files
2026-05-25T18:34:03Z Leaving InitialBlockDownload (latching to false)
2026-05-25T18:34:08Z chainstate-leveldb-files level=0 files=5
2026-05-25T18:34:08Z chainstate-leveldb-files level=1 files=1
2026-05-25T18:34:08Z chainstate-leveldb-files level=2 files=4
2026-05-25T18:34:08Z chainstate-leveldb-files level=3 files=45
2026-05-25T18:34:08Z chainstate-leveldb-files level=4 files=313
2026-05-25T18:34:08Z chainstate-leveldb-files level=5 files=126
2026-05-25T18:34:08Z chainstate-leveldb-files level=6 files=0
2026-05-25T18:34:08Z chainstate-leveldb-stats
                               Compactions
Level  Files Size(MB) Time(sec) Read(MB) Write(MB)
--------------------------------------------------
  0        5      164       494        0     76688
  1        1        7       644    76995     78841
  2        4       99      1135   156626    150880
  3       45      996      2591   339240    319261
  4      313     9987      1424   259176    221690
  5      126     3937         5     1007       875
2026-05-25T18:34:08Z Loading 0 mempool transactions from file...
2026-05-25T18:34:08Z Imported mempool transactions from file: 0 succeeded, 0 failed, 0 expired, 0 already there, 0 waiting for initial broadcast
2026-05-25T18:34:08Z initload thread exit
2026-05-25T18:37:07Z Finished scheduled chainstate database compaction of /mnt/my_storage/BitcoinData/chainstate
2026-05-25T18:37:07Z scheduler thread exit
2026-05-25T18:37:07Z [coindb] Writing chainstate to disk: flush mode=FORCE_FLUSH, prune=0, large=0, critical=0, periodic=0
2026-05-25T18:37:07Z [coindb] Writing final batch of 0.00 MiB
2026-05-25T18:37:07Z [coindb] Committed 0 changed transaction outputs (out of 0) to coin database...
2026-05-25T18:37:07Z [coindb] Writing chainstate to disk: flush mode=FORCE_FLUSH, prune=0, large=0, critical=0, periodic=0
2026-05-25T18:37:07Z [coindb] Writing final batch of 0.00 MiB
2026-05-25T18:37:07Z [coindb] Committed 0 changed transaction outputs (out of 0) to coin database...
2026-05-25T18:37:07Z inputfetch_pool_0 thread exit
2026-05-25T18:37:07Z inputfetch_pool_3 thread exit
2026-05-25T18:37:07Z inputfetch_pool_2 thread exit
--
2026-05-25T18:37:07Z chainstate-leveldb-files level=0 files=0
2026-05-25T18:37:07Z chainstate-leveldb-files level=1 files=0
2026-05-25T18:37:07Z chainstate-leveldb-files level=2 files=0
2026-05-25T18:37:07Z chainstate-leveldb-files level=3 files=0
2026-05-25T18:37:07Z chainstate-leveldb-files level=4 files=0
2026-05-25T18:37:07Z chainstate-leveldb-files level=5 files=335
2026-05-25T18:37:07Z chainstate-leveldb-files level=6 files=0
2026-05-25T18:37:07Z chainstate-leveldb-stats
                               Compactions
Level  Files Size(MB) Time(sec) Read(MB) Write(MB)
--------------------------------------------------
  0        0        0       495        0     76713
  1        0        0       646    77324     79163
  2        0        0      1137   156979    151214
  3        0        0      2604   340977    320932
  4        0        0      1499   271553    233006
  5      335    10818        87    18123     14747
2026-05-25T18:37:07Z Shutdown done
```