### PR TITLE
net: reject headers presync when clock trails chain start

### DIFF
--- a/src/headerssync.cpp
+++ b/src/headerssync.cpp
@@ -18,7 +18,8 @@ HeadersSyncState::HeadersSyncState(NodeId id,
                                    const Consensus::Params& consensus_params,
                                    const HeadersSyncParams& params,
                                    const CBlockIndex& chain_start,
-                                   const arith_uint256& minimum_required_work)
+                                   const arith_uint256& minimum_required_work,
+                                   NodeSeconds now)
     : m_commit_offset((assert(params.commitment_period > 0), // HeadersSyncParams field must be initialized to non-zero.
                        FastRandomContext().randrange(params.commitment_period))),
       m_id(id),
@@ -38,8 +39,7 @@ HeadersSyncState::HeadersSyncState(NodeId id,
     // exceeds this bound, because it's not possible for a consensus-valid
     // chain to be longer than this (at the current time -- in the future we
     // could try again, if necessary, to sync a longer chain).
-    const auto max_seconds_since_start{(Ticks<std::chrono::seconds>(NodeClock::now() - NodeSeconds{std::chrono::seconds{chain_start.GetMedianTimePast()}}))
-                                       + MAX_FUTURE_BLOCK_TIME};
+    const int64_t max_seconds_since_start{Ticks<std::chrono::seconds>(now - NodeSeconds{chain_start.GetMedianTimePast() * 1s}) + MAX_FUTURE_BLOCK_TIME};
     m_max_commitments = 6 * max_seconds_since_start / m_params.commitment_period;
 
     LogDebug(BCLog::NET, "Initial headers sync started with peer=%d: height=%i, max_commitments=%i, min_work=%s\n", m_id, m_current_height, m_max_commitments, m_minimum_required_work.ToString());

--- a/src/headerssync.cpp
+++ b/src/headerssync.cpp
@@ -40,6 +40,7 @@ HeadersSyncState::HeadersSyncState(NodeId id,
     // chain to be longer than this (at the current time -- in the future we
     // could try again, if necessary, to sync a longer chain).
     const int64_t max_seconds_since_start{Ticks<std::chrono::seconds>(now - NodeSeconds{chain_start.GetMedianTimePast() * 1s}) + MAX_FUTURE_BLOCK_TIME};
+    Assert(max_seconds_since_start >= 0);
     m_max_commitments = 6 * max_seconds_since_start / m_params.commitment_period;
 
     LogDebug(BCLog::NET, "Initial headers sync started with peer=%d: height=%i, max_commitments=%i, min_work=%s\n", m_id, m_current_height, m_max_commitments, m_minimum_required_work.ToString());

--- a/src/headerssync.h
+++ b/src/headerssync.h
@@ -13,6 +13,7 @@
 #include <uint256.h>
 #include <util/bitdeque.h>
 #include <util/hasher.h>
+#include <util/time.h>
 
 #include <deque>
 #include <vector>
@@ -135,10 +136,11 @@ public:
      * consensus_params: parameters needed for difficulty adjustment validation
      * chain_start: best known fork point that the peer's headers branch from
      * minimum_required_work: amount of chain work required to accept the chain
+     * now: local clock value used to bound possible headers commitments
      */
     HeadersSyncState(NodeId id, const Consensus::Params& consensus_params,
                      const HeadersSyncParams& params, const CBlockIndex& chain_start,
-                     const arith_uint256& minimum_required_work);
+                     const arith_uint256& minimum_required_work, NodeSeconds now);
 
     /** Result data structure for ProcessNextHeaders. */
     struct ProcessingResult {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -59,6 +59,7 @@
 #include <util/check.h>
 #include <util/strencodings.h>
 #include <util/time.h>
+#include <util/translation.h>
 #include <util/trace.h>
 #include <validation.h>
 
@@ -2789,6 +2790,11 @@ bool PeerManagerImpl::TryLowWorkHeadersSync(Peer& peer, CNode& pfrom, const CBlo
             // of headers is known, some header in this set must be new, so
             // advancing to the first unknown header would be a small effect.
             const auto now{Now<NodeSeconds>()};
+            if (now < NodeSeconds{(chain_start_header.GetMedianTimePast() - MAX_FUTURE_BLOCK_TIME) * 1s}) {
+                m_chainman.GetNotifications().fatalError(Untranslated("System clock too far behind chain start MTP."));
+                headers = {};
+                return true;
+            }
             LOCK(peer.m_headers_sync_mutex);
             peer.m_headers_sync.reset(new HeadersSyncState{peer.m_id, m_chainparams.GetConsensus(), m_chainparams.HeadersSync(), chain_start_header, minimum_chain_work, now});
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2788,9 +2788,9 @@ bool PeerManagerImpl::TryLowWorkHeadersSync(Peer& peer, CNode& pfrom, const CBlo
             // this logic in that case. So even if the first header in this set
             // of headers is known, some header in this set must be new, so
             // advancing to the first unknown header would be a small effect.
+            const auto now{Now<NodeSeconds>()};
             LOCK(peer.m_headers_sync_mutex);
-            peer.m_headers_sync.reset(new HeadersSyncState(peer.m_id, m_chainparams.GetConsensus(),
-                m_chainparams.HeadersSync(), chain_start_header, minimum_chain_work));
+            peer.m_headers_sync.reset(new HeadersSyncState{peer.m_id, m_chainparams.GetConsensus(), m_chainparams.HeadersSync(), chain_start_header, minimum_chain_work, now});
 
             // Now a HeadersSyncState object for tracking this synchronization
             // is created, process the headers using it as normal. Failures are

--- a/src/test/fuzz/headerssync.cpp
+++ b/src/test/fuzz/headerssync.cpp
@@ -45,8 +45,9 @@ class FuzzedHeadersSyncState : public HeadersSyncState
 {
 public:
     FuzzedHeadersSyncState(const HeadersSyncParams& sync_params, const size_t commit_offset,
-                           const CBlockIndex& chain_start, const arith_uint256& minimum_required_work)
-        : HeadersSyncState(/*id=*/0, Params().GetConsensus(), sync_params, chain_start, minimum_required_work)
+                           const CBlockIndex& chain_start, const arith_uint256& minimum_required_work,
+                           NodeSeconds now)
+        : HeadersSyncState{/*id=*/0, Params().GetConsensus(), sync_params, chain_start, minimum_required_work, now}
     {
         const_cast<size_t&>(m_commit_offset) = commit_offset;
     }
@@ -60,7 +61,8 @@ FUZZ_TARGET(headers_sync_state, .init = initialize_headers_sync_state_fuzz)
     CBlockHeader genesis_header{Params().GenesisBlock()};
     CBlockIndex start_index(genesis_header);
 
-    NodeClockContext clock_ctx{ConsumeTime(fuzzed_data_provider, /*min=*/start_index.GetMedianTimePast())};
+    const NodeSeconds now{ConsumeTime(fuzzed_data_provider, /*min=*/start_index.GetMedianTimePast())};
+    NodeClockContext clock_ctx{now};
 
     const uint256 genesis_hash = genesis_header.GetHash();
     start_index.phashBlock = &genesis_hash;
@@ -70,11 +72,12 @@ FUZZ_TARGET(headers_sync_state, .init = initialize_headers_sync_state_fuzz)
         .redownload_buffer_size = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, Params().HeadersSync().redownload_buffer_size * 2),
     };
     arith_uint256 min_work{UintToArith256(ConsumeUInt256(fuzzed_data_provider))};
-    FuzzedHeadersSyncState headers_sync(
+    FuzzedHeadersSyncState headers_sync{
         params,
         /*commit_offset=*/fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, params.commitment_period - 1),
         /*chain_start=*/start_index,
-        /*minimum_required_work=*/min_work);
+        /*minimum_required_work=*/min_work,
+        now};
 
     // Store headers for potential redownload phase.
     std::vector<CBlockHeader> all_headers;

--- a/src/test/headers_sync_chainwork_tests.cpp
+++ b/src/test/headers_sync_chainwork_tests.cpp
@@ -80,7 +80,7 @@ struct HeadersGeneratorSetup : public RegTestingSetup {
         return second_chain;
     }
 
-    HeadersSyncState CreateState()
+    HeadersSyncState CreateState(NodeSeconds now = Now<NodeSeconds>())
     {
         return {/*id=*/0,
                 Params().GetConsensus(),
@@ -89,7 +89,8 @@ struct HeadersGeneratorSetup : public RegTestingSetup {
                     .redownload_buffer_size = REDOWNLOAD_BUFFER_SIZE,
                 },
                 chain_start,
-                /*minimum_required_work=*/CHAIN_WORK};
+                /*minimum_required_work=*/CHAIN_WORK,
+                now};
     }
 
 private:

--- a/src/test/headers_sync_chainwork_tests.cpp
+++ b/src/test/headers_sync_chainwork_tests.cpp
@@ -11,6 +11,7 @@
 #include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
+#include <util/check.h>
 #include <validation.h>
 
 #include <cstddef>
@@ -256,16 +257,12 @@ BOOST_AUTO_TEST_CASE(too_little_work)
 
 BOOST_AUTO_TEST_CASE(system_clock_lagging_behind_chain_start)
 {
-    const NodeClockContext clock_ctx{(genesis.GetBlockTime() - MAX_FUTURE_BLOCK_TIME - 1) * 1s};
-    HeadersSyncState hss{CreateState()};
+    const test_only_CheckFailuresAreExceptionsNotAborts mock_checks{};
+    NodeClockContext clock_ctx{(genesis.GetBlockTime() - MAX_FUTURE_BLOCK_TIME) * 1s};
+    BOOST_CHECK_NO_THROW(CreateState());
 
-    // TODO: The chain-start MTP is already too far in the future for a locally
-    // acceptable extension, so headers presync should fail instead of requesting more.
-    CHECK_RESULT(hss.ProcessNextHeaders({{FirstChain().front()}}, /*full_headers_message=*/true),
-        hss, /*exp_state=*/State::PRESYNC,
-        /*exp_success=*/true, /*exp_request_more=*/true,
-        /*exp_headers_size=*/0, /*exp_pow_validated_prev=*/std::nullopt,
-        /*exp_locator_hash=*/FirstChain().front().GetHash());
+    clock_ctx -= 1s;
+    BOOST_CHECK_EXCEPTION(CreateState(), NonFatalCheckError, HasReason{"Internal bug detected: max_seconds_since_start >= 0"});
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/headers_sync_chainwork_tests.cpp
+++ b/src/test/headers_sync_chainwork_tests.cpp
@@ -10,6 +10,7 @@
 #include <pow.h>
 #include <test/util/common.h>
 #include <test/util/setup_common.h>
+#include <test/util/time.h>
 #include <validation.h>
 
 #include <cstddef>
@@ -250,6 +251,20 @@ BOOST_AUTO_TEST_CASE(too_little_work)
         /*exp_request_more=*/false,
         /*exp_headers_size=*/0, /*exp_pow_validated_prev=*/std::nullopt,
         /*exp_locator_hash=*/std::nullopt);
+}
+
+BOOST_AUTO_TEST_CASE(system_clock_lagging_behind_chain_start)
+{
+    const NodeClockContext clock_ctx{(genesis.GetBlockTime() - MAX_FUTURE_BLOCK_TIME - 1) * 1s};
+    HeadersSyncState hss{CreateState()};
+
+    // TODO: The chain-start MTP is already too far in the future for a locally
+    // acceptable extension, so headers presync should fail instead of requesting more.
+    CHECK_RESULT(hss.ProcessNextHeaders({{FirstChain().front()}}, /*full_headers_message=*/true),
+        hss, /*exp_state=*/State::PRESYNC,
+        /*exp_success=*/true, /*exp_request_more=*/true,
+        /*exp_headers_size=*/0, /*exp_pow_validated_prev=*/std::nullopt,
+        /*exp_locator_hash=*/FirstChain().front().GetHash());
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
**Problem:** Headers presync derives its commitment memory bound from the local node clock relative to the known chain-start MTP. If the local clock is more than `MAX_FUTURE_BLOCK_TIME` behind that chain-start MTP, the elapsed value becomes negative before it is used to derive `m_max_commitments`. This condition is relative to the known fork point, not genesis.

**Fix:** Reject low-work headers presync before constructing `HeadersSyncState` when the captured local clock is earlier than `chain_start_mtp - MAX_FUTURE_BLOCK_TIME`. The same captured `now` is passed into `HeadersSyncState`, where the derived non-negative bound remains asserted. The tests first characterize the existing behavior, then update it to pin the exact `MAX_FUTURE_BLOCK_TIME` boundary.