### PR TITLE
compressor: reject out-of-range decompressed amounts

### DIFF
--- a/src/coins.h
+++ b/src/coins.h
@@ -7,6 +7,7 @@
 #define BITCOIN_COINS_H
 
 #include <attributes.h>
+#include <consensus/amount.h>
 #include <compressor.h>
 #include <core_memusage.h>
 #include <memusage.h>
@@ -65,6 +66,7 @@ public:
         assert(!IsSpent());
         uint32_t code{(uint32_t{nHeight} << 1) | uint32_t{fCoinBase}};
         ::Serialize(s, VARINT(code));
+        Assume(MoneyRange(out.nValue));
         ::Serialize(s, Using<TxOutCompression>(out));
     }
 
@@ -75,6 +77,7 @@ public:
         nHeight = code >> 1;
         fCoinBase = code & 1;
         ::Unserialize(s, Using<TxOutCompression>(out));
+        Assume(MoneyRange(out.nValue));
     }
 
     /** Either this coin never existed (see e.g. coinEmpty in coins.cpp), or it

--- a/src/compressor.h
+++ b/src/compressor.h
@@ -6,11 +6,15 @@
 #ifndef BITCOIN_COMPRESSOR_H
 #define BITCOIN_COMPRESSOR_H
 
+#include <consensus/amount.h>
 #include <prevector.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
 #include <serialize.h>
 #include <span.h>
+#include <util/check.h>
+
+#include <ios>
 
 /**
  * This saves us from making many heap allocations when serializing
@@ -99,13 +103,19 @@ struct AmountCompression
 {
     template<typename Stream, typename I> void Ser(Stream& s, I val)
     {
+        Assert(MoneyRange(val));
         s << VARINT(CompressAmount(val));
     }
     template<typename Stream, typename I> void Unser(Stream& s, I& val)
     {
         uint64_t v;
         s >> VARINT(v);
-        val = DecompressAmount(v);
+        if (auto amount{DecompressAmount(v)}; amount <= MAX_MONEY) {
+            val = amount;
+            Assert(MoneyRange(val));
+        } else {
+            throw std::ios_base::failure("AmountCompression::Unser(): amount out of range");
+        }
     }
 };
 

--- a/src/test/compress_tests.cpp
+++ b/src/test/compress_tests.cpp
@@ -4,10 +4,13 @@
 
 #include <compressor.h>
 #include <script/script.h>
+#include <streams.h>
+#include <test/util/common.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 
 #include <cstdint>
+#include <limits>
 
 #include <boost/test/unit_test.hpp>
 
@@ -61,6 +64,32 @@ BOOST_AUTO_TEST_CASE(compress_amounts)
 
     for (uint64_t i = 0; i < 100000; i++)
         BOOST_CHECK(TestDecode(i));
+}
+
+BOOST_AUTO_TEST_CASE(compress_amount_serialization_range)
+{
+    CAmount amount;
+    {
+        // The largest valid amount still round-trips through the serializer.
+        DataStream stream{};
+        stream << Using<AmountCompression>(MAX_MONEY);
+        stream >> Using<AmountCompression>(amount);
+        BOOST_CHECK_EQUAL(amount, MAX_MONEY);
+    }
+    {
+        test_only_CheckFailuresAreExceptionsNotAborts mock_checks{};
+        for (const CAmount invalid_amount : {CAmount{-1}, MAX_MONEY + 1}) {
+            DataStream stream{};
+            BOOST_CHECK_EXCEPTION(stream << Using<AmountCompression>(invalid_amount), NonFatalCheckError, HasReason{"Internal bug detected: MoneyRange(val)"});
+        }
+    }
+    // Out-of-range amounts are rejected, both the smallest one and the maximal
+    // varint encoding (which wraps around during decompression).
+    for (const uint64_t encoded : {CompressAmount(MAX_MONEY + 1), std::numeric_limits<uint64_t>::max()}) {
+        DataStream stream{};
+        stream << VARINT(encoded);
+        BOOST_CHECK_THROW(stream >> Using<AmountCompression>(amount), std::ios_base::failure);
+    }
 }
 
 BOOST_AUTO_TEST_CASE(compress_script_to_ckey_id)

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -11,6 +11,7 @@
 #include <coins.h>
 #include <common/args.h>
 #include <compressor.h>
+#include <consensus/amount.h>
 #include <consensus/merkle.h>
 #include <key.h>
 #include <merkleblock.h>
@@ -232,14 +233,23 @@ FUZZ_TARGET_DESERIALIZE(blockheader_deserialize, {
 FUZZ_TARGET_DESERIALIZE(txundo_deserialize, {
     CTxUndo tu;
     DeserializeFromFuzzingInput(buffer, tu);
+    for (const auto& coin : tu.vprevout) {
+        assert(MoneyRange(coin.out.nValue));
+    }
 })
 FUZZ_TARGET_DESERIALIZE(blockundo_deserialize, {
     CBlockUndo bu;
     DeserializeFromFuzzingInput(buffer, bu);
+    for (const auto& tx_undo : bu.vtxundo) {
+        for (const auto& coin : tx_undo.vprevout) {
+            assert(MoneyRange(coin.out.nValue));
+        }
+    }
 })
 FUZZ_TARGET_DESERIALIZE(coins_deserialize, {
     Coin coin;
     DeserializeFromFuzzingInput(buffer, coin);
+    assert(MoneyRange(coin.out.nValue));
 })
 FUZZ_TARGET(netaddr_deserialize, .init = initialize_deserialize)
 {
@@ -313,6 +323,7 @@ FUZZ_TARGET_DESERIALIZE(txoutcompressor_deserialize, {
     CTxOut to;
     auto toc = Using<TxOutCompression>(to);
     DeserializeFromFuzzingInput(buffer, toc);
+    assert(MoneyRange(to.nValue));
 })
 FUZZ_TARGET_DESERIALIZE(blocktransactions_deserialize, {
     BlockTransactions bt;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5810,10 +5810,7 @@ util::Result<void> ChainstateManager::PopulateAndValidateSnapshot(
                     return util::Error{Untranslated(strprintf("Bad snapshot data after deserializing %d coins",
                               coins_count - coins_left))};
                 }
-                if (!MoneyRange(coin.out.nValue)) {
-                    return util::Error{Untranslated(strprintf("Bad snapshot data after deserializing %d coins - bad tx out value",
-                              coins_count - coins_left))};
-                }
+                Assert(MoneyRange(coin.out.nValue));
                 coins_cache.EmplaceCoinInternalDANGER(std::move(outpoint), std::move(coin));
 
                 --coins_left;

--- a/test/functional/feature_assumeutxo.py
+++ b/test/functional/feature_assumeutxo.py
@@ -152,7 +152,7 @@ class AssumeutxoTest(BitcoinTestFramework):
                 # txid + coins per txid + vout + coin height
                 32 + 1 + 1 + 2,
                 None,
-                "Bad snapshot data after deserializing 0 coins - bad tx out value"
+                "Bad snapshot format or truncated snapshot after deserializing 0 coins"
             ],  # Amount exceeds MAX_MONEY
         ]
 


### PR DESCRIPTION
**Problem:** Recent follow-ups have tightened tests around silent invariant gaps, including [#35481](https://github.com/bitcoin/bitcoin/pull/35481), which fixed a trivially passing fuzz round-trip assertion, and [#35456](https://github.com/bitcoin/bitcoin/pull/35456), where stronger `CAmount` checking exposed a test path accumulating past 21M BTC.

`AmountCompression::Unser()` still accepted any encoded amount and materialized the decompressed value as `CAmount` without enforcing `MoneyRange()`. Since `TxOutCompression` is used by serialized `Coin` entries, undo data and UTXO snapshots, malformed compressed data could produce amounts above `MAX_MONEY`, including values that become negative when converted from the unsigned decompression result to signed storage.

**Fix:** Enforce the range in `AmountCompression::Unser()` and throw `std::ios_base::failure` before callers receive an invalid amount. This makes the snapshot-only `MoneyRange()` check unreachable, so the snapshot test now expects the deserialization failure.

The tests cover the `MAX_MONEY` boundary, the smallest out-of-range compressed amount, the maximal varint encoding, and fuzz postconditions for `TxOutCompression`, `Coin`, `CTxUndo` and `CBlockUndo`.