### PR TITLE
build: guard forced inlining

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,6 +322,8 @@ if(WIN32)
 
     target_compile_definitions(core_interface INTERFACE
       _UNICODE;UNICODE
+      # Match GCC/Clang's size-optimization macro for the inline guard.
+      $<$<CONFIG:MinSizeRel>:__OPTIMIZE_SIZE__=1>
     )
     target_compile_options(core_interface INTERFACE
       /utf-8

--- a/src/attributes.h
+++ b/src/attributes.h
@@ -16,12 +16,16 @@
 #  define LIFETIMEBOUND
 #endif
 
-#if defined(__GNUC__)
-#  define ALWAYS_INLINE inline __attribute__((always_inline))
-#elif defined(_MSC_VER)
-#  define ALWAYS_INLINE __forceinline
-#else
-#  error No known always_inline attribute for this platform.
+#if !defined(_DEBUG) && !defined(__NO_INLINE__) && !defined(__OPTIMIZE_SIZE__)
+#  if (defined(__GNUC__) || defined(__clang__)) && defined(__OPTIMIZE__)
+#    define ALWAYS_INLINE inline __attribute__((always_inline))
+#  elif defined(_MSC_VER)
+#    define ALWAYS_INLINE __forceinline
+#  endif
+#endif
+
+#ifndef ALWAYS_INLINE
+#  define ALWAYS_INLINE inline
 #endif
 
 #endif // BITCOIN_ATTRIBUTES_H


### PR DESCRIPTION
`ALWAYS_INLINE` currently expands to compiler-specific force-inline spellings even when inlining is disabled, optimization is off, or size optimization is selected.

Keep the existing name, but use forced inlining only for optimized non-size builds and fall back to plain `inline` for debug, no-inline, size-optimized, and unknown compiler modes.

Define `__OPTIMIZE_SIZE__` for MSVC `MinSizeRel` builds so the source guard sees the same size-optimization signal that GCC and Clang expose.