### PR TITLE
coins: stretch periodic chainstate writes

### DIFF
--- a/src/test/chainstate_write_tests.cpp
+++ b/src/test/chainstate_write_tests.cpp
@@ -12,8 +12,8 @@
 using kernel::ChainstateRole;
 
 // Taken from validation.cpp
-static constexpr auto DATABASE_WRITE_INTERVAL_MIN{50min};
-static constexpr auto DATABASE_WRITE_INTERVAL_MAX{70min};
+static constexpr auto DATABASE_WRITE_INTERVAL_MIN{90min};
+static constexpr auto DATABASE_WRITE_INTERVAL_MAX{110min};
 
 BOOST_AUTO_TEST_SUITE(chainstate_write_tests)
 
@@ -38,7 +38,7 @@ BOOST_FIXTURE_TEST_CASE(chainstate_write_interval, TestingSetup)
     m_node.validation_signals->SyncWithValidationInterfaceQueue();
     BOOST_CHECK(!sub->m_did_flush);
 
-    // The periodic flush interval is between 50 and 70 minutes (inclusive)
+    // The periodic flush interval is ~100 minutes on average
     clock += DATABASE_WRITE_INTERVAL_MIN - 1min;
     chainstate.FlushStateToDisk(state_dummy, FlushStateMode::PERIODIC);
     m_node.validation_signals->SyncWithValidationInterfaceQueue();
@@ -86,7 +86,7 @@ BOOST_FIXTURE_TEST_CASE(write_during_multiblock_activation, TestChain100Setup)
     // Set m_next_write to current time
     chainstate.FlushStateToDisk(state_dummy, FlushStateMode::FORCE_FLUSH);
     m_node.validation_signals->SyncWithValidationInterfaceQueue();
-    // The periodic flush interval is between 50 and 70 minutes (inclusive)
+    // The periodic flush interval is ~100 minutes on average
     // The next call to a PERIODIC write will flush
     m_clock += DATABASE_WRITE_INTERVAL_MAX;
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -94,8 +94,8 @@ using node::SnapshotMetadata;
  *  Randomize writing time inside the window to prevent a situation where the
  *  network over time settles into a few cohorts of synchronized writers.
 */
-static constexpr auto DATABASE_WRITE_INTERVAL_MIN{50min};
-static constexpr auto DATABASE_WRITE_INTERVAL_MAX{70min};
+static constexpr auto DATABASE_WRITE_INTERVAL_MIN{90min};
+static constexpr auto DATABASE_WRITE_INTERVAL_MAX{110min};
 /** Maximum age of our tip for us to be considered current for fee estimation */
 static constexpr std::chrono::hours MAX_FEE_ESTIMATION_TIP_AGE{3};
 const std::vector<std::string> CHECKLEVEL_DOC {
@@ -116,7 +116,7 @@ static constexpr int PRUNE_LOCK_BUFFER{10};
 // Return whether the completed full flush should compact chainstate
 static bool ShouldCompactChainstate(bool in_ibd)
 {
-    static constexpr uint32_t flush_ratio{320}; // Roughly every 2 weeks with hourly flushes
+    static constexpr uint32_t flush_ratio{200}; // Roughly every 2 weeks with ~100 minute flushes; missing for ~200 days is a one-in-a-million event
     return !in_ibd && FastRandomContext().randrange(flush_ratio) == 0;
 }
 


### PR DESCRIPTION
**Problem:** Hourly chainstate writes slow down bigger `-dbcache` runs that should stay mostly in memory. With hourly writes, a max-dbcache HDD `-reindex-chainstate` benchmark in #32414 was 11% slower; a ~100-minute experiment cut that to 7%, and this change was almost 10% faster in a rpi5-8 pruned IBD benchmark.

Slow storage makes the cost visible: force-compacting a pruned chainstate took *13m31s* on an rpi4 SSD and *1h38m* on an rpi5 SD card. These are not normal periodic write times, but they show chainstate work can be expensive on slow storage.


<details><summary>forcecompactdb sizes and times</summary>

```bash
after IBD:
> 16G     ../ShallowBitcoinData/chainstate/
after force compaction:
> 11G     ../ShallowBitcoinData/chainstate/

> rpi5-8 @ SSD:
> build/bin/bitcoind -datadir=/mnt/my_storage/ShallowBitcoinData -forcecompactdb -stopatheight=1 -prune=10000
2026-06-24T22:25:55Z Starting database compaction of /mnt/my_storage/ShallowBitcoinData/chainstate
2026-06-24T22:30:49Z Finished database compaction of /mnt/my_storage/ShallowBitcoinData/chainstate

> rpi4-2-1 @ SSD (b28cf409a13b893787c4c95b1ba975ac5f5b6254)
> build/bin/bitcoind -datadir=/mnt/my_storage/ShallowBitcoinData -forcecompactdb -stopatheight=1 -prune=10000
2026-06-25T03:47:56Z Starting database compaction of /mnt/my_storage/ShallowBitcoinData/chainstate
2026-06-25T04:01:27Z Finished database compaction of /mnt/my_storage/ShallowBitcoinData/chainstate

> rpi5-4 @ SD card (0637a1cc6f2b2f28d4ab5d97aaf8a91ec436fc8f)
> build/bin/bitcoind -datadir=/mnt/my_storage/ShallowBitcoinData -forcecompactdb -stopatheight=1 -prune=10000
2026-06-25T17:04:41Z Starting database compaction of /mnt/my_storage/ShallowBitcoinData/chainstate
2026-06-25T18:43:08Z Finished database compaction of /mnt/my_storage/ShallowBitcoinData/chainstate

> Apple M4 Max @ SSD
build/bin/bitcoind -forcecompactdb -stopatheight=1
2026-06-24T23:12:50Z Starting database compaction of /Users/lorinc/Library/Application Support/Bitcoin/chainstate
2026-06-24T23:14:47Z Finished database compaction of /Users/lorinc/Library/Application Support/Bitcoin/chainstate
```
</details>


**Fix:** Increase the randomized write window from 50-70 minutes to 90-110 minutes, averaging about 100 minutes or 10 blocks in steady state.

Since #35465 tuned the random compaction chance for hourly writes, update it from `1/320` to `1/200`. With ~100-minute writes, compaction still averages about every two weeks, and a roughly 200-day stretch without compaction remains a one-in-a-million event.

**Benchmark:**
<details><summary>2026-06-26 | reindex-chainstate | 954459 blocks | dbcache 10000 | i7-hdd | x86_64 | Intel(R) Core(TM) i7-7700 CPU @ 3.60GHz | 8 threads | 62Gi RAM | HDD</summary>

```bash
for DBCACHE in 10000; do \                                                                                                                                                                                                                                                        
    COMMITS="93012d7ff918eef41adf453bf10ddb4da21f3df4 e93a55db5a7daa1d3bdeec858822d39202f04131"; \
    STOP=954459; CC=gcc; CXX=g++; \
    BASE_DIR="/mnt/my_storage"; DATA_DIR="$BASE_DIR/BitcoinData"; LOG_DIR="$BASE_DIR/logs"; \
    (echo ""; for c in $COMMITS; do git fetch -q origin "$c" 2>/dev/null || true; git log -1 --pretty='%h %s' "$c" || exit 1; done) && \
    (echo "" && echo "$(date -I) | reindex-chainstate | ${STOP} blocks | dbcache ${DBCACHE} | $(hostname) | $(uname -m) | $(lscpu | grep 'Model name' | head -1 | cut -d: -f2 | xargs) | $(nproc) threads | $(free -h | awk '/^Mem:/{print $2}') RAM | $(lsblk -no ROTA $(df --output=source $BASE_DIR | tail -1) | grep -q 1 && echo HDD || echo SSD)"; echo "") && \
    hyperfine \
    --sort command \
    --runs 1 \
    --export-json "$BASE_DIR/rdx-$(sed -E 's/([a-f0-9]{8})[a-f0-9]* ?/\1-/g;s/-$//'<<<"$COMMITS")-$STOP-$DBCACHE-$CC.json" \
    --parameter-list COMMIT ${COMMITS// /,} \
    --prepare "killall -9 bitcoind 2>/dev/null; rm -f ./build/bin/bitcoind; git clean -fxd; git reset --hard {COMMIT} && \
      CC=$CC CXX=$CXX cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release && ninja -C build bitcoind -j1 && \
        ./build/bin/bitcoind -datadir=$DATA_DIR -stopatheight=$STOP -printtoconsole=0 && sleep 20 && rm -f $DATA_DIR/debug.log && rm -rfd $DATA_DIR/indexes" \
      --conclude "killall bitcoind || true; sleep 5; \
        grep -q 'height=0' $DATA_DIR/debug.log && \
        grep -q 'Disabling script verification at block #1' $DATA_DIR/debug.log && \
        grep -q 'height=$STOP' $DATA_DIR/debug.log && \
        grep 'Bitcoin Core version' $DATA_DIR/debug.log | grep -q \"\$(git rev-parse --short=12 {COMMIT})\" && \
        cp $DATA_DIR/debug.log $LOG_DIR/debug-{COMMIT}-\$(date +%s).log" \
    "COMPILER=$CC ./build/bin/bitcoind -datadir=$DATA_DIR -stopatheight=$STOP -dbcache=$DBCACHE -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0"; \
done

93012d7ff9 Merge bitcoin/bitcoin#35601: wallet: remove experimental warning from send and sendall
e93a55db5a validation: use 100-minute chainstate writes

2026-06-26 | reindex-chainstate | 954459 blocks | dbcache 10000 | i7-hdd | x86_64 | Intel(R) Core(TM) i7-7700 CPU @ 3.60GHz | 8 threads | 62Gi RAM | HDD

Benchmark 1: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=10000 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = 93012d7ff918eef41adf453bf10ddb4da
  Time (abs ≡):        29895.588 s               [User: 31526.941 s, System: 855.744 s]
 
Benchmark 2: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=10000 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = e93a55db5a7daa1d3bdeec858822d39202f04131)
  Time (abs ≡):        28591.829 s               [User: 31145.347 s, System: 809.118 s]
 
Relative speed comparison
        1.05          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=10000 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = 93012d7ff918eef41adf453bf10ddb4da21f3df4)
        1.00          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=10000 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = e93a55db5a7daa1d3bdeec858822d39202f04131)
```

</details>
