### PR TITLE
 index: shrink txospenderindex value markers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -469,6 +469,12 @@ jobs:
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_freebsd_cross.sh'
 
+          - name: 'OpenBSD Cross'
+            warp-runner: 'warp-ubuntu-latest-x64-8x'
+            fallback-runner: 'ubuntu-latest'
+            timeout-minutes: 120
+            file-env: './ci/test/00_setup_env_openbsd_cross.sh'
+
           - name: 'No wallet'
             warp-runner: 'warp-ubuntu-latest-x64-4x'
             fallback-runner: 'ubuntu-latest'

--- a/ci/test/00_setup_env_openbsd_cross.sh
+++ b/ci/test/00_setup_env_openbsd_cross.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit.
+
+export LC_ALL=C.UTF-8
+
+export CONTAINER_NAME=ci_openbsd_cross
+export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:26.04"
+export APT_LLVM_V="22"
+export HOST=x86_64-unknown-openbsd
+export OPENBSD_VERSION=7.9
+export OPENBSD_SDK_BASENAME="openbsd-${HOST}-${OPENBSD_VERSION}"
+export PACKAGES="clang-${APT_LLVM_V} llvm-${APT_LLVM_V} lld"
+export SYSROOT="--sysroot=${DEPENDS_DIR}/SDKs/${OPENBSD_SDK_BASENAME}"
+export DEP_OPTS="build_CC=clang build_CXX=clang++ \
+ CC='clang --target=${HOST} ${SYSROOT}' \
+ CXX='clang++ --target=${HOST} ${SYSROOT} -stdlib=libc++' \
+ LDFLAGS='-fuse-ld=lld' \
+ AR=llvm-ar-${APT_LLVM_V} \
+ NM=llvm-nm-${APT_LLVM_V} \
+ OBJCOPY=llvm-objcopy-${APT_LLVM_V} \
+ OBJDUMP=llvm-objdump-${APT_LLVM_V} \
+ RANLIB=llvm-ranlib-${APT_LLVM_V} \
+ STRIP=llvm-strip-${APT_LLVM_V}"
+export GOAL="install"
+export BITCOIN_CONFIG="\
+ --preset=dev-mode \
+ -DBUILD_GUI=OFF \
+ -DREDUCE_EXPORTS=ON \
+ -DWITH_USDT=OFF \
+"
+export RUN_UNIT_TESTS="false"
+export RUN_FUNCTIONAL_TESTS="false"

--- a/ci/test/01_base_install.sh
+++ b/ci/test/01_base_install.sh
@@ -122,4 +122,23 @@ if [ -n "$FREEBSD_VERSION" ] && [ ! -d "${DEPENDS_DIR}/SDKs/${FREEBSD_SDK_BASENA
   tar -C "${DEPENDS_DIR}/SDKs/${FREEBSD_SDK_BASENAME}" -xf "$FREEBSD_SDK_PATH"
 fi
 
+if [ -n "$OPENBSD_VERSION" ] && [ ! -d "${DEPENDS_DIR}/SDKs/${OPENBSD_SDK_BASENAME}" ]; then
+  mkdir -p "${DEPENDS_DIR}/SDKs/${OPENBSD_SDK_BASENAME}"
+  for OPENBSD_SDK_FILENAME in base79.tgz comp79.tgz; do
+    OPENBSD_SDK_PATH="${DEPENDS_DIR}/sdk-sources/${OPENBSD_SDK_FILENAME}"
+    if [ ! -f "$OPENBSD_SDK_PATH" ]; then
+      ${CI_RETRY_EXE} curl --location --fail "https://cdn.openbsd.org/pub/OpenBSD/${OPENBSD_VERSION}/amd64/${OPENBSD_SDK_FILENAME}" -o "$OPENBSD_SDK_PATH"
+    fi
+    tar -C "${DEPENDS_DIR}/SDKs/${OPENBSD_SDK_BASENAME}" -xf "$OPENBSD_SDK_PATH"
+    (
+      # The SDK has versioned shared libs, but no unversioned libfoo.so symlink,
+      # which breaks linking the kernel with lld. Create the symlinks.
+      cd "${DEPENDS_DIR}/SDKs/${OPENBSD_SDK_BASENAME}/usr/lib"
+      ln -sf libc++abi.so.*.*  libc++abi.so
+      ln -sf libc++.so.*.*     libc++.so
+      ln -sf libpthread.so.*.* libpthread.so
+    )
+  done
+fi
+
 echo -n "done" > "${CFG_DONE}"

--- a/depends/hosts/openbsd.mk
+++ b/depends/hosts/openbsd.mk
@@ -1,5 +1,6 @@
 openbsd_CFLAGS=
 openbsd_CXXFLAGS=
+openbsd_LDFLAGS=
 
 openbsd_release_CFLAGS=-O2
 openbsd_release_CXXFLAGS=$(openbsd_release_CFLAGS)

--- a/doc/release-notes-35634.md
+++ b/doc/release-notes-35634.md
@@ -1,0 +1,9 @@
+Indexes
+-------
+
+- The transaction output spender index (`-txospenderindex`) now stores one byte
+  less per spender entry for newly indexed blocks. Existing indexes remain
+  compatible and no action is required. To apply the same saving to entries
+  indexed before upgrading, stop the node, delete the
+  `<datadir>/indexes/txospenderindex/` directory, and restart with
+  `-txospenderindex` enabled to rebuild it.

--- a/src/bench/nanobench.h
+++ b/src/bench/nanobench.h
@@ -2654,9 +2654,9 @@ private:
     std::map<uint64_t, Target> mIdToTarget{};
 
     // start with minimum size of 3 for read_format
-    std::vector<uint64_t> mCounters{3};
-    std::vector<uint64_t> mCalibratedOverhead{3};
-    std::vector<uint64_t> mLoopOverhead{3};
+    std::vector<uint64_t> mCounters = std::vector<uint64_t>(3);
+    std::vector<uint64_t> mCalibratedOverhead = std::vector<uint64_t>(3);
+    std::vector<uint64_t> mLoopOverhead = std::vector<uint64_t>(3);
 
     uint64_t mTimeEnabledNanos = 0;
     uint64_t mTimeRunningNanos = 0;

--- a/src/index/txospenderindex.cpp
+++ b/src/index/txospenderindex.cpp
@@ -23,14 +23,16 @@
 #include <util/fs.h>
 #include <validation.h>
 
+#include <cstddef>
 #include <cstdio>
 #include <exception>
+#include <span>
 #include <string>
 #include <utility>
 #include <vector>
 
 /* The database is used to find the spending transaction of a given utxo.
- * For every input of every transaction it stores a key that is a pair(siphash(input outpoint), transaction location on disk) and an empty value.
+ * For every input of every transaction it stores a key that is a pair(siphash(input outpoint), transaction location on disk) and a zero-byte value.
  * To find the spending transaction of an outpoint, we perform a range query on siphash(outpoint), and for each returned key load the transaction
  * and return it if it does spend the provided outpoint.
  */
@@ -73,8 +75,9 @@ void TxoSpenderIndex::WriteSpenderInfos(const std::vector<std::pair<COutPoint, C
     CDBBatch batch(*m_db);
     for (const auto& [outpoint, pos] : items) {
         txospenderindex::DBKey key(txospenderindex::CreateKey(m_siphash_key, outpoint, pos));
-        // key is hash(spent outpoint) | disk pos, value is empty
-        batch.Write(key, "");
+        // The key encodes the spent outpoint hash and disk position. The value is only a marker.
+        // Older entries may contain serialized empty strings; FindSpender() reads only keys.
+        batch.Write(key, std::span<const std::byte>{});
     }
     m_db->WriteBatch(batch);
 }

--- a/src/index/txospenderindex.cpp
+++ b/src/index/txospenderindex.cpp
@@ -25,7 +25,6 @@
 
 #include <cstdio>
 #include <exception>
-#include <ios>
 #include <string>
 #include <utility>
 #include <vector>
@@ -36,28 +35,7 @@
  * and return it if it does spend the provided outpoint.
  */
 
-// LevelDB key prefix. We only have one key for now but it will make it easier to add others if needed.
-constexpr uint8_t DB_TXOSPENDERINDEX{'s'};
-
 std::unique_ptr<TxoSpenderIndex> g_txospenderindex;
-
-struct DBKey {
-    uint64_t hash;
-    CDiskTxPos pos;
-
-    explicit DBKey(const uint64_t& hash_in, const CDiskTxPos& pos_in) : hash(hash_in), pos(pos_in) {}
-
-    SERIALIZE_METHODS(DBKey, obj)
-    {
-        uint8_t prefix{DB_TXOSPENDERINDEX};
-        READWRITE(prefix);
-        if (prefix != DB_TXOSPENDERINDEX) {
-            throw std::ios_base::failure("Invalid format for spender index DB key");
-        }
-        READWRITE(obj.hash);
-        READWRITE(obj.pos);
-    }
-};
 
 TxoSpenderIndex::TxoSpenderIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory, bool f_wipe)
     : BaseIndex(std::move(chain), "txospenderindex", "txospenderidx"), m_db{std::make_unique<DB>(gArgs.GetDataDirNet() / "indexes" / "txospenderindex" / "db", n_cache_size, f_memory, f_wipe)}
@@ -81,16 +59,20 @@ static uint64_t CreateKeyPrefix(std::pair<uint64_t, uint64_t> siphash_key, const
     return PresaltedSipHasher(siphash_key.first, siphash_key.second)(vout.hash.ToUint256(), vout.n);
 }
 
-static DBKey CreateKey(std::pair<uint64_t, uint64_t> siphash_key, const COutPoint& vout, const CDiskTxPos& pos)
+namespace txospenderindex {
+
+DBKey CreateKey(std::pair<uint64_t, uint64_t> siphash_key, const COutPoint& vout, const CDiskTxPos& pos)
 {
     return DBKey(CreateKeyPrefix(siphash_key, vout), pos);
 }
+
+} // namespace txospenderindex
 
 void TxoSpenderIndex::WriteSpenderInfos(const std::vector<std::pair<COutPoint, CDiskTxPos>>& items)
 {
     CDBBatch batch(*m_db);
     for (const auto& [outpoint, pos] : items) {
-        DBKey key(CreateKey(m_siphash_key, outpoint, pos));
+        txospenderindex::DBKey key(txospenderindex::CreateKey(m_siphash_key, outpoint, pos));
         // key is hash(spent outpoint) | disk pos, value is empty
         batch.Write(key, "");
     }
@@ -102,12 +84,14 @@ void TxoSpenderIndex::EraseSpenderInfos(const std::vector<std::pair<COutPoint, C
 {
     CDBBatch batch(*m_db);
     for (const auto& [outpoint, pos] : items) {
-        batch.Erase(CreateKey(m_siphash_key, outpoint, pos));
+        batch.Erase(txospenderindex::CreateKey(m_siphash_key, outpoint, pos));
     }
     m_db->WriteBatch(batch);
 }
 
-static std::vector<std::pair<COutPoint, CDiskTxPos>> BuildSpenderPositions(const interfaces::BlockInfo& block)
+namespace txospenderindex {
+
+std::vector<std::pair<COutPoint, CDiskTxPos>> BuildSpenderPositions(const interfaces::BlockInfo& block)
 {
     std::vector<std::pair<COutPoint, CDiskTxPos>> items;
     items.reserve(block.data->vtx.size());
@@ -125,16 +109,17 @@ static std::vector<std::pair<COutPoint, CDiskTxPos>> BuildSpenderPositions(const
     return items;
 }
 
+} // namespace txospenderindex
 
 bool TxoSpenderIndex::CustomAppend(const interfaces::BlockInfo& block)
 {
-    WriteSpenderInfos(BuildSpenderPositions(block));
+    WriteSpenderInfos(txospenderindex::BuildSpenderPositions(block));
     return true;
 }
 
 bool TxoSpenderIndex::CustomRemove(const interfaces::BlockInfo& block)
 {
-    EraseSpenderInfos(BuildSpenderPositions(block));
+    EraseSpenderInfos(txospenderindex::BuildSpenderPositions(block));
     return true;
 }
 
@@ -161,11 +146,11 @@ util::Expected<std::optional<TxoSpender>, std::string> TxoSpenderIndex::FindSpen
 {
     const uint64_t prefix{CreateKeyPrefix(m_siphash_key, txo)};
     std::unique_ptr<CDBIterator> it(m_db->NewIterator());
-    DBKey key(prefix, CDiskTxPos());
+    txospenderindex::DBKey key(prefix, CDiskTxPos());
 
     // find all keys that start with the outpoint hash, load the transaction at the location specified in the key
     // and return it if it does spend the provided outpoint
-    for (it->Seek(std::pair{DB_TXOSPENDERINDEX, prefix}); it->Valid() && it->GetKey(key) && key.hash == prefix; it->Next()) {
+    for (it->Seek(std::pair{txospenderindex::DBKey::PREFIX, prefix}); it->Valid() && it->GetKey(key) && key.hash == prefix; it->Next()) {
         if (const auto spender{ReadTransaction(key.pos)}) {
             for (const auto& input : spender->tx->vin) {
                 if (input.prevout == txo) {

--- a/src/index/txospenderindex.h
+++ b/src/index/txospenderindex.h
@@ -6,20 +6,21 @@
 #define BITCOIN_INDEX_TXOSPENDERINDEX_H
 
 #include <index/base.h>
+#include <index/disktxpos.h>
 #include <interfaces/chain.h>
 #include <primitives/transaction.h>
+#include <serialize.h>
 #include <uint256.h>
 #include <util/expected.h>
 
 #include <cstddef>
 #include <cstdint>
+#include <ios>
 #include <memory>
 #include <optional>
 #include <string>
 #include <utility>
 #include <vector>
-
-struct CDiskTxPos;
 
 static constexpr bool DEFAULT_TXOSPENDERINDEX{false};
 
@@ -27,6 +28,34 @@ struct TxoSpender {
     CTransactionRef tx;
     uint256 block_hash;
 };
+
+namespace txospenderindex {
+
+struct DBKey {
+public:
+    static constexpr uint8_t PREFIX{'s'};
+
+    uint64_t hash;
+    CDiskTxPos pos;
+
+    explicit DBKey(const uint64_t& hash_in, const CDiskTxPos& pos_in) : hash(hash_in), pos(pos_in) {}
+
+    SERIALIZE_METHODS(DBKey, obj)
+    {
+        uint8_t prefix{PREFIX};
+        READWRITE(prefix);
+        if (prefix != PREFIX) {
+            throw std::ios_base::failure("Invalid format for spender index DB key");
+        }
+        READWRITE(obj.hash);
+        READWRITE(obj.pos);
+    }
+};
+
+DBKey CreateKey(std::pair<uint64_t, uint64_t> siphash_key, const COutPoint& vout, const CDiskTxPos& pos);
+std::vector<std::pair<COutPoint, CDiskTxPos>> BuildSpenderPositions(const interfaces::BlockInfo& block);
+
+} // namespace txospenderindex
 
 /**
  * TxoSpenderIndex is used to look up which transaction spent a given output.

--- a/src/test/txospenderindex_tests.cpp
+++ b/src/test/txospenderindex_tests.cpp
@@ -3,10 +3,16 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <index/txospenderindex.h>
+#include <dbwrapper.h>
+#include <kernel/chain.h>
 #include <test/util/common.h>
 #include <test/util/setup_common.h>
+#include <util/byte_units.h>
+#include <util/check.h>
 #include <validation.h>
 
+#include <cstddef>
+#include <span>
 #include <utility>
 
 #include <boost/test/unit_test.hpp>
@@ -93,6 +99,35 @@ BOOST_FIXTURE_TEST_CASE(txospenderindex_initial_sync, TxoSpenderIndexTestSetup)
 
     // Shutdown sequence (c.f. Shutdown() in init.cpp)
     txospenderindex.Stop();
+}
+
+BOOST_FIXTURE_TEST_CASE(txospenderindex_value_markers, TxoSpenderIndexTestSetup)
+{
+    const auto [block, tip_hash, tip, spent, spender]{CreateSpenderBlock(2)};
+    const auto entries{txospenderindex::BuildSpenderPositions(kernel::MakeBlockInfo(tip, &block))};
+    BOOST_REQUIRE_EQUAL(entries.size(), 2U);
+
+    {
+        constexpr std::pair<uint64_t, uint64_t> siphash_key{1, 2};
+        CDBWrapper dbw({.path = m_args.GetDataDirNet() / "indexes" / "txospenderindex" / "db", .cache_bytes = 1_MiB});
+        dbw.Write("siphash_key", siphash_key);
+        CDBBatch batch(dbw);
+        batch.Write(txospenderindex::CreateKey(siphash_key, entries[0].first, entries[0].second), ""); // Old value format
+        batch.Write(txospenderindex::CreateKey(siphash_key, entries[1].first, entries[1].second), std::span<const std::byte>{}); // New value format
+        dbw.WriteBatch(batch);
+    }
+
+    TxoSpenderIndex index(interfaces::MakeChain(m_node), 1_MiB);
+    BOOST_REQUIRE(index.Init());
+
+    for (size_t i{0}; i < spent.size(); ++i) {
+        const auto tx_spender{index.FindSpender(spent[i])};
+        const auto& [tx, block_hash]{*Assert(*Assert(tx_spender))};
+        BOOST_CHECK_EQUAL(tx->GetHash(), spender[i].GetHash());
+        BOOST_CHECK_EQUAL(block_hash, tip_hash);
+    }
+
+    index.Stop();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/txospenderindex_tests.cpp
+++ b/src/test/txospenderindex_tests.cpp
@@ -7,46 +7,67 @@
 #include <test/util/setup_common.h>
 #include <validation.h>
 
+#include <utility>
+
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE(txospenderindex_tests)
 
-BOOST_FIXTURE_TEST_CASE(txospenderindex_initial_sync, TestChain100Setup)
-{
-    // Setup phase:
-    // Mine blocks for coinbase maturity, so we can spend some coinbase outputs in the test.
-    const CScript& coinbase_script = m_coinbase_txns[0]->vout[0].scriptPubKey;
-    for (int i = 0; i < 10; i++) CreateAndProcessBlock({}, coinbase_script);
+struct TxoSpenderIndexTestSetup : public TestChain100Setup {
+    struct SpenderBlock {
+        CBlock block;
+        uint256 tip_hash;
+        const CBlockIndex* tip;
+        std::vector<COutPoint> spent;
+        std::vector<CMutableTransaction> spender;
+    };
 
-    // Spend 10 outputs
-    std::vector<COutPoint> spent(10);
-    std::vector<CMutableTransaction> spender(spent.size());
-    for (size_t i = 0; i < spent.size(); i++) {
-        // Outpoint
-        auto coinbase_tx = m_coinbase_txns[i];
-        spent[i] = COutPoint(coinbase_tx->GetHash(), 0);
+    SpenderBlock CreateSpenderBlock(size_t count)
+    {
+        // Setup phase:
+        // Mine blocks for coinbase maturity, so we can spend some coinbase outputs in the test.
+        const CScript& coinbase_script = m_coinbase_txns[0]->vout[0].scriptPubKey;
+        for (int i = 0; i < 10; i++) CreateAndProcessBlock({}, coinbase_script);
 
-        // Spending tx
-        spender[i].version = 1;
-        spender[i].vin.resize(1);
-        spender[i].vin[0].prevout.hash = spent[i].hash;
-        spender[i].vin[0].prevout.n = spent[i].n;
-        spender[i].vout.resize(1);
-        spender[i].vout[0].nValue = coinbase_tx->GetValueOut();
-        spender[i].vout[0].scriptPubKey = coinbase_script;
+        // Spend outputs
+        std::vector<COutPoint> spent(count);
+        std::vector<CMutableTransaction> spender(spent.size());
+        for (size_t i = 0; i < spent.size(); i++) {
+            // Outpoint
+            auto coinbase_tx = m_coinbase_txns[i];
+            spent[i] = COutPoint(coinbase_tx->GetHash(), 0);
 
-        // Sign
-        std::vector<unsigned char> vchSig;
-        const uint256 hash = SignatureHash(coinbase_script, spender[i], 0, SIGHASH_ALL, 0, SigVersion::BASE);
-        BOOST_REQUIRE(coinbaseKey.Sign(hash, vchSig));
-        vchSig.push_back((unsigned char)SIGHASH_ALL);
-        spender[i].vin[0].scriptSig << vchSig;
+            // Spending tx
+            spender[i].version = 1;
+            spender[i].vin.resize(1);
+            spender[i].vin[0].prevout.hash = spent[i].hash;
+            spender[i].vin[0].prevout.n = spent[i].n;
+            spender[i].vout.resize(1);
+            spender[i].vout[0].nValue = coinbase_tx->GetValueOut();
+            spender[i].vout[0].scriptPubKey = coinbase_script;
+
+            // Sign
+            std::vector<unsigned char> vchSig;
+            const uint256 hash = SignatureHash(coinbase_script, spender[i], 0, SIGHASH_ALL, 0, SigVersion::BASE);
+            BOOST_REQUIRE(coinbaseKey.Sign(hash, vchSig));
+            vchSig.push_back((unsigned char)SIGHASH_ALL);
+            spender[i].vin[0].scriptSig << vchSig;
+        }
+
+        // Generate and ensure block has been fully processed
+        CBlock block{CreateAndProcessBlock(spender, coinbase_script)};
+        uint256 tip_hash{block.GetHash()};
+        m_node.validation_signals->SyncWithValidationInterfaceQueue();
+        const CBlockIndex* tip{WITH_LOCK(::cs_main, return m_node.chainman->ActiveTip())};
+        BOOST_CHECK_EQUAL(tip->GetBlockHash(), tip_hash);
+
+        return {std::move(block), tip_hash, tip, std::move(spent), std::move(spender)};
     }
+};
 
-    // Generate and ensure block has been fully processed
-    const uint256 tip_hash = CreateAndProcessBlock(spender, coinbase_script).GetHash();
-    m_node.validation_signals->SyncWithValidationInterfaceQueue();
-    BOOST_CHECK_EQUAL(WITH_LOCK(::cs_main, return m_node.chainman->ActiveTip()->GetBlockHash()), tip_hash);
+BOOST_FIXTURE_TEST_CASE(txospenderindex_initial_sync, TxoSpenderIndexTestSetup)
+{
+    const auto [block, tip_hash, tip, spent, spender]{CreateSpenderBlock(10)};
 
     // Now we concluded the setup phase, run index
     TxoSpenderIndex txospenderindex(interfaces::MakeChain(m_node), 1 << 20, true);


### PR DESCRIPTION
**Problem:** `TxoSpenderIndex` stores each spender entry as a LevelDB key with a dummy value.
The lookup path only reads the key, which already contains the disk position of the spending transaction, and never deserializes the value.
The current empty-string marker serializes to one byte, so each spender entry stores one unnecessary byte.

**Fix:** Write new `txospenderindex` entries with a zero-byte value marker instead of a serialized empty string.
Existing indexes remain compatible because `FindSpender()` only iterates over matching keys and reads the spending transaction from the disk position encoded in the key. 

**Reproducer:**  Create index with old code, query with new code, recreate with new code, then query the same spent output with old code.

<details><summary>Reproduction script</summary>

```bash
BEFORE="44a313378e332146576f12edd6c3a3bf2f4ef078"; AFTER="1ab117a62f5a38fe7177f989ed169ea85f2f7a9d"; DATA_DIR="/mnt/my_storage/BitcoinData"; LOG="${DATA_DIR}/debug.log"; \
git reset --hard >/dev/null 2>&1 && git clean -fxd >/dev/null 2>&1 && (git fetch origin $BEFORE $AFTER >/dev/null 2>&1 || true); \
for c in before:$BEFORE after:$AFTER; do git checkout ${c#*:} >/dev/null 2>&1 && cmake -B build-${c%:*} -G Ninja -DCMAKE_BUILD_TYPE=Release >/dev/null 2>&1 && ninja -C build-${c%:*} bitcoind bitcoin-cli >/dev/null 2>&1; done; \
run() { fmt="$1"; reader="$2"; wipe="$3"; cli=./build-"$reader"/bin/bitcoin-cli; [ "$wipe" = wipe ] && rm -rf "${DATA_DIR}/indexes/txospenderindex" "${LOG}"; : > "${LOG}"; ./build-"$reader"/bin/bitcoind -datadir="${DATA_DIR}" -txospenderindex=1 -connect=0 -printtoconsole=0 & pid=$!; while ! grep -Fq 'txospenderindex is enabled at height' "${LOG}" 2>/dev/null; do kill -0 "$pid" 2>/dev/null || { tail -100 "${LOG}"; return 1; }; sleep 5; done; if [ -z "$OUT" ]; then block="$($cli -datadir="${DATA_DIR}" getblockhash 170)"; read SPEND PREV N <<< "$($cli -datadir="${DATA_DIR}" getblock "$block" 2 | awk -F'"' '/"txid":/ { ++i; if (i == 2) spend=$4; if (i == 3) prev=$4 } prev && /"vout":/ { gsub(/[^0-9]/, ""); print spend, prev, $0; exit }')"; OUT="[{\"txid\":\"${PREV}\",\"vout\":${N}}]"; echo "prevout: ${PREV}:${N} -> ${SPEND}"; fi; result="$($cli -datadir="${DATA_DIR}" gettxspendingprevout "$OUT" '{"mempool_only":false}')"; echo "$reader reads $fmt index: $result"; echo "$result" | grep -q "$SPEND"; ok=$?; [ "$wipe" = wipe ] && du -sh "${DATA_DIR}/indexes/txospenderindex" && du -sb "${DATA_DIR}/indexes/txospenderindex"; $cli -datadir="${DATA_DIR}" stop >/dev/null 2>&1 || kill "$pid" 2>/dev/null || true; wait "$pid" || true; return $ok; }; \
for r in "old before wipe" "old after keep" "new after wipe" "new before keep"; do set -- $r; run "$1" "$2" "$3"; done
```
</details>
