### PR TITLE
db: avoid unused LevelDB block cache

### DIFF
--- a/src/bench/index_blockfilter.cpp
+++ b/src/bench/index_blockfilter.cpp
@@ -45,7 +45,7 @@ static void BlockFilterIndexSync(benchmark::Bench& bench)
 
     bench.minEpochIterations(5).run([&] {
         BlockFilterIndex filter_index(interfaces::MakeChain(test_setup->m_node), BlockFilterType::BASIC,
-                                      /*n_cache_size=*/0, /*f_memory=*/false, /*f_wipe=*/true);
+                                      /*f_memory=*/false, /*f_wipe=*/true);
         assert(filter_index.Init());
         assert(!filter_index.BlockUntilSyncedToCurrentChain());
         filter_index.Sync();

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -136,11 +136,10 @@ static void SetMaxOpenFiles(leveldb::Options *options) {
              options->max_open_files, default_open_files);
 }
 
-static leveldb::Options GetOptions(size_t nCacheSize)
+static leveldb::Options GetOptions()
 {
     leveldb::Options options;
-    options.block_cache = leveldb::NewLRUCache(nCacheSize / 2);
-    options.write_buffer_size = nCacheSize / 4; // up to two write buffers may be held in memory simultaneously
+    options.block_cache = leveldb::NewLRUCache(0); // Use zero capacity to avoid LevelDB's default block cache.
     options.filter_policy = leveldb::NewBloomFilterPolicy(10);
     options.compression = leveldb::kNoCompression;
     options.info_log = new CBitcoinLevelDBLogger();
@@ -225,7 +224,7 @@ CDBWrapper::CDBWrapper(const DBParams& params)
     DBContext().iteroptions.verify_checksums = true;
     DBContext().iteroptions.fill_cache = false;
     DBContext().syncoptions.sync = true;
-    DBContext().options = GetOptions(params.cache_bytes);
+    DBContext().options = GetOptions();
     DBContext().options.create_if_missing = true;
     DBContext().options.max_file_size = params.max_file_size;
     assert(!(params.testing_env && params.memory_only));

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -221,6 +221,7 @@ CDBWrapper::CDBWrapper(const DBParams& params)
 {
     DBContext().penv = nullptr;
     DBContext().readoptions.verify_checksums = true;
+    DBContext().readoptions.fill_cache = false; // Skip insertions into the zero-capacity block cache
     DBContext().iteroptions.verify_checksums = true;
     DBContext().iteroptions.fill_cache = false;
     DBContext().syncoptions.sync = true;

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -41,8 +41,6 @@ struct DBOptions {
 struct DBParams {
     //! Location in the filesystem where leveldb data will be stored.
     fs::path path;
-    //! Configures various leveldb cache settings.
-    uint64_t cache_bytes;
     //! If true, use leveldb's memory environment.
     bool memory_only = false;
     //! If true, remove all existing data.

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -65,10 +65,9 @@ CBlockLocator GetLocator(interfaces::Chain& chain, const uint256& block_hash)
     return locator;
 }
 
-BaseIndex::DB::DB(const fs::path& path, size_t n_cache_size, bool f_memory, bool f_wipe, bool f_obfuscate) :
+BaseIndex::DB::DB(const fs::path& path, bool f_memory, bool f_wipe, bool f_obfuscate) :
     CDBWrapper{DBParams{
         .path = path,
-        .cache_bytes = n_cache_size,
         .memory_only = f_memory,
         .wipe_data = f_wipe,
         .obfuscate = f_obfuscate,

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -64,8 +64,7 @@ protected:
     class DB : public CDBWrapper
     {
     public:
-        DB(const fs::path& path, size_t n_cache_size,
-           bool f_memory = false, bool f_wipe = false, bool f_obfuscate = false);
+        DB(const fs::path& path, bool f_memory = false, bool f_wipe = false, bool f_obfuscate = false);
 
         /// Read block locator of the chain that the index is in sync with.
         /// Note, the returned locator will be empty if no record exists.

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -83,7 +83,7 @@ struct DBVal {
 static std::map<BlockFilterType, BlockFilterIndex> g_filter_indexes;
 
 BlockFilterIndex::BlockFilterIndex(std::unique_ptr<interfaces::Chain> chain, BlockFilterType filter_type,
-                                   size_t n_cache_size, bool f_memory, bool f_wipe)
+                                   bool f_memory, bool f_wipe)
     : BaseIndex(std::move(chain), BlockFilterTypeName(filter_type) + " block filter index", BlockFilterThreadName(filter_type))
     , m_filter_type(filter_type)
 {
@@ -93,7 +93,7 @@ BlockFilterIndex::BlockFilterIndex(std::unique_ptr<interfaces::Chain> chain, Blo
     fs::path path = gArgs.GetDataDirNet() / "indexes" / "blockfilter" / fs::u8path(filter_name);
     fs::create_directories(path);
 
-    m_db = std::make_unique<BaseIndex::DB>(path / "db", n_cache_size, f_memory, f_wipe);
+    m_db = std::make_unique<BaseIndex::DB>(path / "db", f_memory, f_wipe);
     m_filter_fileseq = std::make_unique<FlatFileSeq>(std::move(path), "fltr", FLTR_FILE_CHUNK_SIZE);
 }
 
@@ -453,12 +453,12 @@ void ForEachBlockFilterIndex(std::function<void (BlockFilterIndex&)> fn)
 }
 
 bool InitBlockFilterIndex(std::function<std::unique_ptr<interfaces::Chain>()> make_chain, BlockFilterType filter_type,
-                          size_t n_cache_size, bool f_memory, bool f_wipe)
+                          bool f_memory, bool f_wipe)
 {
     auto result = g_filter_indexes.emplace(std::piecewise_construct,
                                            std::forward_as_tuple(filter_type),
                                            std::forward_as_tuple(make_chain(), filter_type,
-                                                                 n_cache_size, f_memory, f_wipe));
+                                                                 f_memory, f_wipe));
     return result.second;
 }
 

--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -76,7 +76,7 @@ protected:
 public:
     /** Constructs the index, which becomes available to be queried. */
     explicit BlockFilterIndex(std::unique_ptr<interfaces::Chain> chain, BlockFilterType filter_type,
-                              size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
+                              bool f_memory = false, bool f_wipe = false);
 
     interfaces::Chain::NotifyOptions CustomOptions() override;
 
@@ -111,7 +111,7 @@ void ForEachBlockFilterIndex(std::function<void (BlockFilterIndex&)> fn);
  * a new index is created and false if one has already been initialized.
  */
 bool InitBlockFilterIndex(std::function<std::unique_ptr<interfaces::Chain>()> make_chain, BlockFilterType filter_type,
-                          size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
+                          bool f_memory = false, bool f_wipe = false);
 
 /**
  * Destroy the block filter index with the given type. Returns false if no such index exists. This

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -86,7 +86,7 @@ struct DBVal {
 
 std::unique_ptr<CoinStatsIndex> g_coin_stats_index;
 
-CoinStatsIndex::CoinStatsIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory, bool f_wipe)
+CoinStatsIndex::CoinStatsIndex(std::unique_ptr<interfaces::Chain> chain, bool f_memory, bool f_wipe)
     : BaseIndex(std::move(chain), "coinstatsindex", "coinstatsidx")
 {
     // An earlier version of the index used "indexes/coinstats" but it contained
@@ -102,7 +102,7 @@ CoinStatsIndex::CoinStatsIndex(std::unique_ptr<interfaces::Chain> chain, size_t 
     fs::path path{gArgs.GetDataDirNet() / "indexes" / "coinstatsindex"};
     fs::create_directories(path);
 
-    m_db = std::make_unique<CoinStatsIndex::DB>(path / "db", n_cache_size, f_memory, f_wipe);
+    m_db = std::make_unique<CoinStatsIndex::DB>(path / "db", f_memory, f_wipe);
 }
 
 bool CoinStatsIndex::CustomAppend(const interfaces::BlockInfo& block)

--- a/src/index/coinstatsindex.h
+++ b/src/index/coinstatsindex.h
@@ -64,7 +64,7 @@ protected:
 
 public:
     // Constructs the index, which becomes available to be queried.
-    explicit CoinStatsIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
+    explicit CoinStatsIndex(std::unique_ptr<interfaces::Chain> chain, bool f_memory = false, bool f_wipe = false);
 
     interfaces::Chain::NotifyOptions CustomOptions() override;
 

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -37,7 +37,7 @@ std::unique_ptr<TxIndex> g_txindex;
 class TxIndex::DB : public BaseIndex::DB
 {
 public:
-    explicit DB(size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
+    explicit DB(bool f_memory = false, bool f_wipe = false);
 
     /// Read the disk location of the transaction data with the given hash. Returns false if the
     /// transaction hash is not indexed.
@@ -47,8 +47,8 @@ public:
     void WriteTxs(const std::vector<std::pair<Txid, CDiskTxPos>>& v_pos);
 };
 
-TxIndex::DB::DB(size_t n_cache_size, bool f_memory, bool f_wipe) :
-    BaseIndex::DB(gArgs.GetDataDirNet() / "indexes" / "txindex", n_cache_size, f_memory, f_wipe)
+TxIndex::DB::DB(bool f_memory, bool f_wipe) :
+    BaseIndex::DB(gArgs.GetDataDirNet() / "indexes" / "txindex", f_memory, f_wipe)
 {}
 
 bool TxIndex::DB::ReadTxPos(const Txid& txid, CDiskTxPos& pos) const
@@ -65,8 +65,8 @@ void TxIndex::DB::WriteTxs(const std::vector<std::pair<Txid, CDiskTxPos>>& v_pos
     WriteBatch(batch);
 }
 
-TxIndex::TxIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory, bool f_wipe)
-    : BaseIndex(std::move(chain), "txindex", "txidx"), m_db(std::make_unique<TxIndex::DB>(n_cache_size, f_memory, f_wipe))
+TxIndex::TxIndex(std::unique_ptr<interfaces::Chain> chain, bool f_memory, bool f_wipe)
+    : BaseIndex(std::move(chain), "txindex", "txidx"), m_db(std::make_unique<TxIndex::DB>(f_memory, f_wipe))
 {}
 
 TxIndex::~TxIndex() = default;

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -40,7 +40,7 @@ protected:
 
 public:
     /// Constructs the index, which becomes available to be queried.
-    explicit TxIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
+    explicit TxIndex(std::unique_ptr<interfaces::Chain> chain, bool f_memory = false, bool f_wipe = false);
 
     // Destructor is declared because this class contains a unique_ptr to an incomplete type.
     virtual ~TxIndex() override;

--- a/src/index/txospenderindex.cpp
+++ b/src/index/txospenderindex.cpp
@@ -61,8 +61,8 @@ struct DBKey {
     }
 };
 
-TxoSpenderIndex::TxoSpenderIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory, bool f_wipe)
-    : BaseIndex(std::move(chain), "txospenderindex", "txospenderidx"), m_db{std::make_unique<DB>(gArgs.GetDataDirNet() / "indexes" / "txospenderindex" / "db", n_cache_size, f_memory, f_wipe)}
+TxoSpenderIndex::TxoSpenderIndex(std::unique_ptr<interfaces::Chain> chain, bool f_memory, bool f_wipe)
+    : BaseIndex(std::move(chain), "txospenderindex", "txospenderidx"), m_db{std::make_unique<DB>(gArgs.GetDataDirNet() / "indexes" / "txospenderindex" / "db", f_memory, f_wipe)}
 {
     if (!m_db->Read("siphash_key", m_siphash_key)) {
         FastRandomContext rng(false);

--- a/src/index/txospenderindex.h
+++ b/src/index/txospenderindex.h
@@ -53,7 +53,7 @@ protected:
     BaseIndex::DB& GetDB() const override;
 
 public:
-    explicit TxoSpenderIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
+    explicit TxoSpenderIndex(std::unique_ptr<interfaces::Chain> chain, bool f_memory = false, bool f_wipe = false);
 
     /**
      * Search the index for a transaction that spends the given outpoint.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1924,22 +1924,22 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     // ********************************************************* Step 8: start indexers
 
     if (args.GetBoolArg("-txindex", DEFAULT_TXINDEX)) {
-        g_txindex = std::make_unique<TxIndex>(interfaces::MakeChain(node), index_cache_sizes.tx_index, false, do_reindex);
+        g_txindex = std::make_unique<TxIndex>(interfaces::MakeChain(node), false, do_reindex);
         node.indexes.emplace_back(g_txindex.get());
     }
 
     if (args.GetBoolArg("-txospenderindex", DEFAULT_TXOSPENDERINDEX)) {
-        g_txospenderindex = std::make_unique<TxoSpenderIndex>(interfaces::MakeChain(node), index_cache_sizes.txospender_index, false, do_reindex);
+        g_txospenderindex = std::make_unique<TxoSpenderIndex>(interfaces::MakeChain(node), false, do_reindex);
         node.indexes.emplace_back(g_txospenderindex.get());
     }
 
     for (const auto& filter_type : g_enabled_filter_types) {
-        InitBlockFilterIndex([&]{ return interfaces::MakeChain(node); }, filter_type, index_cache_sizes.filter_index, false, do_reindex);
+        InitBlockFilterIndex([&]{ return interfaces::MakeChain(node); }, filter_type, false, do_reindex);
         node.indexes.emplace_back(GetBlockFilterIndex(filter_type));
     }
 
     if (args.GetBoolArg("-coinstatsindex", DEFAULT_COINSTATSINDEX)) {
-        g_coin_stats_index = std::make_unique<CoinStatsIndex>(interfaces::MakeChain(node), /*cache_size=*/0, false, do_reindex);
+        g_coin_stats_index = std::make_unique<CoinStatsIndex>(interfaces::MakeChain(node), false, do_reindex);
         node.indexes.emplace_back(g_coin_stats_index.get());
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1850,20 +1850,10 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     // cache size calculations
     node::LogOversizedDbCache(args);
-    const auto [index_cache_sizes, kernel_cache_sizes] = CalculateCacheSizes(args, g_enabled_filter_types.size());
+    const auto [kernel_cache_sizes] = CalculateCacheSizes(args);
 
     LogInfo("Cache configuration:");
     LogInfo("* Using %.1f MiB for block index database", kernel_cache_sizes.block_tree_db / double(1_MiB));
-    if (args.GetBoolArg("-txindex", DEFAULT_TXINDEX)) {
-        LogInfo("* Using %.1f MiB for transaction index database", index_cache_sizes.tx_index / double(1_MiB));
-    }
-    if (args.GetBoolArg("-txospenderindex", DEFAULT_TXOSPENDERINDEX)) {
-        LogInfo("* Using %.1f MiB for transaction output spender index database", index_cache_sizes.txospender_index / double(1_MiB));
-    }
-    for (BlockFilterType filter_type : g_enabled_filter_types) {
-        LogInfo("* Using %.1f MiB for %s block filter index database",
-                  index_cache_sizes.filter_index / double(1_MiB), BlockFilterTypeName(filter_type));
-    }
     LogInfo("* Using %.1f MiB for chain state database", kernel_cache_sizes.coins_db / double(1_MiB));
 
     assert(!node.mempool);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1850,10 +1850,6 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     node::LogOversizedDbCache(args);
     const auto [kernel_cache_sizes] = CalculateCacheSizes(args);
 
-    LogInfo("Cache configuration:");
-    LogInfo("* Using %.1f MiB for block index database", kernel_cache_sizes.block_tree_db / double(1_MiB));
-    LogInfo("* Using %.1f MiB for chain state database", kernel_cache_sizes.coins_db / double(1_MiB));
-
     assert(!node.mempool);
     assert(!node.chainman);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -151,7 +151,7 @@ using http_bitcoin::StartHTTPServer;
 using http_bitcoin::StopHTTPServer;
 using node::ApplyArgsManOptions;
 using node::BlockManager;
-using node::CalculateCacheSizes;
+using node::CalculateDbCacheBytes;
 using node::ChainstateLoadResult;
 using node::ChainstateLoadStatus;
 using node::DEFAULT_PERSIST_MEMPOOL;
@@ -1320,7 +1320,7 @@ static ChainstateLoadResult InitAndLoadChainstate(
     NodeContext& node,
     bool do_reindex,
     const bool do_reindex_chainstate,
-    const kernel::CacheSizes& cache_sizes,
+    const uint64_t coins_cache_bytes,
     const ArgsManager& args)
 {
     // This function may be called twice, so any dirty state must be reset.
@@ -1344,8 +1344,8 @@ static ChainstateLoadResult InitAndLoadChainstate(
     auto mining_args{node::ReadMiningArgs(args)};
     Assert(mining_args); // no error can happen, already checked in AppInitParameterInteraction
     node.mining_args = std::move(*mining_args);
-    LogInfo("* Using %.1f MiB for in-memory UTXO set (plus up to %.1f MiB of unused mempool space)",
-            cache_sizes.coins / double(1_MiB),
+    LogInfo("Using %.1f MiB for in-memory UTXO set (plus up to %.1f MiB of unused mempool space)",
+            coins_cache_bytes / double(1_MiB),
             mempool_opts.max_size_bytes / double(1_MiB));
     ChainstateManager::Options chainman_opts{
         .chainparams = chainparams,
@@ -1422,7 +1422,7 @@ static ChainstateLoadResult InitAndLoadChainstate(
             return std::make_tuple(node::ChainstateLoadStatus::FAILURE, _("Error loading databases"));
         }
     };
-    auto [status, error] = catch_exceptions([&] { return LoadChainstate(chainman, cache_sizes, options); });
+    auto [status, error] = catch_exceptions([&] { return LoadChainstate(chainman, coins_cache_bytes, options); });
     if (status == node::ChainstateLoadStatus::SUCCESS) {
         uiInterface.InitMessage(_("Verifying blocks…"));
         if (chainman.m_blockman.m_have_pruned && options.check_blocks > MIN_BLOCKS_TO_KEEP) {
@@ -1848,7 +1848,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     // cache size calculations
     node::LogOversizedDbCache(args);
-    const auto kernel_cache_sizes = CalculateCacheSizes(args);
+    const uint64_t coins_cache_bytes{CalculateDbCacheBytes(args)};
 
     assert(!node.mempool);
     assert(!node.chainman);
@@ -1861,7 +1861,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         node,
         do_reindex,
         do_reindex_chainstate,
-        kernel_cache_sizes,
+        coins_cache_bytes,
         args);
     if (status == ChainstateLoadStatus::FAILURE && !do_reindex && !ShutdownRequested(node)) {
         // suggest a reindex
@@ -1881,7 +1881,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
             node,
             do_reindex,
             do_reindex_chainstate,
-            kernel_cache_sizes,
+            coins_cache_bytes,
             args);
     }
     if (status != ChainstateLoadStatus::SUCCESS && status != ChainstateLoadStatus::INTERRUPTED) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1157,7 +1157,6 @@ bool AppInitParameterInteraction(const ArgsManager& args)
             .notifications = chainman_opts_dummy.notifications,
             .block_tree_db_params = DBParams{
                 .path = args.GetDataDirNet() / "blocks" / "index",
-                .cache_bytes = 0,
             },
         };
         auto blockman_result{ApplyArgsManOptions(args, blockman_opts_dummy)};
@@ -1362,7 +1361,6 @@ static ChainstateLoadResult InitAndLoadChainstate(
         .notifications = chainman_opts.notifications,
         .block_tree_db_params = DBParams{
             .path = args.GetDataDirNet() / "blocks" / "index",
-            .cache_bytes = cache_sizes.block_tree_db,
             .wipe_data = do_reindex,
         },
     };

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1848,7 +1848,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     // cache size calculations
     node::LogOversizedDbCache(args);
-    const auto [kernel_cache_sizes] = CalculateCacheSizes(args);
+    const auto kernel_cache_sizes = CalculateCacheSizes(args);
 
     assert(!node.mempool);
     assert(!node.chainman);

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -1048,8 +1048,7 @@ btck_ChainstateManager* btck_chainstate_manager_create(
     try {
         const auto chainstate_load_opts{WITH_LOCK(opts.m_mutex, return opts.m_chainstate_load_options)};
 
-        kernel::CacheSizes cache_sizes{DEFAULT_KERNEL_CACHE};
-        auto [status, chainstate_err]{node::LoadChainstate(*chainman, cache_sizes, chainstate_load_opts)};
+        auto [status, chainstate_err]{node::LoadChainstate(*chainman, DEFAULT_KERNEL_CACHE, chainstate_load_opts)};
         if (status != node::ChainstateLoadStatus::SUCCESS) {
             LogError("Failed to load chain state from your data directory: %s", chainstate_err.original);
             return nullptr;

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -468,7 +468,6 @@ struct ChainstateManagerOptions {
               .notifications = *context->m_notifications,
               .block_tree_db_params = DBParams{
                   .path = data_dir / "blocks" / "index",
-                  .cache_bytes = kernel::CacheSizes{DEFAULT_KERNEL_CACHE}.block_tree_db,
               }}},
           m_context{context}, m_chainstate_load_options{node::ChainstateLoadOptions{}}
     {

--- a/src/kernel/caches.h
+++ b/src/kernel/caches.h
@@ -7,7 +7,6 @@
 
 #include <util/byte_units.h>
 
-#include <algorithm>
 #include <cstdint>
 
 //! Suggested default amount of cache reserved for the kernel (bytes)
@@ -15,25 +14,11 @@ static constexpr uint64_t DEFAULT_KERNEL_CACHE{450_MiB};
 //! Default LevelDB write batch size
 static constexpr uint64_t DEFAULT_DB_CACHE_BATCH{32_MiB};
 
-//! Max memory allocated to block tree DB specific cache (bytes)
-static constexpr uint64_t MAX_BLOCK_DB_CACHE{2_MiB};
-//! Max memory allocated to coin DB specific cache (bytes)
-static constexpr uint64_t MAX_COINS_DB_CACHE{8_MiB};
-
 namespace kernel {
 struct CacheSizes {
-    uint64_t block_tree_db;
-    uint64_t coins_db;
     uint64_t coins;
 
-    CacheSizes(uint64_t total_cache)
-    {
-        block_tree_db = std::min(total_cache / 8, MAX_BLOCK_DB_CACHE);
-        total_cache -= block_tree_db;
-        coins_db = std::min(total_cache / 2, MAX_COINS_DB_CACHE);
-        total_cache -= coins_db;
-        coins = total_cache; // the rest goes to the coins cache
-    }
+    CacheSizes(uint64_t total_cache) : coins{total_cache} {}
 };
 } // namespace kernel
 

--- a/src/kernel/caches.h
+++ b/src/kernel/caches.h
@@ -14,12 +14,4 @@ static constexpr uint64_t DEFAULT_KERNEL_CACHE{450_MiB};
 //! Default LevelDB write batch size
 static constexpr uint64_t DEFAULT_DB_CACHE_BATCH{32_MiB};
 
-namespace kernel {
-struct CacheSizes {
-    uint64_t coins;
-
-    CacheSizes(uint64_t total_cache) : coins{total_cache} {}
-};
-} // namespace kernel
-
 #endif // BITCOIN_KERNEL_CACHES_H

--- a/src/node/caches.cpp
+++ b/src/node/caches.cpp
@@ -6,7 +6,6 @@
 
 #include <common/args.h>
 #include <common/system.h>
-#include <kernel/caches.h>
 #include <node/interface_ui.h>
 #include <tinyformat.h>
 #include <util/byte_units.h>
@@ -46,11 +45,6 @@ uint64_t CalculateDbCacheBytes(const ArgsManager& args)
         return std::max<uint64_t>(MIN_DB_CACHE, std::min<uint64_t>(db_cache_bytes, max_db_cache));
     }
     return GetDefaultDBCache();
-}
-
-kernel::CacheSizes CalculateCacheSizes(const ArgsManager& args)
-{
-    return kernel::CacheSizes{CalculateDbCacheBytes(args)};
 }
 
 void LogOversizedDbCache(const ArgsManager& args) noexcept

--- a/src/node/caches.cpp
+++ b/src/node/caches.cpp
@@ -48,9 +48,9 @@ uint64_t CalculateDbCacheBytes(const ArgsManager& args)
     return GetDefaultDBCache();
 }
 
-CacheSizes CalculateCacheSizes(const ArgsManager& args)
+kernel::CacheSizes CalculateCacheSizes(const ArgsManager& args)
 {
-    return {kernel::CacheSizes{CalculateDbCacheBytes(args)}};
+    return kernel::CacheSizes{CalculateDbCacheBytes(args)};
 }
 
 void LogOversizedDbCache(const ArgsManager& args) noexcept

--- a/src/node/caches.cpp
+++ b/src/node/caches.cpp
@@ -62,27 +62,16 @@ CacheSizes CalculateCacheSizes(const ArgsManager& args, size_t n_indexes)
 {
     uint64_t total_cache{CalculateDbCacheBytes(args)};
 
-    // Allocate proportional to usage pattern benefit:
-    // - txindex (10%): serves getrawtransaction RPCs with mostly unique,
-    //   non-repetitive lookups across the entire blockchain.
-    // - blockfilterindex (5%): serves BIP 157 light clients that repeatedly
-    //   query recent blocks, benefiting from LevelDB cache, but the
-    //   working set for a typical 2-week offline gap is ~200kiB, well within 5%
-    //   of the total cache.
-    // - txospenderindex (5%): serves gettxspendingprevout RPCs with very
-    //   specific, rarely repeated outpoint queries.
-    // - coinstatsindex: intentionally not included here, since usage pattern
-    //   does not seem to suggest it would be necessary to cache.
     IndexCacheSizes index_sizes;
-    index_sizes.tx_index = std::min(total_cache * 10 / 100, args.GetBoolArg("-txindex", DEFAULT_TXINDEX) ? MAX_TX_INDEX_CACHE : 0);
-    index_sizes.txospender_index = std::min(total_cache * 5 / 100, args.GetBoolArg("-txospenderindex", DEFAULT_TXOSPENDERINDEX) ? MAX_TXOSPENDER_INDEX_CACHE : 0);
+    index_sizes.tx_index = std::min(total_cache / 8, args.GetBoolArg("-txindex", DEFAULT_TXINDEX) ? MAX_TX_INDEX_CACHE : 0);
+    total_cache -= index_sizes.tx_index;
+    index_sizes.txospender_index = std::min(total_cache / 8, args.GetBoolArg("-txospenderindex", DEFAULT_TXOSPENDERINDEX) ? MAX_TXOSPENDER_INDEX_CACHE : 0);
+    total_cache -= index_sizes.txospender_index;
     if (n_indexes > 0) {
-        uint64_t max_cache = std::min(total_cache * 5 / 100, MAX_FILTER_INDEX_CACHE);
+        uint64_t max_cache = std::min(total_cache / 8, MAX_FILTER_INDEX_CACHE);
         index_sizes.filter_index = max_cache / n_indexes;
         total_cache -= index_sizes.filter_index * n_indexes;
     }
-    total_cache -= index_sizes.tx_index;
-    total_cache -= index_sizes.txospender_index;
     return {index_sizes, kernel::CacheSizes{total_cache}};
 }
 

--- a/src/node/caches.cpp
+++ b/src/node/caches.cpp
@@ -6,8 +6,6 @@
 
 #include <common/args.h>
 #include <common/system.h>
-#include <index/txindex.h>
-#include <index/txospenderindex.h>
 #include <kernel/caches.h>
 #include <node/interface_ui.h>
 #include <tinyformat.h>
@@ -21,14 +19,6 @@
 #include <limits>
 #include <string>
 
-// Unlike for the UTXO database, for the txindex scenario the leveldb cache make
-// a meaningful difference: https://github.com/bitcoin/bitcoin/pull/8273#issuecomment-229601991
-//! Max memory allocated to tx index DB specific cache in bytes.
-static constexpr uint64_t MAX_TX_INDEX_CACHE{1_GiB};
-//! Max memory allocated to all block filter index caches combined in bytes.
-static constexpr uint64_t MAX_FILTER_INDEX_CACHE{1_GiB};
-//! Max memory allocated to tx spenderindex DB specific cache in bytes.
-static constexpr uint64_t MAX_TXOSPENDER_INDEX_CACHE{1_GiB};
 //! Maximum dbcache size on 32-bit systems.
 static constexpr uint64_t MAX_32BIT_DBCACHE{1_GiB};
 //! Larger default dbcache on 64-bit systems with enough RAM.
@@ -58,21 +48,9 @@ uint64_t CalculateDbCacheBytes(const ArgsManager& args)
     return GetDefaultDBCache();
 }
 
-CacheSizes CalculateCacheSizes(const ArgsManager& args, size_t n_indexes)
+CacheSizes CalculateCacheSizes(const ArgsManager& args)
 {
-    uint64_t total_cache{CalculateDbCacheBytes(args)};
-
-    IndexCacheSizes index_sizes;
-    index_sizes.tx_index = std::min(total_cache / 8, args.GetBoolArg("-txindex", DEFAULT_TXINDEX) ? MAX_TX_INDEX_CACHE : 0);
-    total_cache -= index_sizes.tx_index;
-    index_sizes.txospender_index = std::min(total_cache / 8, args.GetBoolArg("-txospenderindex", DEFAULT_TXOSPENDERINDEX) ? MAX_TXOSPENDER_INDEX_CACHE : 0);
-    total_cache -= index_sizes.txospender_index;
-    if (n_indexes > 0) {
-        uint64_t max_cache = std::min(total_cache / 8, MAX_FILTER_INDEX_CACHE);
-        index_sizes.filter_index = max_cache / n_indexes;
-        total_cache -= index_sizes.filter_index * n_indexes;
-    }
-    return {index_sizes, kernel::CacheSizes{total_cache}};
+    return {kernel::CacheSizes{CalculateDbCacheBytes(args)}};
 }
 
 void LogOversizedDbCache(const ArgsManager& args) noexcept

--- a/src/node/caches.h
+++ b/src/node/caches.h
@@ -19,10 +19,7 @@ static constexpr uint64_t DEFAULT_DB_CACHE{DEFAULT_KERNEL_CACHE};
 
 namespace node {
 uint64_t GetDefaultDBCache();
-struct CacheSizes {
-    kernel::CacheSizes kernel;
-};
-CacheSizes CalculateCacheSizes(const ArgsManager& args);
+kernel::CacheSizes CalculateCacheSizes(const ArgsManager& args);
 constexpr bool ShouldWarnOversizedDbCache(uint64_t dbcache, uint64_t total_ram) noexcept
 {
     const uint64_t cap{(total_ram < 2_GiB) ? DEFAULT_DB_CACHE : (total_ram / 100) * 75};

--- a/src/node/caches.h
+++ b/src/node/caches.h
@@ -8,7 +8,6 @@
 #include <kernel/caches.h>
 #include <util/byte_units.h>
 
-#include <cstddef>
 #include <cstdint>
 
 class ArgsManager;
@@ -20,16 +19,10 @@ static constexpr uint64_t DEFAULT_DB_CACHE{DEFAULT_KERNEL_CACHE};
 
 namespace node {
 uint64_t GetDefaultDBCache();
-struct IndexCacheSizes {
-    uint64_t tx_index{0};
-    uint64_t filter_index{0};
-    uint64_t txospender_index{0};
-};
 struct CacheSizes {
-    IndexCacheSizes index;
     kernel::CacheSizes kernel;
 };
-CacheSizes CalculateCacheSizes(const ArgsManager& args, size_t n_indexes = 0);
+CacheSizes CalculateCacheSizes(const ArgsManager& args);
 constexpr bool ShouldWarnOversizedDbCache(uint64_t dbcache, uint64_t total_ram) noexcept
 {
     const uint64_t cap{(total_ram < 2_GiB) ? DEFAULT_DB_CACHE : (total_ram / 100) * 75};

--- a/src/node/caches.h
+++ b/src/node/caches.h
@@ -19,7 +19,7 @@ static constexpr uint64_t DEFAULT_DB_CACHE{DEFAULT_KERNEL_CACHE};
 
 namespace node {
 uint64_t GetDefaultDBCache();
-kernel::CacheSizes CalculateCacheSizes(const ArgsManager& args);
+uint64_t CalculateDbCacheBytes(const ArgsManager& args);
 constexpr bool ShouldWarnOversizedDbCache(uint64_t dbcache, uint64_t total_ram) noexcept
 {
     const uint64_t cap{(total_ram < 2_GiB) ? DEFAULT_DB_CACHE : (total_ram / 100) * 75};

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -71,7 +71,6 @@ static ChainstateLoadResult CompleteChainstateInitialization(
     };
 
     assert(chainman.m_total_coinstip_cache > 0);
-    assert(chainman.m_total_coinsdb_cache > 0);
 
     // If running with multiple chainstates, limit the cache sizes with a
     // discount factor. If discounted the actual cache size will be
@@ -88,7 +87,6 @@ static ChainstateLoadResult CompleteChainstateInitialization(
 
         try {
             chainstate->InitCoinsDB(
-                /*cache_size_bytes=*/chainman.m_total_coinsdb_cache * init_cache_fraction,
                 /*in_memory=*/options.coins_db_in_memory,
                 /*should_wipe=*/options.wipe_chainstate_db);
         } catch (dbwrapper_error& err) {
@@ -170,7 +168,6 @@ ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSize
     LOCK(cs_main);
 
     chainman.m_total_coinstip_cache = cache_sizes.coins;
-    chainman.m_total_coinsdb_cache = cache_sizes.coins_db;
 
     // Load the fully validated chainstate.
     Chainstate& validated_cs{chainman.InitializeChainstate(options.mempool)};

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -8,7 +8,6 @@
 #include <chain.h>
 #include <coins.h>
 #include <consensus/params.h>
-#include <kernel/caches.h>
 #include <node/blockstorage.h>
 #include <sync.h>
 #include <tinyformat.h>
@@ -25,8 +24,6 @@
 #include <algorithm>
 #include <cassert>
 #include <vector>
-
-using kernel::CacheSizes;
 
 namespace node {
 // Complete initialization of chainstates after the initial call has been made
@@ -146,7 +143,7 @@ static ChainstateLoadResult CompleteChainstateInitialization(
     return {ChainstateLoadStatus::SUCCESS, {}};
 }
 
-ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSizes& cache_sizes,
+ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, uint64_t coins_cache_bytes,
                                     const ChainstateLoadOptions& options)
 {
     if (!chainman.AssumedValidBlock().IsNull()) {
@@ -167,7 +164,7 @@ ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSize
 
     LOCK(cs_main);
 
-    chainman.m_total_coinstip_cache = cache_sizes.coins;
+    chainman.m_total_coinstip_cache = coins_cache_bytes;
 
     // Load the fully validated chainstate.
     Chainstate& validated_cs{chainman.InitializeChainstate(options.mempool)};

--- a/src/node/chainstate.h
+++ b/src/node/chainstate.h
@@ -14,10 +14,6 @@
 
 class CTxMemPool;
 
-namespace kernel {
-struct CacheSizes;
-} // namespace kernel
-
 namespace node {
 
 struct ChainstateLoadOptions {
@@ -66,7 +62,7 @@ using ChainstateLoadResult = std::tuple<ChainstateLoadStatus, bilingual_str>;
  *
  *  LoadChainstate returns a (status code, error string) tuple.
  */
-ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const kernel::CacheSizes& cache_sizes,
+ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, uint64_t coins_cache_bytes,
                                     const ChainstateLoadOptions& options);
 ChainstateLoadResult VerifyLoadedChainstate(ChainstateManager& chainman, const ChainstateLoadOptions& options);
 } // namespace node

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -3571,7 +3571,6 @@ const std::vector<RPCResult> RPCHelpForChainstate{
     {RPCResult::Type::NUM, "difficulty", "difficulty of the tip"},
     {RPCResult::Type::NUM, "verificationprogress", "progress towards the network tip"},
     {RPCResult::Type::STR_HEX, "snapshot_blockhash", /*optional=*/true, "the base block of the snapshot this chainstate is based on, if any"},
-    {RPCResult::Type::NUM, "coins_db_cache_bytes", "size of the coinsdb cache"},
     {RPCResult::Type::NUM, "coins_tip_cache_bytes", "size of the coinstip cache"},
     {RPCResult::Type::BOOL, "validated", "whether the chainstate is fully validated. True if all blocks in the chainstate were validated, false if the chain is based on a snapshot and the snapshot has not yet been validated."},
 };
@@ -3614,7 +3613,6 @@ return RPCMethod{
         data.pushKV("target", GetTarget(*tip, chainman.GetConsensus().powLimit).GetHex());
         data.pushKV("difficulty", GetDifficulty(*tip));
         data.pushKV("verificationprogress", chainman.GuessVerificationProgress(tip));
-        data.pushKV("coins_db_cache_bytes",  cs.m_coinsdb_cache_size_bytes);
         data.pushKV("coins_tip_cache_bytes", cs.m_coinstip_cache_size_bytes);
         if (cs.m_from_snapshot_blockhash) {
             data.pushKV("snapshot_blockhash", cs.m_from_snapshot_blockhash->ToString());

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -3231,7 +3231,6 @@ UniValue CreateRolledBackUTXOSnapshot(
     // Create temporary database
     DBParams db_params{
         .path = temp_db_path,
-        .cache_bytes = 0,
         .memory_only = in_memory,
         .wipe_data = true,
         .obfuscate = false,

--- a/src/test/baseindex_tests.cpp
+++ b/src/test/baseindex_tests.cpp
@@ -6,7 +6,6 @@
 #include <interfaces/chain.h>
 #include <script/script.h>
 #include <test/util/setup_common.h>
-#include <util/byte_units.h>
 #include <util/check.h>
 #include <validation.h>
 
@@ -25,7 +24,7 @@ BOOST_FIXTURE_TEST_CASE(baseindex_no_commit_ahead_of_flush, TestChain100Setup)
 {
     Chainstate& chainstate = Assert(m_node.chainman)->ActiveChainstate();
     auto sync_index = [&](bool do_flush, int expected_sync_height, int expected_commit_height) {
-        CoinStatsIndex index{interfaces::MakeChain(m_node), /*n_cache_size=*/1_MiB};
+        CoinStatsIndex index{interfaces::MakeChain(m_node)};
         BOOST_REQUIRE(index.Init());
         index.Sync();
         if (do_flush) {

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -138,7 +138,7 @@ bool BuildChainTestingSetup::BuildChain(const CBlockIndex* pindex,
 
 BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
 {
-    BlockFilterIndex filter_index(interfaces::MakeChain(m_node), BlockFilterType::BASIC, 1_MiB, true);
+    BlockFilterIndex filter_index(interfaces::MakeChain(m_node), BlockFilterType::BASIC, true);
     BOOST_REQUIRE(filter_index.Init());
 
     uint256 last_header;
@@ -299,14 +299,14 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_init_destroy, BasicTestingSetup)
     filter_index = GetBlockFilterIndex(BlockFilterType::BASIC);
     BOOST_CHECK(filter_index == nullptr);
 
-    BOOST_CHECK(InitBlockFilterIndex([&]{ return interfaces::MakeChain(m_node); }, BlockFilterType::BASIC, 1_MiB, true, false));
+    BOOST_CHECK(InitBlockFilterIndex([&]{ return interfaces::MakeChain(m_node); }, BlockFilterType::BASIC, true, false));
 
     filter_index = GetBlockFilterIndex(BlockFilterType::BASIC);
     BOOST_CHECK(filter_index != nullptr);
     BOOST_CHECK(filter_index->GetFilterType() == BlockFilterType::BASIC);
 
     // Initialize returns false if index already exists.
-    BOOST_CHECK(!InitBlockFilterIndex([&]{ return interfaces::MakeChain(m_node); }, BlockFilterType::BASIC, 1_MiB, true, false));
+    BOOST_CHECK(!InitBlockFilterIndex([&]{ return interfaces::MakeChain(m_node); }, BlockFilterType::BASIC, true, false));
 
     int iter_count = 0;
     ForEachBlockFilterIndex([&iter_count](BlockFilterIndex& _index) { iter_count++; });
@@ -321,7 +321,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_init_destroy, BasicTestingSetup)
     BOOST_CHECK(filter_index == nullptr);
 
     // Reinitialize index.
-    BOOST_CHECK(InitBlockFilterIndex([&]{ return interfaces::MakeChain(m_node); }, BlockFilterType::BASIC, 1_MiB, true, false));
+    BOOST_CHECK(InitBlockFilterIndex([&]{ return interfaces::MakeChain(m_node); }, BlockFilterType::BASIC, true, false));
 
     DestroyAllBlockFilterIndexes();
 
@@ -343,7 +343,7 @@ public:
     {
         const fs::path path = gArgs.GetDataDirNet() / "index";
         fs::create_directories(path);
-        m_db = std::make_unique<BaseIndex::DB>(path / "db", /*n_cache_size=*/0, /*f_memory=*/true, /*f_wipe=*/false);
+        m_db = std::make_unique<BaseIndex::DB>(path / "db", /*f_memory=*/true, /*f_wipe=*/false);
     }
 
     bool AllowPrune() const override { return false; }

--- a/src/test/blockmanager_tests.cpp
+++ b/src/test/blockmanager_tests.cpp
@@ -37,7 +37,6 @@ BOOST_AUTO_TEST_CASE(blockmanager_find_block_pos)
         .notifications = notifications,
         .block_tree_db_params = DBParams{
             .path = m_args.GetDataDirNet() / "blocks" / "index",
-            .cache_bytes = 0,
         },
     };
     BlockManager blockman{*Assert(m_node.shutdown_signal), blockman_opts};
@@ -241,7 +240,6 @@ BOOST_AUTO_TEST_CASE(blockmanager_flush_block_file)
         .notifications = notifications,
         .block_tree_db_params = DBParams{
             .path = m_args.GetDataDirNet() / "blocks" / "index",
-            .cache_bytes = 0,
         },
     };
     BlockManager blockman{*Assert(m_node.shutdown_signal), blockman_opts};

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -298,7 +298,7 @@ BOOST_FIXTURE_TEST_SUITE(coins_tests_dbbase, BasicTestingSetup)
 
 BOOST_FIXTURE_TEST_CASE(coins_cache_dbbase_simulation_test, CacheTest)
 {
-    CCoinsViewDB db_base{{.path = "test", .cache_bytes = 8_MiB, .memory_only = true}, {}};
+    CCoinsViewDB db_base{{.path = "test", .memory_only = true}, {}};
     SimulationTest(&db_base, true);
 }
 
@@ -1050,7 +1050,7 @@ void TestFlushBehavior(
 BOOST_FIXTURE_TEST_CASE(ccoins_flush_behavior, FlushTest)
 {
     // Create two in-memory caches atop a leveldb view.
-    CCoinsViewDB base{{.path = "test", .cache_bytes = 8_MiB, .memory_only = true}, {}};
+    CCoinsViewDB base{{.path = "test", .memory_only = true}, {}};
     std::vector<std::unique_ptr<CCoinsViewCacheTest>> caches;
     caches.push_back(std::make_unique<CCoinsViewCacheTest>(&base));
     caches.push_back(std::make_unique<CCoinsViewCacheTest>(caches.back().get()));
@@ -1070,7 +1070,7 @@ BOOST_FIXTURE_TEST_CASE(coins_db_leveldb_layout, FlushTest)
     const Coin coin{MakeCoin()};
     const uint256 block_hash{m_rng.rand256()};
 
-    CCoinsViewDB base{{.path = m_args.GetDataDirBase() / "coins_db_leveldb_layout", .cache_bytes = 1_MiB, .wipe_data = true}, {}};
+    CCoinsViewDB base{{.path = m_args.GetDataDirBase() / "coins_db_leveldb_layout", .wipe_data = true}, {}};
     CCoinsViewCache cache{&base};
 
     cache.EmplaceCoinInternalDANGER(COutPoint{outpoint}, Coin{coin});

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -13,7 +13,6 @@
 #include <txdb.h>
 #include <uint256.h>
 #include <undo.h>
-#include <util/byte_units.h>
 #include <util/check.h>
 #include <util/strencodings.h>
 

--- a/src/test/coinstatsindex_tests.cpp
+++ b/src/test/coinstatsindex_tests.cpp
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_SUITE(coinstatsindex_tests)
 
 BOOST_FIXTURE_TEST_CASE(coinstatsindex_initial_sync, TestChain100Setup)
 {
-    CoinStatsIndex coin_stats_index{interfaces::MakeChain(m_node), 1_MiB, true};
+    CoinStatsIndex coin_stats_index{interfaces::MakeChain(m_node), true};
     BOOST_REQUIRE(coin_stats_index.Init());
 
     const CBlockIndex* block_index;
@@ -89,7 +89,7 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_unclean_shutdown, TestChain100Setup)
     Chainstate& chainstate = Assert(m_node.chainman)->ActiveChainstate();
     const CChainParams& params = Params();
     {
-        CoinStatsIndex index{interfaces::MakeChain(m_node), 1_MiB};
+        CoinStatsIndex index{interfaces::MakeChain(m_node)};
         BOOST_REQUIRE(index.Init());
         index.Sync();
         std::shared_ptr<const CBlock> new_block;
@@ -115,7 +115,7 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_unclean_shutdown, TestChain100Setup)
     }
 
     {
-        CoinStatsIndex index{interfaces::MakeChain(m_node), 1_MiB};
+        CoinStatsIndex index{interfaces::MakeChain(m_node)};
         BOOST_REQUIRE(index.Init());
         // Make sure the index can be loaded.
         BOOST_REQUIRE(index.StartBackgroundSync());

--- a/src/test/coinsviewoverlay_tests.cpp
+++ b/src/test/coinsviewoverlay_tests.cpp
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_SUITE(coinsviewoverlay_tests)
 BOOST_AUTO_TEST_CASE(fetch_inputs_from_db)
 {
     const auto block{CreateBlock()};
-    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewDB db{{.path = "", .memory_only = true}, {}};
     PopulateView(block, db);
     CCoinsViewCache main_cache{&db};
     CoinsViewOverlay view{&main_cache, MakeStartedThreadPool()};
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE(fetch_inputs_from_db)
 BOOST_AUTO_TEST_CASE(fetch_inputs_from_cache)
 {
     const auto block{CreateBlock()};
-    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewDB db{{.path = "", .memory_only = true}, {}};
     CCoinsViewCache main_cache{&db};
     PopulateView(block, main_cache);
     CoinsViewOverlay view{&main_cache, MakeStartedThreadPool()};
@@ -151,7 +151,7 @@ BOOST_AUTO_TEST_CASE(fetch_inputs_from_cache)
 BOOST_AUTO_TEST_CASE(fetch_no_double_spend)
 {
     const auto block{CreateBlock()};
-    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewDB db{{.path = "", .memory_only = true}, {}};
     PopulateView(block, db);
     CCoinsViewCache main_cache{&db};
     // Add all inputs as spent already in cache
@@ -173,7 +173,7 @@ BOOST_AUTO_TEST_CASE(fetch_no_double_spend)
 BOOST_AUTO_TEST_CASE(fetch_no_inputs)
 {
     const auto block{CreateBlock()};
-    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewDB db{{.path = "", .memory_only = true}, {}};
     CCoinsViewCache main_cache{&db};
     CoinsViewOverlay view{&main_cache, MakeStartedThreadPool()};
     const auto reset_guard{view.StartFetching(block)};
@@ -195,7 +195,7 @@ BOOST_AUTO_TEST_CASE(access_non_input_coins)
     CMutableTransaction coinbase;
     coinbase.vin.emplace_back();
     block.vtx.push_back(MakeTransactionRef(coinbase));
-    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewDB db{{.path = "", .memory_only = true}, {}};
     CCoinsViewCache main_cache{&db};
     Coin coin{};
     coin.out.nValue = 1;
@@ -220,7 +220,7 @@ BOOST_AUTO_TEST_CASE(access_non_input_coins)
 BOOST_AUTO_TEST_CASE(fetch_out_of_order_input_uses_normal_lookup)
 {
     const auto block{CreateBlock()};
-    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewDB db{{.path = "", .memory_only = true}, {}};
     CCoinsViewCache main_cache{&db};
     PopulateView(block, main_cache);
 
@@ -252,7 +252,7 @@ BOOST_AUTO_TEST_CASE(fetch_out_of_order_input_uses_normal_lookup)
 BOOST_AUTO_TEST_CASE(fetch_state_is_reusable_after_teardown)
 {
     const auto block{CreateBlock()};
-    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewDB db{{.path = "", .memory_only = true}, {}};
     CCoinsViewCache main_cache{&db};
     PopulateView(block, main_cache);
     CoinsViewOverlay view{&main_cache, MakeStartedThreadPool()};
@@ -279,7 +279,7 @@ BOOST_AUTO_TEST_SUITE(coinsviewoverlay_tests_noworkers)
 BOOST_AUTO_TEST_CASE(fetch_unstarted_thread_pool)
 {
     const auto block{CreateBlock()};
-    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewDB db{{.path = "", .memory_only = true}, {}};
     CCoinsViewCache main_cache{&db};
     PopulateView(block, main_cache);
     auto thread_pool{std::make_shared<ThreadPool>("fetch_none")};
@@ -292,7 +292,7 @@ BOOST_AUTO_TEST_CASE(fetch_unstarted_thread_pool)
 BOOST_AUTO_TEST_CASE(fetch_interrupted_thread_pool_uses_normal_lookup)
 {
     const auto block{CreateBlock()};
-    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewDB db{{.path = "", .memory_only = true}, {}};
     CCoinsViewCache main_cache{&db};
     PopulateView(block, main_cache);
 

--- a/src/test/coinsviewoverlay_tests.cpp
+++ b/src/test/coinsviewoverlay_tests.cpp
@@ -9,7 +9,6 @@
 #include <primitives/transaction_identifier.h>
 #include <txdb.h>
 #include <uint256.h>
-#include <util/byte_units.h>
 #include <util/hasher.h>
 #include <util/threadpool.h>
 

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -7,7 +7,6 @@
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>
-#include <util/byte_units.h>
 #include <util/string.h>
 
 #include <memory>
@@ -23,7 +22,6 @@ BOOST_AUTO_TEST_CASE(dbwrapper)
 {
     // Perform tests both obfuscated and non-obfuscated.
     for (const bool obfuscate : {false, true}) {
-        constexpr size_t CACHE_SIZE{1_MiB};
         const fs::path path{m_args.GetDataDirBase() / "dbwrapper"};
 
         Obfuscation obfuscation;
@@ -31,7 +29,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper)
 
         // Write values
         {
-            CDBWrapper dbw{{.path = path, .cache_bytes = CACHE_SIZE, .wipe_data = true, .obfuscate = obfuscate}};
+            CDBWrapper dbw{{.path = path, .wipe_data = true, .obfuscate = obfuscate}};
             BOOST_CHECK_EQUAL(obfuscate, !dbw.IsEmpty());
 
             // Ensure that we're doing real obfuscation when obfuscate=true
@@ -48,13 +46,13 @@ BOOST_AUTO_TEST_CASE(dbwrapper)
 
         // Verify that the obfuscation key is never obfuscated
         {
-            CDBWrapper dbw{{.path = path, .cache_bytes = CACHE_SIZE, .obfuscate = false}};
+            CDBWrapper dbw{{.path = path, .obfuscate = false}};
             BOOST_CHECK_EQUAL(obfuscation, dbwrapper_private::GetObfuscation(dbw));
         }
 
         // Read back the values
         {
-            CDBWrapper dbw{{.path = path, .cache_bytes = CACHE_SIZE, .obfuscate = obfuscate}};
+            CDBWrapper dbw{{.path = path, .obfuscate = obfuscate}};
 
             // Ensure obfuscation is read back correctly
             BOOST_CHECK_EQUAL(obfuscation, dbwrapper_private::GetObfuscation(dbw));
@@ -75,7 +73,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper_basic_data)
     // Perform tests both obfuscated and non-obfuscated.
     for (bool obfuscate : {false, true}) {
         fs::path ph = m_args.GetDataDirBase() / (obfuscate ? "dbwrapper_1_obfuscate_true" : "dbwrapper_1_obfuscate_false");
-        CDBWrapper dbw({.path = ph, .cache_bytes = 1_MiB, .memory_only = false, .wipe_data = true, .obfuscate = obfuscate});
+        CDBWrapper dbw({.path = ph, .memory_only = false, .wipe_data = true, .obfuscate = obfuscate});
 
         uint256 res;
         uint32_t res_uint_32;
@@ -156,7 +154,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper_batch)
     // Perform tests both obfuscated and non-obfuscated.
     for (const bool obfuscate : {false, true}) {
         fs::path ph = m_args.GetDataDirBase() / (obfuscate ? "dbwrapper_batch_obfuscate_true" : "dbwrapper_batch_obfuscate_false");
-        CDBWrapper dbw({.path = ph, .cache_bytes = 1_MiB, .memory_only = true, .wipe_data = false, .obfuscate = obfuscate});
+        CDBWrapper dbw({.path = ph, .memory_only = true, .wipe_data = false, .obfuscate = obfuscate});
 
         uint8_t key{'i'};
         uint256 in = m_rng.rand256();
@@ -199,7 +197,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper_iterator)
     // Perform tests both obfuscated and non-obfuscated.
     for (const bool obfuscate : {false, true}) {
         fs::path ph = m_args.GetDataDirBase() / (obfuscate ? "dbwrapper_iterator_obfuscate_true" : "dbwrapper_iterator_obfuscate_false");
-        CDBWrapper dbw({.path = ph, .cache_bytes = 1_MiB, .memory_only = true, .wipe_data = false, .obfuscate = obfuscate});
+        CDBWrapper dbw({.path = ph, .memory_only = true, .wipe_data = false, .obfuscate = obfuscate});
 
         // The two keys are intentionally chosen for ordering
         uint8_t key{'j'};
@@ -264,7 +262,7 @@ BOOST_AUTO_TEST_CASE(existing_data_no_obfuscate)
     fs::create_directories(ph);
 
     // Set up a non-obfuscated wrapper to write some initial data.
-    std::unique_ptr<CDBWrapper> dbw = std::make_unique<CDBWrapper>(DBParams{.path = ph, .cache_bytes = 1 << 10, .memory_only = false, .wipe_data = false, .obfuscate = false});
+    std::unique_ptr<CDBWrapper> dbw = std::make_unique<CDBWrapper>(DBParams{.path = ph, .memory_only = false, .wipe_data = false, .obfuscate = false});
     uint8_t key{'k'};
     uint256 in = m_rng.rand256();
     uint256 res;
@@ -277,7 +275,7 @@ BOOST_AUTO_TEST_CASE(existing_data_no_obfuscate)
     dbw.reset();
 
     // Now, set up another wrapper that wants to obfuscate the same directory
-    CDBWrapper odbw({.path = ph, .cache_bytes = 1 << 10, .memory_only = false, .wipe_data = false, .obfuscate = true});
+    CDBWrapper odbw({.path = ph, .memory_only = false, .wipe_data = false, .obfuscate = true});
 
     // Check that the key/val we wrote with unobfuscated wrapper exists and
     // is readable.
@@ -305,7 +303,7 @@ BOOST_AUTO_TEST_CASE(existing_data_reindex)
     fs::create_directories(ph);
 
     // Set up a non-obfuscated wrapper to write some initial data.
-    std::unique_ptr<CDBWrapper> dbw = std::make_unique<CDBWrapper>(DBParams{.path = ph, .cache_bytes = 1 << 10, .memory_only = false, .wipe_data = false, .obfuscate = false});
+    std::unique_ptr<CDBWrapper> dbw = std::make_unique<CDBWrapper>(DBParams{.path = ph, .memory_only = false, .wipe_data = false, .obfuscate = false});
     uint8_t key{'k'};
     uint256 in = m_rng.rand256();
     uint256 res;
@@ -318,7 +316,7 @@ BOOST_AUTO_TEST_CASE(existing_data_reindex)
     dbw.reset();
 
     // Simulate a -reindex by wiping the existing data store
-    CDBWrapper odbw({.path = ph, .cache_bytes = 1 << 10, .memory_only = false, .wipe_data = true, .obfuscate = true});
+    CDBWrapper odbw({.path = ph, .memory_only = false, .wipe_data = true, .obfuscate = true});
 
     // Check that the key/val we wrote with unobfuscated wrapper doesn't exist
     uint256 res2;
@@ -337,7 +335,7 @@ BOOST_AUTO_TEST_CASE(existing_data_reindex)
 BOOST_AUTO_TEST_CASE(iterator_ordering)
 {
     fs::path ph = m_args.GetDataDirBase() / "iterator_ordering";
-    CDBWrapper dbw({.path = ph, .cache_bytes = 1_MiB, .memory_only = true, .wipe_data = false, .obfuscate = false});
+    CDBWrapper dbw({.path = ph, .memory_only = true, .wipe_data = false, .obfuscate = false});
     for (int x=0x00; x<256; ++x) {
         uint8_t key = x;
         uint32_t value = x*x;
@@ -405,7 +403,7 @@ struct StringContentsSerializer {
 BOOST_AUTO_TEST_CASE(iterator_string_ordering)
 {
     fs::path ph = m_args.GetDataDirBase() / "iterator_string_ordering";
-    CDBWrapper dbw({.path = ph, .cache_bytes = 1_MiB, .memory_only = true, .wipe_data = false, .obfuscate = false});
+    CDBWrapper dbw({.path = ph, .memory_only = true, .wipe_data = false, .obfuscate = false});
     for (int x = 0; x < 10; ++x) {
         for (int y = 0; y < 10; ++y) {
             std::string key{ToString(x)};
@@ -447,7 +445,7 @@ BOOST_AUTO_TEST_CASE(unicodepath)
     // the ANSI CreateDirectoryA call and the code page isn't UTF8.
     // It will succeed if created with CreateDirectoryW.
     fs::path ph = m_args.GetDataDirBase() / "test_runner_₿_🏃_20191128_104644";
-    CDBWrapper dbw({.path = ph, .cache_bytes = 1_MiB});
+    CDBWrapper dbw({.path = ph});
 
     fs::path lockPath = ph / "LOCK";
     BOOST_CHECK(fs::exists(lockPath));

--- a/src/test/fuzz/block_index.cpp
+++ b/src/test/fuzz/block_index.cpp
@@ -58,7 +58,6 @@ FUZZ_TARGET(block_index, .init = init_block_index)
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     auto block_index = kernel::BlockTreeDB(DBParams{
         .path = "", // Memory only.
-
         .memory_only = true,
     });
 

--- a/src/test/fuzz/block_index.cpp
+++ b/src/test/fuzz/block_index.cpp
@@ -59,7 +59,7 @@ FUZZ_TARGET(block_index, .init = init_block_index)
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     auto block_index = kernel::BlockTreeDB(DBParams{
         .path = "", // Memory only.
-        .cache_bytes = 1_MiB,
+
         .memory_only = true,
     });
 

--- a/src/test/fuzz/block_index.cpp
+++ b/src/test/fuzz/block_index.cpp
@@ -10,7 +10,6 @@
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
 #include <txdb.h>
-#include <util/byte_units.h>
 #include <validation.h>
 
 using kernel::CBlockFileInfo;

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -426,7 +426,6 @@ FUZZ_TARGET(coins_view_db, .init = initialize_coins_view)
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     auto db_params = DBParams{
         .path = "",
-        .cache_bytes = 1_MiB,
         .memory_only = true,
     };
     CCoinsViewDB backend_coins_view{std::move(db_params), CoinsViewOptions{}};
@@ -457,7 +456,6 @@ FUZZ_TARGET(coins_view_stacked, .init = initialize_coins_view) EXCLUSIVE_LOCKS_R
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     auto db_params = DBParams{
         .path = "",
-        .cache_bytes = 1_MiB,
         .memory_only = true,
     };
     CCoinsViewDB backend_base_coins_view{std::move(db_params), CoinsViewOptions{}};

--- a/src/test/fuzz/dbwrapper.cpp
+++ b/src/test/fuzz/dbwrapper.cpp
@@ -186,7 +186,6 @@ DBParams ConsumeDBParams(FuzzedDataProvider& provider, leveldb::Env* testing_env
 {
     return DBParams{
         .path = "dbwrapper_fuzz",
-        .cache_bytes = provider.ConsumeIntegralInRange<size_t>(64 << 10, 1_MiB),
         .obfuscate = obfuscate,
         .options = options,
         .testing_env = testing_env,

--- a/src/test/txindex_tests.cpp
+++ b/src/test/txindex_tests.cpp
@@ -7,7 +7,6 @@
 #include <index/txindex.h>
 #include <interfaces/chain.h>
 #include <test/util/setup_common.h>
-#include <util/byte_units.h>
 #include <validation.h>
 
 #include <boost/test/unit_test.hpp>
@@ -16,7 +15,7 @@ BOOST_AUTO_TEST_SUITE(txindex_tests)
 
 BOOST_FIXTURE_TEST_CASE(txindex_initial_sync, TestChain100Setup)
 {
-    TxIndex txindex(interfaces::MakeChain(m_node), 1_MiB, true);
+    TxIndex txindex(interfaces::MakeChain(m_node), true);
     BOOST_REQUIRE(txindex.Init());
 
     CTransactionRef tx_disk;

--- a/src/test/txospenderindex_tests.cpp
+++ b/src/test/txospenderindex_tests.cpp
@@ -49,7 +49,7 @@ BOOST_FIXTURE_TEST_CASE(txospenderindex_initial_sync, TestChain100Setup)
     BOOST_CHECK_EQUAL(WITH_LOCK(::cs_main, return m_node.chainman->ActiveTip()->GetBlockHash()), tip_hash);
 
     // Now we concluded the setup phase, run index
-    TxoSpenderIndex txospenderindex(interfaces::MakeChain(m_node), 1 << 20, true);
+    TxoSpenderIndex txospenderindex(interfaces::MakeChain(m_node), true);
     BOOST_REQUIRE(txospenderindex.Init());
     BOOST_CHECK(!txospenderindex.BlockUntilSyncedToCurrentChain()); // false when not synced
     BOOST_CHECK_NE(txospenderindex.GetSummary().best_block_hash, tip_hash);

--- a/src/test/util/chainstate.h
+++ b/src/test/util/chainstate.h
@@ -82,7 +82,7 @@ CreateAndActivateUTXOSnapshot(
             Chainstate& chain = node.chainman->ActiveChainstate();
             Assert(node.chainman->LoadGenesisBlock());
             // These cache values will be corrected shortly in `MaybeRebalanceCaches`.
-            chain.InitCoinsDB(1_MiB, /*in_memory=*/true, /*should_wipe=*/false);
+            chain.InitCoinsDB(/*in_memory=*/true, /*should_wipe=*/false);
             chain.InitCoinsCache(1_MiB);
             chain.CoinsTip().SetBestBlock(gen_hash);
             chain.LoadChainTip();

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -18,7 +18,6 @@
 #include <init.h>
 #include <interfaces/chain.h>
 #include <interfaces/mining.h>
-#include <kernel/caches.h>
 #include <kernel/context.h>
 #include <key.h>
 #include <logging.h>
@@ -356,7 +355,7 @@ void ChainTestingSetup::LoadVerifyActivateChainstate()
     options.check_blocks = m_args.GetIntArg("-checkblocks", DEFAULT_CHECKBLOCKS);
     options.check_level = m_args.GetIntArg("-checklevel", DEFAULT_CHECKLEVEL);
     options.require_full_verification = m_args.IsArgSet("-checkblocks") || m_args.IsArgSet("-checklevel");
-    auto [status, error] = LoadChainstate(chainman, m_kernel_cache_sizes, options);
+    auto [status, error] = LoadChainstate(chainman, m_coins_cache_bytes, options);
     assert(status == node::ChainstateLoadStatus::SUCCESS);
 
     std::tie(status, error) = VerifyLoadedChainstate(chainman, options);

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -320,7 +320,6 @@ ChainTestingSetup::ChainTestingSetup(const ChainType chainType, TestOpts opts)
             .notifications = chainman_opts.notifications,
             .block_tree_db_params = DBParams{
                 .path = m_args.GetDataDirNet() / "blocks" / "index",
-                .cache_bytes = m_kernel_cache_sizes.block_tree_db,
                 .memory_only = opts.block_tree_db_in_memory,
                 .wipe_data = m_args.GetBoolArg("-reindex", false),
             },

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -98,7 +98,7 @@ struct BasicTestingSetup {
  * initialization behaviour.
  */
 struct ChainTestingSetup : public BasicTestingSetup {
-    kernel::CacheSizes m_kernel_cache_sizes{node::CalculateCacheSizes(m_args).kernel};
+    kernel::CacheSizes m_kernel_cache_sizes{node::CalculateCacheSizes(m_args)};
     bool m_coins_db_in_memory{true};
     bool m_block_tree_db_in_memory{true};
     std::function<void()> m_make_chainman{};

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -7,7 +7,6 @@
 
 #include <common/args.h> // IWYU pragma: export
 #include <consensus/amount.h>
-#include <kernel/caches.h>
 #include <key.h>
 #include <node/caches.h>
 #include <node/context.h> // IWYU pragma: export
@@ -98,7 +97,7 @@ struct BasicTestingSetup {
  * initialization behaviour.
  */
 struct ChainTestingSetup : public BasicTestingSetup {
-    kernel::CacheSizes m_kernel_cache_sizes{node::CalculateCacheSizes(m_args)};
+    uint64_t m_coins_cache_bytes{node::CalculateDbCacheBytes(m_args)};
     bool m_coins_db_in_memory{true};
     bool m_block_tree_db_in_memory{true};
     std::function<void()> m_make_chainman{};

--- a/src/test/validation_chainstate_tests.cpp
+++ b/src/test/validation_chainstate_tests.cpp
@@ -35,7 +35,7 @@ BOOST_FIXTURE_TEST_SUITE(validation_chainstate_tests, ChainTestingSetup)
 
 //! Test resizing coins-related Chainstate caches during runtime.
 //!
-BOOST_AUTO_TEST_CASE(validation_chainstate_resize_caches)
+BOOST_AUTO_TEST_CASE(validation_chainstate_resize_cache)
 {
     ChainstateManager& manager = *Assert(m_node.chainman);
     CTxMemPool& mempool = *Assert(m_node.mempool);
@@ -50,17 +50,17 @@ BOOST_AUTO_TEST_CASE(validation_chainstate_resize_caches)
         const auto outpoint = AddTestCoin(m_rng, c1.CoinsTip());
 
         // Set a meaningless bestblock value in the coinsview cache - otherwise we won't
-        // flush during ResizecoinsCaches() and will subsequently hit an assertion.
+        // flush during ResizeCoinsCache() and will subsequently hit an assertion.
         c1.CoinsTip().SetBestBlock(m_rng.rand256());
 
         BOOST_CHECK(c1.CoinsTip().HaveCoinInCache(outpoint));
 
-        c1.ResizeCoinsCaches(16_MiB); // upsizing the coinsview cache
+        c1.ResizeCoinsCache(16_MiB); // upsizing the coinsview cache
 
         // View should still have the coin cached, since we haven't destructed the cache on upsize.
         BOOST_CHECK(c1.CoinsTip().HaveCoinInCache(outpoint));
 
-        c1.ResizeCoinsCaches(4_MiB); // downsizing the coinsview cache
+        c1.ResizeCoinsCache(4_MiB); // downsizing the coinsview cache
 
         // The view cache should be empty since we had to destruct to downsize.
         BOOST_CHECK(!c1.CoinsTip().HaveCoinInCache(outpoint));

--- a/src/test/validation_chainstate_tests.cpp
+++ b/src/test/validation_chainstate_tests.cpp
@@ -40,8 +40,7 @@ BOOST_AUTO_TEST_CASE(validation_chainstate_resize_caches)
     ChainstateManager& manager = *Assert(m_node.chainman);
     CTxMemPool& mempool = *Assert(m_node.mempool);
     Chainstate& c1 = WITH_LOCK(cs_main, return manager.InitializeChainstate(&mempool));
-    c1.InitCoinsDB(
-        /*cache_size_bytes=*/8_MiB, /*in_memory=*/true, /*should_wipe=*/false);
+    c1.InitCoinsDB(/*in_memory=*/true, /*should_wipe=*/false);
     WITH_LOCK(::cs_main, c1.InitCoinsCache(8_MiB));
     BOOST_REQUIRE(manager.LoadGenesisBlock()); // Need at least one block loaded to be able to flush caches
 
@@ -56,18 +55,12 @@ BOOST_AUTO_TEST_CASE(validation_chainstate_resize_caches)
 
         BOOST_CHECK(c1.CoinsTip().HaveCoinInCache(outpoint));
 
-        c1.ResizeCoinsCaches(
-            16_MiB, // upsizing the coinsview cache
-            4_MiB // downsizing the coinsdb cache
-        );
+        c1.ResizeCoinsCaches(16_MiB); // upsizing the coinsview cache
 
         // View should still have the coin cached, since we haven't destructed the cache on upsize.
         BOOST_CHECK(c1.CoinsTip().HaveCoinInCache(outpoint));
 
-        c1.ResizeCoinsCaches(
-            4_MiB, // downsizing the coinsview cache
-            8_MiB // upsizing the coinsdb cache
-        );
+        c1.ResizeCoinsCaches(4_MiB); // downsizing the coinsview cache
 
         // The view cache should be empty since we had to destruct to downsize.
         BOOST_CHECK(!c1.CoinsTip().HaveCoinInCache(outpoint));

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -438,7 +438,6 @@ struct SnapshotTestSetup : TestChain100Setup {
                 .notifications = chainman_opts.notifications,
                 .block_tree_db_params = DBParams{
                     .path = chainman.m_options.datadir / "blocks" / "index",
-                    .cache_bytes = m_kernel_cache_sizes.block_tree_db,
                     .memory_only = m_block_tree_db_in_memory,
                 },
             };

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -72,8 +72,7 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager, TestChain100Setup)
     //
     const uint256 snapshot_blockhash = active_tip->GetBlockHash();
     Chainstate& c2{WITH_LOCK(::cs_main, return manager.AddChainstate(std::make_unique<Chainstate>(nullptr, manager.m_blockman, manager, snapshot_blockhash)))};
-    c2.InitCoinsDB(
-        /*cache_size_bytes=*/8_MiB, /*in_memory=*/true, /*should_wipe=*/false);
+    c2.InitCoinsDB(/*in_memory=*/true, /*should_wipe=*/false);
     {
         LOCK(::cs_main);
         c2.InitCoinsCache(8_MiB);
@@ -123,7 +122,6 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_rebalance_caches, TestChain100Setup)
     ChainstateManager& manager = *m_node.chainman;
 
     size_t max_cache = 10000;
-    manager.m_total_coinsdb_cache = max_cache;
     manager.m_total_coinstip_cache = max_cache;
 
     std::vector<Chainstate*> chainstates;
@@ -139,15 +137,13 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_rebalance_caches, TestChain100Setup)
     }
 
     BOOST_CHECK_EQUAL(c1.m_coinstip_cache_size_bytes, max_cache);
-    BOOST_CHECK_EQUAL(c1.m_coinsdb_cache_size_bytes, max_cache);
 
     // Create a snapshot-based chainstate.
     //
     CBlockIndex* snapshot_base{WITH_LOCK(manager.GetMutex(), return manager.ActiveChain()[manager.ActiveChain().Height() / 2])};
     Chainstate& c2{WITH_LOCK(::cs_main, return manager.AddChainstate(std::make_unique<Chainstate>(nullptr, manager.m_blockman, manager, *snapshot_base->phashBlock)))};
     chainstates.push_back(&c2);
-    c2.InitCoinsDB(
-        /*cache_size_bytes=*/8_MiB, /*in_memory=*/true, /*should_wipe=*/false);
+    c2.InitCoinsDB(/*in_memory=*/true, /*should_wipe=*/false);
 
     // Reset IBD state so IsInitialBlockDownload() returns true and causes
     // MaybeRebalanceCaches() to prioritize the snapshot chainstate, giving it
@@ -165,9 +161,7 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_rebalance_caches, TestChain100Setup)
     }
 
     BOOST_CHECK_CLOSE(double(c1.m_coinstip_cache_size_bytes), max_cache * 0.05, 1);
-    BOOST_CHECK_CLOSE(double(c1.m_coinsdb_cache_size_bytes), max_cache * 0.05, 1);
     BOOST_CHECK_CLOSE(double(c2.m_coinstip_cache_size_bytes), max_cache * 0.95, 1);
-    BOOST_CHECK_CLOSE(double(c2.m_coinsdb_cache_size_bytes), max_cache * 0.95, 1);
 }
 
 BOOST_FIXTURE_TEST_CASE(chainstatemanager_ibd_exit_after_loading_blocks, ChainTestingSetup)
@@ -790,7 +784,6 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_snapshot_completion, SnapshotTestSetup
     Chainstate& active_cs = chainman.ActiveChainstate();
     Chainstate& validated_cs{*Assert(WITH_LOCK(cs_main, return chainman.HistoricalChainstate()))};
     auto tip_cache_before_complete = active_cs.m_coinstip_cache_size_bytes;
-    auto db_cache_before_complete = active_cs.m_coinsdb_cache_size_bytes;
 
     SnapshotCompletionResult res;
     m_node.notifications->m_shutdown_on_fatal_error = false;
@@ -813,7 +806,6 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_snapshot_completion, SnapshotTestSetup
     // Cache should have been rebalanced and reallocated to the "only" remaining
     // chainstate.
     BOOST_CHECK(active_cs.m_coinstip_cache_size_bytes > tip_cache_before_complete);
-    BOOST_CHECK(active_cs.m_coinsdb_cache_size_bytes > db_cache_before_complete);
 
     // Trying completion again should return false.
     res = WITH_LOCK(::cs_main, return chainman.MaybeValidateSnapshot(validated_cs, active_cs));
@@ -847,7 +839,6 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_snapshot_completion, SnapshotTestSetup
         BOOST_CHECK_EQUAL(chainman_restarted.m_chainstates.size(), 1);
         BOOST_CHECK(!chainman_restarted.CurrentChainstate().m_from_snapshot_blockhash);
         BOOST_CHECK(active_cs2.m_coinstip_cache_size_bytes > tip_cache_before_complete);
-        BOOST_CHECK(active_cs2.m_coinsdb_cache_size_bytes > db_cache_before_complete);
 
         BOOST_CHECK_EQUAL(chainman_restarted.ActiveTip()->GetBlockHash(), snapshot_tip_hash);
         BOOST_CHECK_EQUAL(chainman_restarted.ActiveHeight(), 210);

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -56,15 +56,15 @@ struct CoinEntry {
 } // namespace
 
 CCoinsViewDB::CCoinsViewDB(DBParams db_params, CoinsViewOptions options) :
-    m_db_params{std::move(db_params)},
+    m_db_path{db_params.path},
     m_options{std::move(options)},
-    m_db{std::make_unique<CDBWrapper>(m_db_params)} { }
+    m_db{std::make_unique<CDBWrapper>(db_params)} { }
 
 CCoinsViewDB::~CCoinsViewDB()
 {
     if (m_compaction.valid()) {
         if (m_compaction.wait_for(std::chrono::seconds{0}) != std::future_status::ready) {
-            LogInfo("Waiting for background chainstate compaction of %s", fs::PathToString(m_db_params.path));
+            LogInfo("Waiting for background chainstate compaction of %s", fs::PathToString(m_db_path));
         }
         m_compaction.wait();
     }
@@ -187,9 +187,9 @@ std::shared_future<void> CCoinsViewDB::CompactFullAsync()
     m_compaction = std::async(std::launch::async, [this] {
         try {
             util::ThreadRename("utxocompact");
-            LogDebug(BCLog::COINDB, "Starting chainstate compaction of %s", fs::PathToString(m_db_params.path));
+            LogDebug(BCLog::COINDB, "Starting chainstate compaction of %s", fs::PathToString(m_db_path));
             m_db->CompactFull();
-            LogDebug(BCLog::COINDB, "Finished chainstate compaction of %s", fs::PathToString(m_db_params.path));
+            LogDebug(BCLog::COINDB, "Finished chainstate compaction of %s", fs::PathToString(m_db_path));
         } catch (const std::exception& e) {
             LogWarning("Failed chainstate compaction (%s)", e.what());
         }

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -70,21 +70,6 @@ CCoinsViewDB::~CCoinsViewDB()
     }
 }
 
-void CCoinsViewDB::ResizeCache(size_t new_cache_size)
-{
-    // We can't do this operation with an in-memory DB since we'll lose all the coins upon
-    // reset.
-    if (!m_db_params.memory_only) {
-        LOCK(m_db_mutex);
-        // Have to do a reset first to get the original `m_db` state to release its
-        // filesystem lock.
-        m_db.reset();
-        m_db_params.cache_bytes = new_cache_size;
-        m_db_params.wipe_data = false;
-        m_db = std::make_unique<CDBWrapper>(m_db_params);
-    }
-}
-
 std::optional<Coin> CCoinsViewDB::GetCoin(const COutPoint& outpoint) const
 {
     if (Coin coin; m_db->Read(CoinEntry(&outpoint), coin)) {
@@ -202,8 +187,6 @@ std::shared_future<void> CCoinsViewDB::CompactFullAsync()
     m_compaction = std::async(std::launch::async, [this] {
         try {
             util::ThreadRename("utxocompact");
-            LOCK(m_db_mutex);
-
             LogDebug(BCLog::COINDB, "Starting chainstate compaction of %s", fs::PathToString(m_db_params.path));
             m_db->CompactFull();
             LogDebug(BCLog::COINDB, "Finished chainstate compaction of %s", fs::PathToString(m_db_params.path));

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -38,8 +38,6 @@ class CCoinsViewDB final : public CCoinsView
 protected:
     DBParams m_db_params;
     CoinsViewOptions m_options;
-    //! Prevents CompactFull() from using m_db while ResizeCache() replaces it.
-    Mutex m_db_mutex;
     std::unique_ptr<CDBWrapper> m_db;
     std::shared_future<void> m_compaction;
 public:
@@ -58,11 +56,8 @@ public:
     bool NeedsUpgrade();
     size_t EstimateSize() const override;
 
-    //! Dynamically alter the underlying leveldb cache size.
-    void ResizeCache(size_t new_cache_size) EXCLUSIVE_LOCKS_REQUIRED(cs_main, !m_db_mutex);
-
     //! Perform a full compaction of the underlying LevelDB on a one-shot background thread.
-    std::shared_future<void> CompactFullAsync() EXCLUSIVE_LOCKS_REQUIRED(cs_main, !m_db_mutex);
+    std::shared_future<void> CompactFullAsync() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //! Return an underlying LevelDB property value, if available.
     std::optional<std::string> GetDBProperty(const std::string& property);

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -36,7 +36,7 @@ struct CoinsViewOptions {
 class CCoinsViewDB final : public CCoinsView
 {
 protected:
-    DBParams m_db_params;
+    const fs::path m_db_path;
     CoinsViewOptions m_options;
     std::unique_ptr<CDBWrapper> m_db;
     std::shared_future<void> m_compaction;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1930,7 +1930,6 @@ void Chainstate::InitCoinsDB(
     m_coins_views = std::make_unique<CoinsViews>(
         DBParams{
             .path = StoragePath(),
-            .cache_bytes = cache_size_bytes,
             .memory_only = in_memory,
             .wipe_data = should_wipe,
             .obfuscate = true,
@@ -5493,8 +5492,6 @@ bool Chainstate::ResizeCoinsCaches(size_t coinstip_size, size_t coinsdb_size)
     size_t old_coinstip_size = m_coinstip_cache_size_bytes;
     m_coinstip_cache_size_bytes = coinstip_size;
     m_coinsdb_cache_size_bytes = coinsdb_size;
-    CoinsDB().ResizeCache(coinsdb_size);
-
     LogInfo("[%s] resized coinsdb cache to %.1f MiB",
         this->ToString(), coinsdb_size / double(1_MiB));
     LogInfo("[%s] resized coinstip cache to %.1f MiB",

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1932,7 +1932,6 @@ void Chainstate::InitCoinsDB(bool in_memory, bool should_wipe)
             .obfuscate = true,
             .options = m_chainman.m_options.coins_db},
         m_chainman.m_options.coins_view);
-
 }
 
 void Chainstate::InitCoinsCache(size_t cache_size_bytes)
@@ -5477,7 +5476,7 @@ std::string Chainstate::ToString()
                      tip ? tip->nHeight : -1, tip ? tip->GetBlockHash().ToString() : "null");
 }
 
-bool Chainstate::ResizeCoinsCaches(size_t coinstip_size)
+bool Chainstate::ResizeCoinsCache(size_t coinstip_size)
 {
     AssertLockHeld(::cs_main);
     if (coinstip_size == m_coinstip_cache_size_bytes) {
@@ -5669,7 +5668,7 @@ util::Result<CBlockIndex*> ChainstateManager::ActivateSnapshot(
 
         // Temporarily resize the active coins cache to make room for the newly-created
         // snapshot chain.
-        this->ActiveChainstate().ResizeCoinsCaches(
+        this->ActiveChainstate().ResizeCoinsCache(
             static_cast<size_t>(current_coinstip_cache_size * IBD_CACHE_PERC));
     }
 
@@ -6100,22 +6099,22 @@ void ChainstateManager::MaybeRebalanceCaches()
     if (!historical_cs && !current_cs.m_from_snapshot_blockhash) {
         // Allocate everything to the IBD chainstate. This will always happen
         // when we are not using a snapshot.
-        current_cs.ResizeCoinsCaches(m_total_coinstip_cache);
+        current_cs.ResizeCoinsCache(m_total_coinstip_cache);
     } else if (!historical_cs) {
         // If background validation has completed and snapshot is our active chain...
         LogInfo("[snapshot] allocating all cache to the snapshot chainstate");
         // Allocate everything to the snapshot chainstate.
-        current_cs.ResizeCoinsCaches(m_total_coinstip_cache);
+        current_cs.ResizeCoinsCache(m_total_coinstip_cache);
     } else {
         // If both chainstates exist, determine who needs more cache based on IBD status.
         //
         // Note: shrink caches first so that we don't inadvertently overwhelm available memory.
         if (IsInitialBlockDownload()) {
-            historical_cs->ResizeCoinsCaches(m_total_coinstip_cache * 0.05);
-            current_cs.ResizeCoinsCaches(m_total_coinstip_cache * 0.95);
+            historical_cs->ResizeCoinsCache(m_total_coinstip_cache * 0.05);
+            current_cs.ResizeCoinsCache(m_total_coinstip_cache * 0.95);
         } else {
-            current_cs.ResizeCoinsCaches(m_total_coinstip_cache * 0.05);
-            historical_cs->ResizeCoinsCaches(m_total_coinstip_cache * 0.95);
+            current_cs.ResizeCoinsCache(m_total_coinstip_cache * 0.05);
+            historical_cs->ResizeCoinsCache(m_total_coinstip_cache * 0.95);
         }
     }
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1922,10 +1922,7 @@ void Chainstate::SetTargetBlockHash(uint256 block_hash)
     m_cached_target_block = nullptr;
 }
 
-void Chainstate::InitCoinsDB(
-    size_t cache_size_bytes,
-    bool in_memory,
-    bool should_wipe)
+void Chainstate::InitCoinsDB(bool in_memory, bool should_wipe)
 {
     m_coins_views = std::make_unique<CoinsViews>(
         DBParams{
@@ -1936,7 +1933,6 @@ void Chainstate::InitCoinsDB(
             .options = m_chainman.m_options.coins_db},
         m_chainman.m_options.coins_view);
 
-    m_coinsdb_cache_size_bytes = cache_size_bytes;
 }
 
 void Chainstate::InitCoinsCache(size_t cache_size_bytes)
@@ -5481,19 +5477,15 @@ std::string Chainstate::ToString()
                      tip ? tip->nHeight : -1, tip ? tip->GetBlockHash().ToString() : "null");
 }
 
-bool Chainstate::ResizeCoinsCaches(size_t coinstip_size, size_t coinsdb_size)
+bool Chainstate::ResizeCoinsCaches(size_t coinstip_size)
 {
     AssertLockHeld(::cs_main);
-    if (coinstip_size == m_coinstip_cache_size_bytes &&
-            coinsdb_size == m_coinsdb_cache_size_bytes) {
+    if (coinstip_size == m_coinstip_cache_size_bytes) {
         // Cache sizes are unchanged, no need to continue.
         return true;
     }
     size_t old_coinstip_size = m_coinstip_cache_size_bytes;
     m_coinstip_cache_size_bytes = coinstip_size;
-    m_coinsdb_cache_size_bytes = coinsdb_size;
-    LogInfo("[%s] resized coinsdb cache to %.1f MiB",
-        this->ToString(), coinsdb_size / double(1_MiB));
     LogInfo("[%s] resized coinstip cache to %.1f MiB",
         this->ToString(), coinstip_size / double(1_MiB));
 
@@ -5652,7 +5644,6 @@ util::Result<CBlockIndex*> ChainstateManager::ActivateSnapshot(
         }
     }
 
-    int64_t current_coinsdb_cache_size{0};
     int64_t current_coinstip_cache_size{0};
 
     // Cache percentages to allocate to each chainstate.
@@ -5674,14 +5665,12 @@ util::Result<CBlockIndex*> ChainstateManager::ActivateSnapshot(
         // the right allocation (including the possibility that no snapshot was activated
         // and that we should restore the active chainstate caches to their original size).
         //
-        current_coinsdb_cache_size = this->ActiveChainstate().m_coinsdb_cache_size_bytes;
         current_coinstip_cache_size = this->ActiveChainstate().m_coinstip_cache_size_bytes;
 
         // Temporarily resize the active coins cache to make room for the newly-created
         // snapshot chain.
         this->ActiveChainstate().ResizeCoinsCaches(
-            static_cast<size_t>(current_coinstip_cache_size * IBD_CACHE_PERC),
-            static_cast<size_t>(current_coinsdb_cache_size * IBD_CACHE_PERC));
+            static_cast<size_t>(current_coinstip_cache_size * IBD_CACHE_PERC));
     }
 
     auto snapshot_chainstate = WITH_LOCK(::cs_main,
@@ -5690,9 +5679,7 @@ util::Result<CBlockIndex*> ChainstateManager::ActivateSnapshot(
 
     {
         LOCK(::cs_main);
-        snapshot_chainstate->InitCoinsDB(
-            static_cast<size_t>(current_coinsdb_cache_size * SNAPSHOT_CACHE_PERC),
-            in_memory, /*should_wipe=*/false);
+        snapshot_chainstate->InitCoinsDB(in_memory, /*should_wipe=*/false);
         snapshot_chainstate->InitCoinsCache(
             static_cast<size_t>(current_coinstip_cache_size * SNAPSHOT_CACHE_PERC));
     }
@@ -6113,26 +6100,22 @@ void ChainstateManager::MaybeRebalanceCaches()
     if (!historical_cs && !current_cs.m_from_snapshot_blockhash) {
         // Allocate everything to the IBD chainstate. This will always happen
         // when we are not using a snapshot.
-        current_cs.ResizeCoinsCaches(m_total_coinstip_cache, m_total_coinsdb_cache);
+        current_cs.ResizeCoinsCaches(m_total_coinstip_cache);
     } else if (!historical_cs) {
         // If background validation has completed and snapshot is our active chain...
         LogInfo("[snapshot] allocating all cache to the snapshot chainstate");
         // Allocate everything to the snapshot chainstate.
-        current_cs.ResizeCoinsCaches(m_total_coinstip_cache, m_total_coinsdb_cache);
+        current_cs.ResizeCoinsCaches(m_total_coinstip_cache);
     } else {
         // If both chainstates exist, determine who needs more cache based on IBD status.
         //
         // Note: shrink caches first so that we don't inadvertently overwhelm available memory.
         if (IsInitialBlockDownload()) {
-            historical_cs->ResizeCoinsCaches(
-                m_total_coinstip_cache * 0.05, m_total_coinsdb_cache * 0.05);
-            current_cs.ResizeCoinsCaches(
-                m_total_coinstip_cache * 0.95, m_total_coinsdb_cache * 0.95);
+            historical_cs->ResizeCoinsCaches(m_total_coinstip_cache * 0.05);
+            current_cs.ResizeCoinsCaches(m_total_coinstip_cache * 0.95);
         } else {
-            current_cs.ResizeCoinsCaches(
-                m_total_coinstip_cache * 0.05, m_total_coinsdb_cache * 0.05);
-            historical_cs->ResizeCoinsCaches(
-                m_total_coinstip_cache * 0.95, m_total_coinsdb_cache * 0.95);
+            current_cs.ResizeCoinsCaches(m_total_coinstip_cache * 0.05);
+            historical_cs->ResizeCoinsCaches(m_total_coinstip_cache * 0.95);
         }
     }
 }

--- a/src/validation.h
+++ b/src/validation.h
@@ -721,7 +721,7 @@ public:
 
     //! Resize the in-memory coins cache dynamically and flush state to disk.
     //! @returns true unless an error occurred during the flush.
-    bool ResizeCoinsCaches(size_t coinstip_size)
+    bool ResizeCoinsCache(size_t coinstip_size)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /**
@@ -1310,7 +1310,7 @@ public:
     bool LoadBlockIndex() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //! Check to see if caches are out of balance and if so, call
-    //! ResizeCoinsCaches() as needed.
+    //! ResizeCoinsCache() as needed.
     void MaybeRebalanceCaches() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /**

--- a/src/validation.h
+++ b/src/validation.h
@@ -607,7 +607,6 @@ public:
      * All parameters forwarded to CoinsViews.
      */
     void InitCoinsDB(
-        size_t cache_size_bytes,
         bool in_memory,
         bool should_wipe);
 
@@ -717,15 +716,12 @@ public:
     //! Destructs all objects related to accessing the UTXO set.
     void ResetCoinsViews() { m_coins_views.reset(); }
 
-    //! The cache size of the on-disk coins view.
-    size_t m_coinsdb_cache_size_bytes{0};
-
     //! The cache size of the in-memory coins view.
     size_t m_coinstip_cache_size_bytes{0};
 
-    //! Resize the CoinsViews caches dynamically and flush state to disk.
+    //! Resize the in-memory coins cache dynamically and flush state to disk.
     //! @returns true unless an error occurred during the flush.
-    bool ResizeCoinsCaches(size_t coinstip_size, size_t coinsdb_size)
+    bool ResizeCoinsCaches(size_t coinstip_size)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /**
@@ -1085,10 +1081,6 @@ public:
     //! The total number of bytes available for us to use across all in-memory
     //! coins caches. This will be split somehow across chainstates.
     size_t m_total_coinstip_cache{0};
-    //
-    //! The total number of bytes available for us to use across all leveldb
-    //! coins databases. This will be split somehow across chainstates.
-    size_t m_total_coinsdb_cache{0};
 
     /// Ensures a genesis block is in the block tree, possibly writing one to disk.
     [[nodiscard]] bool LoadGenesisBlock();


### PR DESCRIPTION
```
for DBCACHE in 4000; do     COMMITS="3c76bd435681ee2ebaa1f407ac23736d9c3b331b ecb530c63dab1802dc756d14180730dc7e15e15b a479f8a071a6719b5ff6f389af3c3f4c0cf40c36 3c76bd435681ee2ebaa1f407ac23736d9c3b331b ecb530c63dab1802dc756d14180730dc7e15e15b a479f8a071a6719b5ff6f389af3c3f4c0cf40c36";     STOP=954459; CC=gcc; CXX=g++;     BASE_DIR="/mnt/my_storage"; DATA_DIR="$BASE_DIR/BitcoinData"; LOG_DIR="$BASE_DIR/logs";     (echo ""; for c in $COMMITS; do git fetch -q origin "$c" 2>/dev/null || true; git log -1 --pretty='%h %s' "$c" || exit 1; done) &&     (echo "" && echo "$(date -I) | reindex-chainstate | ${STOP} blocks | dbcache ${DBCACHE} | $(hostname) | $(uname -m) | $(lscpu | grep 'Model name' | head -1 | cut -d: -f2 | xargs) | $(nproc) threads | $(free -h | awk '/^Mem:/{print $2}') RAM | $(lsblk -no ROTA $(df --output=source $BASE_DIR | tail -1) | grep -q 1 && echo HDD || echo SSD)"; echo "") &&     hyperfine     --sort command     --runs 1     --export-json "$BASE_DIR/rdx-$(sed -E 's/([a-f0-9]{8})[a-f0-9]* ?/\1-/g;s/-$//'<<<"$COMMITS")-$STOP-$DBCACHE-$CC.json"     --parameter-list COMMIT ${COMMITS// /,}     --prepare "killall -9 bitcoind 2>/dev/null; rm -f ./build/bin/bitcoind; git clean -fxd; git reset --hard {COMMIT} && \                                                                                            
      CC=$CC CXX=$CXX cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release && ninja -C build bitcoind -j1 && \                                                                                                                        
        ./build/bin/bitcoind -datadir=$DATA_DIR -stopatheight=$STOP -printtoconsole=0 && sleep 20 && rm -f $DATA_DIR/debug.log && rm -rfd $DATA_DIR/indexes"       --conclude "killall bitcoind || true; sleep 5; \                 
        grep -q 'height=0' $DATA_DIR/debug.log && \                                                                                                                                                                                 
        grep -q 'Disabling script verification at block #1' $DATA_DIR/debug.log && \                                                                                                                                                
        grep -q 'height=$STOP' $DATA_DIR/debug.log && \                                                                                                                                                                             
        grep 'Bitcoin Core version' $DATA_DIR/debug.log | grep -q \"\$(git rev-parse --short=12 {COMMIT})\" && \                                                                                                                            cp $DATA_DIR/debug.log $LOG_DIR/debug-{COMMIT}-\$(date +%s).log"     "COMPILER=$CC ./build/bin/bitcoind -datadir=$DATA_DIR -stopatheight=$STOP -dbcache=$DBCACHE -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0"; done

3c76bd4356 Merge bitcoin/bitcoin#35603: build: QRencode cleanups
ecb530c63d db: avoid unused LevelDB block cache on 64-bit
a479f8a071 db: move unused block cache to write buffer
3c76bd4356 Merge bitcoin/bitcoin#35603: build: QRencode cleanups
ecb530c63d db: avoid unused LevelDB block cache on 64-bit
a479f8a071 db: move unused block cache to write buffer

2026-07-08 | reindex-chainstate | 954459 blocks | dbcache 4000 | i7-hdd | x86_64 | Intel(R) Core(TM) i7-7700 CPU @ 3.60GHz | 8 threads | 62Gi RAM | HDD

Benchmark 1: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=4000 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = 3c76bd435681ee2ebaa1f407ac23736d9c3b331b)
  Time (abs ≡):        29667.568 s               [User: 32229.503 s, System: 916.608 s]
 
Benchmark 2: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=4000 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = ecb530c63dab1802dc756d14180730dc7e
  Time (abs ≡):        29776.032 s               [User: 32244.086 s, System: 907.367 s]
 
Benchmark 3: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=4000 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = a479f8a071a6719b5ff6f389af3c3f4c0c
  Time (abs ≡):        30502.369 s               [User: 32286.714 s, System: 903.774 s]
 
Benchmark 4: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=4000 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = 3c76bd435681ee2ebaa1f407ac23736d9c3b331b)

  Time (abs ≡):        43182.197 s               [User: 32578.164 s, System: 931.049 s]
 
Benchmark 5: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=4000 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = ecb530c63dab1802dc756d14180730dc7e15e15b)
  Time (abs ≡):        29764.505 s               [User: 32270.846 s, System: 924.261 s]
 
Benchmark 6: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=4000 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = a479f8a071a6719b5ff6f389af3c3f4c0cf40c36)
 
  Time (abs ≡):        29733.517 s               [User: 32237.926 s, System: 921.858 s]
 
Relative speed comparison
        1.00          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=4000 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = 3c76bd435681ee2ebaa1f407ac23736d9c3b331b)
        1.00          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=4000 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = ecb530c63dab1802dc756d14180730dc7e15e15b)
        1.03          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=4000 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = a479f8a071a6719b5ff6f389af3c3f4c0cf40c36)
        1.46          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=4000 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = 3c76bd435681ee2ebaa1f407ac23736d9c3b331b)
        1.00          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=4000 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = ecb530c63dab1802dc756d14180730dc7e15e15b)
        1.00          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=954459 -dbcache=4000 -reindex-chainstate -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = a479f8a071a6719b5ff6f389af3c3f4c0cf40c36)
```