### PR TITLE
http: fix response framing after libevent removal

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -547,6 +547,7 @@ void HTTPRequest::WriteReply(HTTPStatusCode status, std::span<const std::byte> r
         if (m_version.minor == 0) {
             auto connection_header{m_headers.FindFirst("Connection")};
             if (!response_close && connection_header && ToLower(connection_header.value()) == "keep-alive") {
+                res.m_headers.RemoveAll("Connection");
                 res.m_headers.Write("Connection", "keep-alive");
                 keep_alive = true;
                 // HTTP/1.0 connections are closed by default so EOF is sufficient

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -527,7 +527,12 @@ void HTTPRequest::WriteReply(HTTPStatusCode status, std::span<const std::byte> r
 
     // See libevent evhttp_response_needs_body()
     // Response headers are different if no body is needed
-    bool needs_body{status != HTTP_NO_CONTENT && (status < 100 || status >= 200)};
+    bool needs_body{
+        m_method != HTTPRequestMethod::HEAD &&
+        status != HTTP_NO_CONTENT &&
+        (status < 100 || status >= 200)};
+    std::span<const std::byte> response_body{reply_body};
+    if (!needs_body) response_body = {};
     bool needs_content_length{false};
 
     bool keep_alive{false};
@@ -571,7 +576,7 @@ void HTTPRequest::WriteReply(HTTPStatusCode status, std::span<const std::byte> r
 
     if (needs_content_length) {
         res.m_headers.RemoveAll("Content-Length");
-        res.m_headers.Write("Content-Length", util::ToString(reply_body.size()));
+        res.m_headers.Write("Content-Length", util::ToString(response_body.size()));
     }
 
     if (needs_body && !res.m_headers.FindFirst("Content-Type")) {
@@ -604,14 +609,14 @@ void HTTPRequest::WriteReply(HTTPStatusCode status, std::span<const std::byte> r
         // We've been using std::span up until now but it is finally time to copy
         // data. The original data will go out of scope when WriteReply() returns.
         // This is analogous to the memcpy() in libevent's evbuffer_add()
-        m_client->m_send_buffer.insert(m_client->m_send_buffer.end(), reply_body.begin(), reply_body.end());
+        m_client->m_send_buffer.insert(m_client->m_send_buffer.end(), response_body.begin(), response_body.end());
     }
 
     LogDebug(
         BCLog::HTTP,
         "HTTPResponse (status code: %d size: %lld) added to send buffer for client %s (id=%llu)",
         status,
-        headers_bytes.size() + reply_body.size(),
+        headers_bytes.size() + response_body.size(),
         m_client->m_origin,
         m_client->m_id);
 

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -531,6 +531,14 @@ void HTTPRequest::WriteReply(HTTPStatusCode status, std::span<const std::byte> r
     bool needs_content_length{false};
 
     bool keep_alive{false};
+    bool response_close{false};
+
+    for (const std::string_view response_connection_header : res.m_headers.FindAll("Connection")) {
+        if (ToLower(response_connection_header) == "close") {
+            response_close = true;
+            break;
+        }
+    }
 
     // See libevent evhttp_make_header_response()
     // Expected response headers depend on protocol version
@@ -538,7 +546,7 @@ void HTTPRequest::WriteReply(HTTPStatusCode status, std::span<const std::byte> r
         // HTTP/1.0
         if (m_version.minor == 0) {
             auto connection_header{m_headers.FindFirst("Connection")};
-            if (connection_header && ToLower(connection_header.value()) == "keep-alive") {
+            if (!response_close && connection_header && ToLower(connection_header.value()) == "keep-alive") {
                 res.m_headers.Write("Connection", "keep-alive");
                 keep_alive = true;
                 // HTTP/1.0 connections are closed by default so EOF is sufficient
@@ -556,7 +564,7 @@ void HTTPRequest::WriteReply(HTTPStatusCode status, std::span<const std::byte> r
             if (needs_body) needs_content_length = true;
 
             // Default for HTTP/1.1
-            keep_alive = true;
+            keep_alive = !response_close;
         }
     }
 
@@ -570,7 +578,7 @@ void HTTPRequest::WriteReply(HTTPStatusCode status, std::span<const std::byte> r
     }
 
     auto connection_header{m_headers.FindFirst("Connection")};
-    if (connection_header && ToLower(connection_header.value()) == "close") {
+    if ((connection_header && ToLower(connection_header.value()) == "close") || response_close) {
         // Might not exist already but we need to replace it, not append to it
         res.m_headers.RemoveAll("Connection");
 

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -569,6 +569,7 @@ void HTTPRequest::WriteReply(HTTPStatusCode status, std::span<const std::byte> r
     }
 
     if (needs_content_length) {
+        res.m_headers.RemoveAll("Content-Length");
         res.m_headers.Write("Content-Length", util::ToString(reply_body.size()));
     }
 

--- a/src/test/httpserver_tests.cpp
+++ b/src/test/httpserver_tests.cpp
@@ -204,8 +204,46 @@ BOOST_AUTO_TEST_CASE(http_response_tests)
         "Content-Length: 41\r\n"
         "\r\n");
 
-    auto response_close_client{std::make_shared<HTTPRemoteClient>(
+    auto content_length_client{std::make_shared<HTTPRemoteClient>(
         /*id=*/0,
+        CService{},
+        std::make_unique<StaticContentsSock>(""))};
+    {
+        LOCK(content_length_client->m_send_mutex);
+        content_length_client->m_send_buffer.push_back(std::byte{'x'});
+    }
+
+    HTTPRequest content_length_req{content_length_client};
+    LineReader content_length_reader{"GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n", MAX_HEADERS_SIZE};
+    BOOST_REQUIRE(content_length_req.LoadControlData(content_length_reader));
+    BOOST_REQUIRE(content_length_req.LoadHeaders(content_length_reader));
+    BOOST_REQUIRE(content_length_req.LoadBody(content_length_reader));
+
+    content_length_client->m_req_busy = true;
+    content_length_req.WriteHeader("Content-Length", "999");
+    content_length_req.WriteReply(HTTP_OK, "abc");
+
+    const std::vector<std::byte> content_length_sent{WITH_LOCK(content_length_client->m_send_mutex, return content_length_client->m_send_buffer)};
+    BOOST_REQUIRE_GT(content_length_sent.size(), 1);
+    BOOST_CHECK_EQUAL(std::to_integer<unsigned char>(content_length_sent.front()), 'x');
+
+    std::string content_length_response;
+    content_length_response.reserve(content_length_sent.size() - 1);
+    for (auto it{content_length_sent.begin() + 1}; it != content_length_sent.end(); ++it) {
+        content_length_response.push_back(static_cast<char>(std::to_integer<unsigned char>(*it)));
+    }
+    BOOST_CHECK(content_length_response.starts_with("HTTP/1.0 200 OK\r\n"));
+    BOOST_CHECK(content_length_response.find("Connection: keep-alive\r\n") != std::string::npos);
+    BOOST_CHECK_EQUAL(CountOccurrences(content_length_response, "Content-Length: 3\r\n"), 1);
+    BOOST_CHECK_EQUAL(CountOccurrences(content_length_response, "Content-Length: "), 1);
+    BOOST_CHECK(content_length_response.find("Content-Type: text/html; charset=ISO-8859-1\r\n") != std::string::npos);
+    BOOST_CHECK(content_length_response.ends_with("\r\n\r\nabc"));
+    BOOST_CHECK(content_length_client->m_keep_alive.load());
+    BOOST_CHECK(content_length_client->m_send_ready.load());
+    BOOST_CHECK(!content_length_client->m_req_busy.load());
+
+    auto response_close_client{std::make_shared<HTTPRemoteClient>(
+        /*id=*/1,
         CService{},
         std::make_unique<StaticContentsSock>(""))};
     {

--- a/src/test/httpserver_tests.cpp
+++ b/src/test/httpserver_tests.cpp
@@ -220,6 +220,7 @@ BOOST_AUTO_TEST_CASE(http_response_tests)
     BOOST_REQUIRE(content_length_req.LoadBody(content_length_reader));
 
     content_length_client->m_req_busy = true;
+    content_length_req.WriteHeader("Connection", "keep-alive");
     content_length_req.WriteHeader("Content-Length", "999");
     content_length_req.WriteReply(HTTP_OK, "abc");
 
@@ -233,7 +234,8 @@ BOOST_AUTO_TEST_CASE(http_response_tests)
         content_length_response.push_back(static_cast<char>(std::to_integer<unsigned char>(*it)));
     }
     BOOST_CHECK(content_length_response.starts_with("HTTP/1.0 200 OK\r\n"));
-    BOOST_CHECK(content_length_response.find("Connection: keep-alive\r\n") != std::string::npos);
+    BOOST_CHECK_EQUAL(CountOccurrences(content_length_response, "Connection: keep-alive\r\n"), 1);
+    BOOST_CHECK_EQUAL(CountOccurrences(content_length_response, "Connection: "), 1);
     BOOST_CHECK_EQUAL(CountOccurrences(content_length_response, "Content-Length: 3\r\n"), 1);
     BOOST_CHECK_EQUAL(CountOccurrences(content_length_response, "Content-Length: "), 1);
     BOOST_CHECK(content_length_response.find("Content-Type: text/html; charset=ISO-8859-1\r\n") != std::string::npos);

--- a/src/test/httpserver_tests.cpp
+++ b/src/test/httpserver_tests.cpp
@@ -30,6 +30,15 @@ constexpr std::string_view full_request = "POST / HTTP/1.1\r\n"
                                           "\r\n"
                                           R"({"method":"getblockcount","params":[],"id":1})""\n";
 
+size_t CountOccurrences(std::string_view haystack, std::string_view needle)
+{
+    size_t count{0};
+    for (size_t pos{haystack.find(needle)}; pos != std::string_view::npos; pos = haystack.find(needle, pos + needle.size())) {
+        ++count;
+    }
+    return count;
+}
+
 BOOST_FIXTURE_TEST_SUITE(httpserver_tests, SocketTestingSetup)
 
 BOOST_AUTO_TEST_CASE(test_query_parameters)
@@ -194,6 +203,44 @@ BOOST_AUTO_TEST_CASE(http_response_tests)
         "HTTP/1.1 200 OK\r\n"
         "Content-Length: 41\r\n"
         "\r\n");
+
+    auto response_close_client{std::make_shared<HTTPRemoteClient>(
+        /*id=*/0,
+        CService{},
+        std::make_unique<StaticContentsSock>(""))};
+    {
+        LOCK(response_close_client->m_send_mutex);
+        response_close_client->m_send_buffer.push_back(std::byte{'x'});
+    }
+
+    HTTPRequest response_close_req{response_close_client};
+    LineReader response_close_reader{"GET / HTTP/1.1\r\n\r\n", MAX_HEADERS_SIZE};
+    BOOST_REQUIRE(response_close_req.LoadControlData(response_close_reader));
+    BOOST_REQUIRE(response_close_req.LoadHeaders(response_close_reader));
+    BOOST_REQUIRE(response_close_req.LoadBody(response_close_reader));
+
+    response_close_client->m_req_busy = true;
+    response_close_req.WriteHeader("Connection", "keep-alive");
+    response_close_req.WriteHeader("Connection", "close");
+    response_close_req.WriteReply(HTTP_INTERNAL_SERVER_ERROR, "boom");
+
+    const std::vector<std::byte> response_close_sent{WITH_LOCK(response_close_client->m_send_mutex, return response_close_client->m_send_buffer)};
+    BOOST_REQUIRE_GT(response_close_sent.size(), 1);
+    BOOST_CHECK_EQUAL(std::to_integer<unsigned char>(response_close_sent.front()), 'x');
+
+    std::string response_close_response;
+    response_close_response.reserve(response_close_sent.size() - 1);
+    for (auto it{response_close_sent.begin() + 1}; it != response_close_sent.end(); ++it) {
+        response_close_response.push_back(static_cast<char>(std::to_integer<unsigned char>(*it)));
+    }
+    BOOST_CHECK(response_close_response.starts_with("HTTP/1.1 500 Internal Server Error\r\n"));
+    BOOST_CHECK_EQUAL(CountOccurrences(response_close_response, "Connection: close\r\n"), 1);
+    BOOST_CHECK_EQUAL(CountOccurrences(response_close_response, "Connection: keep-alive\r\n"), 0);
+    BOOST_CHECK(response_close_response.find("Content-Length: 4\r\n") != std::string::npos);
+    BOOST_CHECK(response_close_response.ends_with("\r\n\r\nboom"));
+    BOOST_CHECK(!response_close_client->m_keep_alive.load());
+    BOOST_CHECK(response_close_client->m_send_ready.load());
+    BOOST_CHECK(!response_close_client->m_req_busy.load());
 }
 
 BOOST_AUTO_TEST_CASE(http_request_tests)

--- a/src/test/httpserver_tests.cpp
+++ b/src/test/httpserver_tests.cpp
@@ -281,6 +281,71 @@ BOOST_AUTO_TEST_CASE(http_response_tests)
     BOOST_CHECK(!response_close_client->m_keep_alive.load());
     BOOST_CHECK(response_close_client->m_send_ready.load());
     BOOST_CHECK(!response_close_client->m_req_busy.load());
+
+    auto head_pipes{std::make_shared<DynSock::Pipes>()};
+    auto head_client{std::make_shared<HTTPRemoteClient>(
+        /*id=*/2,
+        CService{},
+        std::make_unique<DynSock>(head_pipes))};
+
+    HTTPRequest head_req{head_client};
+    LineReader head_reader("HEAD / HTTP/1.1\r\n\r\n", MAX_HEADERS_SIZE);
+    BOOST_REQUIRE(head_req.LoadControlData(head_reader));
+    BOOST_REQUIRE(head_req.LoadHeaders(head_reader));
+    BOOST_REQUIRE(head_req.LoadBody(head_reader));
+
+    head_client->m_req_busy = true;
+    head_req.WriteReply(HTTP_OK, "abc");
+
+    WITH_LOCK(head_client->m_sock_mutex, head_client->m_sock.reset());
+    std::array<char, 1024> head_sent{};
+    const ssize_t head_sent_size{
+        head_pipes->send.GetBytes(head_sent.data(), head_sent.size())};
+    BOOST_REQUIRE_GT(head_sent_size, 0);
+    const std::string head_response{
+        head_sent.data(),
+        static_cast<size_t>(head_sent_size)};
+    BOOST_CHECK(head_response.starts_with("HTTP/1.1 200 OK\r\n"));
+    BOOST_CHECK(head_response.find("Content-Length: ") == std::string::npos);
+    BOOST_CHECK(head_response.find("Content-Type: ") == std::string::npos);
+    const size_t head_body_start{head_response.find("\r\n\r\n")};
+    BOOST_REQUIRE(head_body_start != std::string::npos);
+    BOOST_CHECK_EQUAL(head_response.substr(head_body_start + 4), "");
+    BOOST_CHECK(head_client->m_keep_alive.load());
+    BOOST_CHECK(!head_client->m_req_busy.load());
+
+    auto no_content_pipes{std::make_shared<DynSock::Pipes>()};
+    auto no_content_client{std::make_shared<HTTPRemoteClient>(
+        /*id=*/3,
+        CService{},
+        std::make_unique<DynSock>(no_content_pipes))};
+
+    HTTPRequest no_content_req{no_content_client};
+    LineReader no_content_reader{"GET / HTTP/1.1\r\nConnection: close\r\n\r\n", MAX_HEADERS_SIZE};
+    BOOST_REQUIRE(no_content_req.LoadControlData(no_content_reader));
+    BOOST_REQUIRE(no_content_req.LoadHeaders(no_content_reader));
+    BOOST_REQUIRE(no_content_req.LoadBody(no_content_reader));
+
+    no_content_client->m_req_busy = true;
+    no_content_req.WriteReply(HTTP_NO_CONTENT, "abc");
+
+    WITH_LOCK(no_content_client->m_sock_mutex, no_content_client->m_sock.reset());
+    std::array<char, 1024> no_content_sent{};
+    const ssize_t no_content_sent_size{
+        no_content_pipes->send.GetBytes(no_content_sent.data(), no_content_sent.size())};
+    BOOST_REQUIRE_GT(no_content_sent_size, 0);
+    const std::string no_content_response{
+        no_content_sent.data(),
+        static_cast<size_t>(no_content_sent_size)};
+    BOOST_CHECK(no_content_response.starts_with("HTTP/1.1 204 No Content\r\n"));
+    BOOST_CHECK(no_content_response.find("Connection: close\r\n") != std::string::npos);
+    BOOST_CHECK(no_content_response.find("Content-Length: ") == std::string::npos);
+    BOOST_CHECK(no_content_response.find("Content-Type: ") == std::string::npos);
+    const size_t no_content_body_start{no_content_response.find("\r\n\r\n")};
+    BOOST_REQUIRE(no_content_body_start != std::string::npos);
+    BOOST_CHECK_EQUAL(no_content_response.substr(no_content_body_start + 4), "");
+    BOOST_CHECK(no_content_client->m_disconnect.load());
+    BOOST_CHECK(!no_content_client->m_req_busy.load());
 }
 
 BOOST_AUTO_TEST_CASE(http_request_tests)


### PR DESCRIPTION
**Problem:** The in-tree HTTP server added in #35182 still had a few response-framing mismatches around generated headers, connection reuse, and bodyless responses.

The clearest libevent parity issue is response-side `Connection: close`: the worker exception path already writes that header before returning a 500 response, but the new server could still keep the HTTP/1.1 connection alive. Libevent checks response output headers in its close predicate and uses that predicate when deciding whether to free or reuse the connection:
https://github.com/libevent/libevent/blob/release-2.1.12-stable/http.c#L480-L487
https://github.com/libevent/libevent/blob/release-2.1.12-stable/http.c#L2777-L2792

There were also local framing issues when generated `Content-Length` or `Connection: keep-alive` headers were appended after stale caller-provided values, and when HEAD or 204 responses were given body bytes.

**Fix:** Make `HTTPRequest::WriteReply()` own the final response-framing decisions:

* honor response-side `Connection: close` when deciding connection reuse
* replace stale caller-provided `Content-Length` before writing the computed value
* replace stale response `Connection` values before generated HTTP/1.0 keep-alive
* suppress bodies and generated body headers for HEAD and 204 responses

The HEAD behavior intentionally follows RFC 9110 section 9.3.2 rather than libevent's raw output-buffer append, because `WriteReply()` is the common layer that sees both the request method and final response status.