### PR TITLE
validation, net: avoid small temporary copies

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -515,8 +515,9 @@ CNode* CConnman::ConnectNode(CAddress addrConnect,
         }
 
         NetPermissionFlags permission_flags = NetPermissionFlags::None;
-        std::vector<NetWhitelistPermissions> whitelist_permissions = conn_type == ConnectionType::MANUAL ? vWhitelistedRangeOutgoing : std::vector<NetWhitelistPermissions>{};
-        AddWhitelistPermissionFlags(permission_flags, target_addr, whitelist_permissions);
+        if (conn_type == ConnectionType::MANUAL) {
+            AddWhitelistPermissionFlags(permission_flags, target_addr, vWhitelistedRangeOutgoing);
+        }
 
         // Add node
         NodeId id = GetNewNodeId();
@@ -3452,7 +3453,7 @@ CConnman::CConnman(uint64_t nSeed0In,
     , m_netgroupman{netgroupman}
     , nSeed0(nSeed0In)
     , nSeed1(nSeed1In)
-    , m_interrupt_net{interrupt_net}
+    , m_interrupt_net{std::move(interrupt_net)}
     , m_params(params)
 {
     SetTryNewOutboundPeer(false);
@@ -4059,7 +4060,7 @@ CNode::CNode(NodeId idIn,
              CNodeOptions&& node_opts)
     : m_transport{MakeTransport(idIn, node_opts.use_v2transport, conn_type_in == ConnectionType::INBOUND)},
       m_permission_flags{node_opts.permission_flags},
-      m_sock{sock},
+      m_sock{std::move(sock)},
       m_connected{NodeClock::now()},
       m_proxy_override{std::move(node_opts.proxy_override)},
       addr{addrIn},

--- a/src/net.h
+++ b/src/net.h
@@ -1421,7 +1421,7 @@ private:
         std::shared_ptr<Sock> sock;
         inline void AddSocketPermissionFlags(NetPermissionFlags& flags) const { NetPermissions::AddFlag(flags, m_permissions); }
         ListenSocket(std::shared_ptr<Sock> sock_, NetPermissionFlags permissions_)
-            : sock{sock_}, m_permissions{permissions_}
+            : sock{std::move(sock_)}, m_permissions{permissions_}
         {
         }
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -5090,6 +5090,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         vRecv >> vInv;
         std::vector<GenTxid> tx_invs;
         if (vInv.size() <= node::MAX_PEER_TX_ANNOUNCEMENTS + MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
+            tx_invs.reserve(vInv.size());
             for (CInv &inv : vInv) {
                 if (inv.IsGenTxMsg()) {
                     tx_invs.emplace_back(ToGenTxid(inv));

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1303,11 +1303,11 @@ bool MemPoolAccept::SubmitPackage(const ATMPArgs& args, std::vector<Workspace>& 
         Assume(iter.has_value());
         const auto effective_feerate = args.m_package_feerates ? ws.m_package_feerate :
             CFeeRate{ws.m_modified_fees, static_cast<int32_t>(ws.m_vsize)};
-        const auto effective_feerate_wtxids = args.m_package_feerates ? all_package_wtxids :
-            std::vector<Wtxid>{ws.m_ptx->GetWitnessHash()};
         results.emplace(ws.m_ptx->GetWitnessHash(),
                         MempoolAcceptResult::Success(std::move(m_subpackage.m_replaced_transactions), ws.m_vsize,
-                                         ws.m_base_fees, effective_feerate, effective_feerate_wtxids));
+                                         ws.m_base_fees, effective_feerate, args.m_package_feerates ?
+                                             all_package_wtxids :
+                                             std::vector<Wtxid>{ws.m_ptx->GetWitnessHash()}));
         if (!m_pool.m_opts.signals) continue;
         const CTransaction& tx = *ws.m_ptx;
         const auto tx_info = NewMempoolTransactionInfo(ws.m_ptx, ws.m_base_fees,
@@ -1550,12 +1550,12 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptMultipleTransactionsInternal(con
         if (args.m_test_accept) {
             const auto effective_feerate = args.m_package_feerates ? ws.m_package_feerate :
                 CFeeRate{ws.m_modified_fees, static_cast<int32_t>(ws.m_vsize)};
-            const auto effective_feerate_wtxids = args.m_package_feerates ? all_package_wtxids :
-                std::vector<Wtxid>{ws.m_ptx->GetWitnessHash()};
             results.emplace(ws.m_ptx->GetWitnessHash(),
                             MempoolAcceptResult::Success(std::move(m_subpackage.m_replaced_transactions),
                                                          ws.m_vsize, ws.m_base_fees, effective_feerate,
-                                                         effective_feerate_wtxids));
+                                                         args.m_package_feerates ?
+                                                             all_package_wtxids :
+                                                             std::vector<Wtxid>{ws.m_ptx->GetWitnessHash()}));
         }
     }
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -165,22 +165,22 @@ struct MempoolAcceptResult {
     const std::optional<Wtxid> m_other_wtxid;
 
     static MempoolAcceptResult Failure(TxValidationState state) {
-        return MempoolAcceptResult(state);
+        return MempoolAcceptResult(std::move(state));
     }
 
     static MempoolAcceptResult FeeFailure(TxValidationState state,
                                           CFeeRate effective_feerate,
-                                          const std::vector<Wtxid>& wtxids_fee_calculations) {
-        return MempoolAcceptResult(state, effective_feerate, wtxids_fee_calculations);
+                                          std::vector<Wtxid> wtxids_fee_calculations) {
+        return MempoolAcceptResult(std::move(state), std::move(effective_feerate), std::move(wtxids_fee_calculations));
     }
 
     static MempoolAcceptResult Success(std::list<CTransactionRef>&& replaced_txns,
                                        int64_t vsize,
                                        CAmount fees,
                                        CFeeRate effective_feerate,
-                                       const std::vector<Wtxid>& wtxids_fee_calculations) {
+                                       std::vector<Wtxid> wtxids_fee_calculations) {
         return MempoolAcceptResult(std::move(replaced_txns), vsize, fees,
-                                   effective_feerate, wtxids_fee_calculations);
+                                   std::move(effective_feerate), std::move(wtxids_fee_calculations));
     }
 
     static MempoolAcceptResult MempoolTx(int64_t vsize, CAmount fees) {
@@ -195,8 +195,8 @@ struct MempoolAcceptResult {
 private:
     /** Constructor for failure case */
     explicit MempoolAcceptResult(TxValidationState state)
-        : m_result_type(ResultType::INVALID), m_state(state) {
-            Assume(!state.IsValid()); // Can be invalid or error
+        : m_result_type(ResultType::INVALID), m_state{std::move(state)} {
+            Assume(!m_state.IsValid()); // Can be invalid or error
         }
 
     /** Constructor for success case */
@@ -204,22 +204,22 @@ private:
                                  int64_t vsize,
                                  CAmount fees,
                                  CFeeRate effective_feerate,
-                                 const std::vector<Wtxid>& wtxids_fee_calculations)
+                                 std::vector<Wtxid> wtxids_fee_calculations)
         : m_result_type(ResultType::VALID),
         m_replaced_transactions(std::move(replaced_txns)),
         m_vsize{vsize},
         m_base_fees(fees),
-        m_effective_feerate(effective_feerate),
-        m_wtxids_fee_calculations(wtxids_fee_calculations) {}
+        m_effective_feerate{std::move(effective_feerate)},
+        m_wtxids_fee_calculations{std::move(wtxids_fee_calculations)} {}
 
     /** Constructor for fee-related failure case */
     explicit MempoolAcceptResult(TxValidationState state,
                                  CFeeRate effective_feerate,
-                                 const std::vector<Wtxid>& wtxids_fee_calculations)
+                                 std::vector<Wtxid> wtxids_fee_calculations)
         : m_result_type(ResultType::INVALID),
-        m_state(state),
-        m_effective_feerate(effective_feerate),
-        m_wtxids_fee_calculations(wtxids_fee_calculations) {}
+        m_state{std::move(state)},
+        m_effective_feerate{std::move(effective_feerate)},
+        m_wtxids_fee_calculations{std::move(wtxids_fee_calculations)} {}
 
     /** Constructor for already-in-mempool case. It wouldn't replace any transactions. */
     explicit MempoolAcceptResult(int64_t vsize, CAmount fees)
@@ -246,11 +246,11 @@ struct PackageMempoolAcceptResult
 
     explicit PackageMempoolAcceptResult(PackageValidationState state,
                                         std::map<Wtxid, MempoolAcceptResult>&& results)
-        : m_state{state}, m_tx_results(std::move(results)) {}
+        : m_state{std::move(state)}, m_tx_results(std::move(results)) {}
 
     explicit PackageMempoolAcceptResult(PackageValidationState state, CFeeRate feerate,
                                         std::map<Wtxid, MempoolAcceptResult>&& results)
-        : m_state{state}, m_tx_results(std::move(results)) {}
+        : m_state{std::move(state)}, m_tx_results(std::move(results)) {}
 
     /** Constructor to create a PackageMempoolAcceptResult from a single MempoolAcceptResult */
     explicit PackageMempoolAcceptResult(const Wtxid& wtxid, const MempoolAcceptResult& result)


### PR DESCRIPTION
**Problem:** Mempool accept result construction still copies validation state and fee-calculation txids before storing them, while a few net paths copy setup pointers or grow bounded temporary vectors unnecessarily.

**Fix:** Move those values into their final owners, avoid building an empty outgoing whitelist-permission vector for non-manual connections, and reserve the bounded `NOTFOUND` txid vector before filtering it.
