### PR TITLE
db: avoid exhausted iterator access

### DIFF
--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -159,6 +159,7 @@ public:
     void Next();
 
     template<typename K> bool GetKey(K& key) {
+        if (!Valid()) return false;
         try {
             SpanReader ssKey{GetKeyImpl()};
             ssKey >> key;
@@ -169,6 +170,7 @@ public:
     }
 
     template<typename V> bool GetValue(V& value) {
+        if (!Valid()) return false;
         try {
             ScopedDataStreamUsage scoped_scratch{m_scratch};
             m_scratch.write(GetValueImpl());

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -1083,6 +1083,16 @@ BOOST_FIXTURE_TEST_CASE(coins_db_leveldb_layout, FlushTest)
 
     BOOST_CHECK(*Assert(base.GetCoin(outpoint)) == coin);
     BOOST_CHECK_EQUAL(base.GetBestBlock(), block_hash);
+
+    auto cursor{base.Cursor()};
+    BOOST_REQUIRE(cursor->Valid());
+    cursor->Next();
+    BOOST_CHECK(!cursor->Valid());
+
+    COutPoint cursor_outpoint;
+    BOOST_CHECK(!cursor->GetKey(cursor_outpoint));
+    Coin cursor_coin;
+    BOOST_CHECK(!cursor->GetValue(cursor_coin));
 }
 
 BOOST_AUTO_TEST_CASE(coins_resource_is_used)

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -253,6 +253,8 @@ BOOST_AUTO_TEST_CASE(dbwrapper_iterator)
 
         it->Next();
         BOOST_CHECK_EQUAL(it->Valid(), false);
+        BOOST_CHECK(!it->GetKey(key_res));
+        BOOST_CHECK(!it->GetValue(val_res));
     }
 }
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -268,7 +268,10 @@ bool CCoinsViewDBCursor::GetKey(COutPoint &key) const
 
 bool CCoinsViewDBCursor::GetValue(Coin &coin) const
 {
-    return pcursor->GetValue(coin);
+    if (!Valid()) return false;
+    const bool found{pcursor->GetValue(coin)};
+    Assume(!found || !coin.IsSpent());
+    return found;
 }
 
 bool CCoinsViewDBCursor::Valid() const


### PR DESCRIPTION
**Problem:** Advancing a DB iterator or coins cursor past the last entry it represents should make later key/value access fail at the wrapper boundary.
`CDBIterator::GetKey()`/`GetValue()` could still call `leveldb::Iterator::key()`/`value()` after the underlying iterator was exhausted.
`CCoinsViewDBCursor::GetValue()` could also ignore the coins cursor's own `Valid()` state, which is based on the cached key type.
LevelDB documents those accessors as requiring a valid iterator, and debug builds assert that precondition:
https://github.com/bitcoin/bitcoin/blob/2990bd773551c835ab0b6b59d85730adab2fd428/src/leveldb/include/leveldb/iterator.h#L60-L70
https://github.com/bitcoin/bitcoin/blob/2990bd773551c835ab0b6b59d85730adab2fd428/src/leveldb/db/db_iter.cc#L63-L70

**Fix:** Return false before decoding when the iterator/cursor is no longer valid.
The coins cursor keeps its own guard because it can be invalid while the underlying `CDBIterator` is still positioned on another DB record; `GetValue()` also now `Assume`s that successfully read coins are unspent.
The existing iterator tests cover access after exhaustion.
