### PR TITLE
validation: avoid preallocating unused txdata during assumevalid

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2514,10 +2514,12 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
 
     // Precomputed transaction data pointers must not be invalidated
     // until after `control` has run the script checks (potentially
-    // in multiple threads). Preallocate the vector size so a new allocation
+    // in multiple threads). Preallocate the vector size after assumevalid
     // doesn't invalidate pointers into the vector, and keep txsdata in scope
     // for as long as `control`.
-    std::vector<PrecomputedTransactionData> txsdata(block.vtx.size());
+    std::vector<PrecomputedTransactionData> txsdata;
+    if (fScriptChecks) txsdata.resize(block.vtx.size());
+
     std::optional<CCheckQueueControl<CScriptCheck>> control;
     if (auto& queue = m_chainman.GetCheckQueue(); queue.HasThreads() && fScriptChecks) control.emplace(queue);
 
@@ -2578,6 +2580,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
 
         if (!tx.IsCoinBase() && fScriptChecks)
         {
+            assert(i < txsdata.size());
             bool fCacheResults = fJustCheck; /* Don't cache results if we're actually connecting blocks (still consult the cache, though) */
             bool tx_ok;
             TxValidationState tx_state;


### PR DESCRIPTION
**Problem:** During IBD and reindex, `ConnectBlock()` skips script verification for blocks in the `assumevalid` period.
However, it still performs one heap allocation for a fresh `txsdata` vector and default-constructs one `PrecomputedTransactionData` entry for every transaction in each connected block.
Because `CheckInputScripts()` is not called in that path, that work is unused and only adds allocator churn and avoidable heap fragmentation on large blocks.

**Fix:** Leave `txsdata` empty unless `fScriptChecks` is true, then resize it before queued checks can take pointers into the vector.
Update the lifetime comment and add an indexed-use assert that matches the real precondition.

**Reproducer:** On a synthetic ~7000-transaction block, the skipped-check path avoids the unused heap allocation and saves ~2MB memory per block.
<details><summary>ConnectBlockAllSchnorr mem usage: 7000 txs, num_schnorr=1, num_ecdsa=0, fScriptChecks=false</summary>

```bash
for C in 1835f2fcbf482035e1c11c72ae39cee4e24e4c00 832dc594f72bb6e8415674dce434684202073b12; do
  git reset --hard -q && git checkout -q "$C"
  perl -0pi -e 's/(num_txs = )1000/${1}7000/; s@(/\*num_schnorr=\*/)\d+, (/\*num_ecdsa=\*/)\d+@${1}1, ${2}0@; s/(fScriptChecks)\{[^}]+\};/${1}{false};/;' src/bench/connectblock.cpp src/validation.cpp
  cmake -B build -DBUILD_BENCH=ON >/dev/null 2>&1 && cmake --build build --target bench_bitcoin >/dev/null 2>&1
  /usr/bin/time -v build/bin/bench_bitcoin -filter=ConnectBlockAllSchnorr -sanity-check 2>&1 >/dev/null | grep 'Maximum resident'
done
```

> 1835f2fcbf ... Maximum resident set size: 58704 kB
> 832dc594f7 ... Maximum resident set size: 56664 kB
</details>