### PR TITLE
validation: keep failed blocks out of candidates

### DIFF
--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -4,10 +4,12 @@
 //
 #include <chainparams.h>
 #include <consensus/validation.h>
+#include <flatfile.h>
 #include <kernel/disconnected_transactions.h>
 #include <node/chainstatemanager_args.h>
 #include <node/kernel_notifications.h>
 #include <node/utxo_snapshot.h>
+#include <primitives/block.h>
 #include <random.h>
 #include <rpc/blockchain.h>
 #include <sync.h>
@@ -26,6 +28,7 @@
 
 #include <tinyformat.h>
 
+#include <cstddef>
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
@@ -33,6 +36,27 @@
 using node::BlockManager;
 using node::KernelNotifications;
 using node::SnapshotMetadata;
+
+namespace {
+CBlockHeader ChildHeader(const CBlockIndex& parent, uint32_t nonce)
+{
+    CBlockHeader header;
+    header.nVersion = 4;
+    header.hashPrevBlock = parent.GetBlockHash();
+    header.hashMerkleRoot = uint256{static_cast<uint8_t>(nonce)};
+    header.nTime = parent.GetBlockTime() + 1;
+    header.nBits = Params().GenesisBlock().nBits;
+    header.nNonce = nonce;
+    return header;
+}
+
+CBlock DummyBlockWithTransactions(size_t tx_count)
+{
+    CBlock block;
+    block.vtx.resize(tx_count);
+    return block;
+}
+} // namespace
 
 BOOST_FIXTURE_TEST_SUITE(validation_chainstatemanager_tests, TestingSetup)
 
@@ -617,6 +641,46 @@ BOOST_FIXTURE_TEST_CASE(loadblockindex_invalid_descendants, TestChain100Setup)
     BOOST_CHECK(grand_parent->nStatus & BLOCK_FAILED_VALID);
     BOOST_CHECK(parent->nStatus & BLOCK_FAILED_VALID);
     BOOST_CHECK(child->nStatus & BLOCK_FAILED_VALID);
+}
+
+BOOST_FIXTURE_TEST_CASE(received_block_transactions_skips_failed_unlinked_child, TestChain100Setup)
+{
+    ChainstateManager& chainman{*Assert(m_node.chainman)};
+    Chainstate& chainstate{chainman.ActiveChainstate()};
+    CBlockIndex* parent;
+    CBlockIndex* child;
+
+    {
+        LOCK(chainman.GetMutex());
+        CBlockIndex* tip{chainman.ActiveChain().Tip()};
+        parent = chainman.m_blockman.AddToBlockIndex(ChildHeader(*tip, /*nonce=*/1), chainman.m_best_header);
+        child = chainman.m_blockman.AddToBlockIndex(ChildHeader(*parent, /*nonce=*/2), chainman.m_best_header);
+
+        CBlock child_block{DummyBlockWithTransactions(/*tx_count=*/1)};
+        chainman.ReceivedBlockTransactions(child_block, child, FlatFilePos{0, 1});
+        BOOST_CHECK(child->nStatus & BLOCK_HAVE_DATA);
+        BOOST_CHECK(!child->HaveNumChainTxs());
+    }
+
+    BlockValidationState state;
+    BOOST_REQUIRE(chainstate.InvalidateBlock(state, child));
+
+    {
+        LOCK(chainman.GetMutex());
+        BOOST_REQUIRE(child->nStatus & BLOCK_FAILED_VALID);
+        BOOST_CHECK_EQUAL(chainstate.setBlockIndexCandidates.count(child), 0U);
+
+        CBlock parent_block{DummyBlockWithTransactions(/*tx_count=*/1)};
+        chainman.ReceivedBlockTransactions(parent_block, parent, FlatFilePos{0, 2});
+
+        BOOST_CHECK(parent->HaveNumChainTxs());
+        BOOST_CHECK(child->HaveNumChainTxs());
+        BOOST_CHECK(child->nStatus & BLOCK_FAILED_VALID);
+        BOOST_CHECK_EQUAL(chainstate.setBlockIndexCandidates.count(child), 0U);
+        BOOST_CHECK_EQUAL(chainstate.setBlockIndexCandidates.count(parent), 1U);
+    }
+
+    chainman.CheckBlockIndex();
 }
 
 //! Verify that ReconsiderBlock clears failure flags for the target block, its ancestors, and descendants,

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -683,6 +683,75 @@ BOOST_FIXTURE_TEST_CASE(received_block_transactions_skips_failed_unlinked_child,
     chainman.CheckBlockIndex();
 }
 
+BOOST_FIXTURE_TEST_CASE(invalidate_block_removes_out_of_chain_candidate, TestChain100Setup)
+{
+    ChainstateManager& chainman{*Assert(m_node.chainman)};
+    Chainstate& chainstate{chainman.ActiveChainstate()};
+    CBlockIndex* parent;
+    CBlockIndex* child;
+
+    {
+        LOCK(chainman.GetMutex());
+        CBlockIndex* tip{chainman.ActiveChain().Tip()};
+        parent = chainman.m_blockman.AddToBlockIndex(ChildHeader(*tip, /*nonce=*/3), chainman.m_best_header);
+        child = chainman.m_blockman.AddToBlockIndex(ChildHeader(*parent, /*nonce=*/4), chainman.m_best_header);
+
+        CBlock parent_block{DummyBlockWithTransactions(/*tx_count=*/1)};
+        chainman.ReceivedBlockTransactions(parent_block, parent, FlatFilePos{0, 3});
+        CBlock child_block{DummyBlockWithTransactions(/*tx_count=*/1)};
+        chainman.ReceivedBlockTransactions(child_block, child, FlatFilePos{0, 4});
+        BOOST_REQUIRE(parent->HaveNumChainTxs());
+        BOOST_REQUIRE(child->HaveNumChainTxs());
+        BOOST_CHECK_EQUAL(chainstate.setBlockIndexCandidates.count(parent), 1U);
+        BOOST_CHECK_EQUAL(chainstate.setBlockIndexCandidates.count(child), 1U);
+    }
+
+    BlockValidationState state;
+    BOOST_REQUIRE(chainstate.InvalidateBlock(state, parent));
+
+    {
+        LOCK(chainman.GetMutex());
+        BOOST_CHECK(parent->nStatus & BLOCK_FAILED_VALID);
+        BOOST_CHECK(child->nStatus & BLOCK_FAILED_VALID);
+        BOOST_CHECK_EQUAL(chainstate.setBlockIndexCandidates.count(parent), 0U);
+        BOOST_CHECK_EQUAL(chainstate.setBlockIndexCandidates.count(child), 0U);
+    }
+
+    chainman.CheckBlockIndex();
+}
+
+BOOST_FIXTURE_TEST_CASE(invalidate_block_removes_out_of_chain_descendant_during_disconnect, TestChain100Setup)
+{
+    ChainstateManager& chainman{*Assert(m_node.chainman)};
+    Chainstate& chainstate{chainman.ActiveChainstate()};
+    CBlockIndex* tip;
+    CBlockIndex* child;
+
+    {
+        LOCK(chainman.GetMutex());
+        tip = chainman.ActiveChain().Tip();
+        child = chainman.m_blockman.AddToBlockIndex(ChildHeader(*tip, /*nonce=*/5), chainman.m_best_header);
+
+        CBlock child_block{DummyBlockWithTransactions(/*tx_count=*/1)};
+        chainman.ReceivedBlockTransactions(child_block, child, FlatFilePos{0, 5});
+        BOOST_REQUIRE(child->HaveNumChainTxs());
+        BOOST_CHECK_EQUAL(chainstate.setBlockIndexCandidates.count(child), 1U);
+    }
+
+    BlockValidationState state;
+    BOOST_REQUIRE(chainstate.InvalidateBlock(state, tip));
+
+    {
+        LOCK(chainman.GetMutex());
+        BOOST_CHECK(tip->nStatus & BLOCK_FAILED_VALID);
+        BOOST_CHECK(child->nStatus & BLOCK_FAILED_VALID);
+        BOOST_CHECK_EQUAL(chainstate.setBlockIndexCandidates.count(tip), 0U);
+        BOOST_CHECK_EQUAL(chainstate.setBlockIndexCandidates.count(child), 0U);
+    }
+
+    chainman.CheckBlockIndex();
+}
+
 //! Verify that ReconsiderBlock clears failure flags for the target block, its ancestors, and descendants,
 //! but not for sibling forks that diverge from a shared ancestor.
 BOOST_FIXTURE_TEST_CASE(invalidate_block_and_reconsider_fork, TestChain100Setup)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3528,6 +3528,14 @@ bool Chainstate::PreciousBlock(BlockValidationState& state, CBlockIndex* pindex)
     return ActivateBestChain(state, std::shared_ptr<const CBlock>());
 }
 
+static void RemoveBlockIndexCandidate(ChainstateManager& chainman, CBlockIndex& block) EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
+{
+    AssertLockHeld(::cs_main);
+    for (const auto& chainstate : chainman.m_chainstates) {
+        chainstate->setBlockIndexCandidates.erase(&block);
+    }
+}
+
 bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* const pindex)
 {
     AssertLockNotHeld(m_chainstate_mutex);
@@ -3608,7 +3616,7 @@ bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* const
         // nStatus" criteria for inclusion in setBlockIndexCandidates).
         disconnected_tip->nStatus |= BLOCK_FAILED_VALID;
         m_blockman.m_dirty_blockindex.insert(disconnected_tip);
-        setBlockIndexCandidates.erase(disconnected_tip);
+        RemoveBlockIndexCandidate(m_chainman, *disconnected_tip);
         setBlockIndexCandidates.insert(new_tip);
 
         // Mark out-of-chain descendants of the invalidated block as invalid
@@ -3630,6 +3638,7 @@ bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* const
                 m_blockman.m_dirty_blockindex.insert(candidate);
                 // If invalidated, the block is irrelevant for setBlockIndexCandidates
                 // and for m_best_header and can be removed from the cache.
+                RemoveBlockIndexCandidate(m_chainman, *candidate);
                 candidate_it = highpow_outofchain_headers.erase(candidate_it);
                 continue;
             }
@@ -3664,7 +3673,7 @@ bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* const
         if (!pindex_was_in_chain && !(pindex->nStatus & BLOCK_FAILED_VALID)) {
             pindex->nStatus |= BLOCK_FAILED_VALID;
             m_blockman.m_dirty_blockindex.insert(pindex);
-            setBlockIndexCandidates.erase(pindex);
+            RemoveBlockIndexCandidate(m_chainman, *pindex);
         }
 
         // If any new blocks somehow arrived while we were disconnecting
@@ -3675,7 +3684,9 @@ bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* const
         // Loop back over all block index entries and add any missing entries
         // to setBlockIndexCandidates.
         for (auto& [_, block_index] : m_blockman.m_block_index) {
-            if (block_index.IsValid(BLOCK_VALID_TRANSACTIONS) && block_index.HaveNumChainTxs() && !setBlockIndexCandidates.value_comp()(&block_index, m_chain.Tip())) {
+            if (block_index.IsValid(BLOCK_VALID_TRANSACTIONS) &&
+                block_index.HaveNumChainTxs() &&
+                !setBlockIndexCandidates.value_comp()(&block_index, m_chain.Tip())) {
                 setBlockIndexCandidates.insert(&block_index);
             }
         }
@@ -3710,10 +3721,12 @@ void Chainstate::SetBlockFailureFlags(CBlockIndex* invalid_block)
 {
     AssertLockHeld(cs_main);
 
+    RemoveBlockIndexCandidate(m_chainman, *invalid_block);
     for (auto& [_, block_index] : m_blockman.m_block_index) {
         if (invalid_block != &block_index && block_index.GetAncestor(invalid_block->nHeight) == invalid_block) {
             block_index.nStatus |= BLOCK_FAILED_VALID;
             m_blockman.m_dirty_blockindex.insert(&block_index);
+            RemoveBlockIndexCandidate(m_chainman, block_index);
         }
     }
 }
@@ -3742,6 +3755,7 @@ void Chainstate::ResetBlockFailureFlags(CBlockIndex *pindex) {
 void Chainstate::TryAddBlockIndexCandidate(CBlockIndex* pindex)
 {
     AssertLockHeld(cs_main);
+    if (!Assume(!(pindex->nStatus & BLOCK_FAILED_VALID))) return;
 
     // Do not continue building a chainstate that is based on an invalid
     // snapshot. This is a belt-and-suspenders type of check because if an
@@ -5306,6 +5320,7 @@ void ChainstateManager::CheckBlockIndex() const
         // Chainstate-specific checks on setBlockIndexCandidates
         for (const auto& c : m_chainstates) {
             if (c->m_chain.Tip() == nullptr) continue;
+            assert(pindexFirstInvalid == nullptr || !c->setBlockIndexCandidates.contains(pindex));
             // Two main factors determine whether pindex is a candidate in
             // setBlockIndexCandidates:
             //
@@ -5321,8 +5336,7 @@ void ChainstateManager::CheckBlockIndex() const
             //   also a potential candidate.
             if (!CBlockIndexWorkComparator()(pindex, c->m_chain.Tip()) && (pindexFirstNeverProcessed == nullptr || pindex == snap_base)) {
                 // If pindex was detected as invalid (pindexFirstInvalid is
-                // non-null), it is not required to be in
-                // setBlockIndexCandidates.
+                // non-null), it must not be in setBlockIndexCandidates.
                 if (pindexFirstInvalid == nullptr) {
                     // If pindex and all its parents back to the genesis block
                     // or an assumeutxo snapshot block downloaded transactions,

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3817,8 +3817,11 @@ void ChainstateManager::ReceivedBlockTransactions(const CBlock& block, CBlockInd
             }
             pindex->m_chain_tx_count = prev_tx_sum(*pindex);
             pindex->nSequenceId = nBlockSequenceId++;
-            for (const auto& c : m_chainstates) {
-                c->TryAddBlockIndexCandidate(pindex);
+            // Failed descendants still need chain transaction counts for reconsideration, but must not be candidates.
+            if (!(pindex->nStatus & BLOCK_FAILED_VALID)) {
+                for (const auto& c : m_chainstates) {
+                    c->TryAddBlockIndexCandidate(pindex);
+                }
             }
             std::pair<std::multimap<CBlockIndex*, CBlockIndex*>::iterator, std::multimap<CBlockIndex*, CBlockIndex*>::iterator> range = m_blockman.m_blocks_unlinked.equal_range(pindex);
             while (range.first != range.second) {

--- a/src/validation.h
+++ b/src/validation.h
@@ -677,8 +677,8 @@ public:
      * The set of all CBlockIndex entries that have as much work as our current
      * tip or more, and transaction data needed to be validated (with
      * BLOCK_VALID_TRANSACTIONS for each block and its parents back to the
-     * genesis block or an assumeutxo snapshot block). Entries may be failed,
-     * though, and pruning nodes may be missing the data for the block.
+     * genesis block or an assumeutxo snapshot block). Entries must not be
+     * failed, though pruning nodes may be missing the data for the block.
      */
     std::set<CBlockIndex*, node::CBlockIndexWorkComparator> setBlockIndexCandidates;
 


### PR DESCRIPTION
**Problem:** PR #31405 made invalid-block handling stricter by eagerly marking failed descendants, and PR #32950 removed the separate `BLOCK_FAILED_CHILD` state. `setBlockIndexCandidates` still allowed failed entries and relied on `FindMostWorkChain()` to clean them up lazily, which keeps the candidate-set contract weaker than the failure-state contract and forces tests and fuzzing to tolerate failed candidates.

**Fix:** Keep chain transaction count propagation for failed unlinked descendants, but skip candidate insertion. When invalidation paths mark a block failed, remove it from all chainstate candidate sets and assert the invariant at candidate insertion and `CheckBlockIndex()` time. `FindMostWorkChain()` still keeps its defensive lazy cleanup for old or transient states and pruned missing-data handling. The existing chainstate-manager unit tests cover the unlinked-child, out-of-chain-candidate, and disconnect-descendant paths.

**Related work:** https://github.com/bitcoin/bitcoin/pull/31405 and https://github.com/bitcoin/bitcoin/pull/32950
