### PR TITLE
rbf: avoid overflow in replacement fee delta

### DIFF
--- a/src/policy/rbf.cpp
+++ b/src/policy/rbf.cpp
@@ -14,9 +14,9 @@
 #include <uint256.h>
 #include <util/check.h>
 #include <util/moneystr.h>
+#include <util/overflow.h>
 #include <util/rbf.h>
 
-#include <limits>
 #include <vector>
 
 #include <compare>
@@ -114,12 +114,12 @@ std::optional<std::string> PaysForRBF(CAmount original_fees,
     // Rule #4: The new transaction must pay for its own bandwidth. Otherwise, we have a DoS
     // vector where attackers can cause a transaction to be replaced (and relayed) repeatedly by
     // increasing the fee by tiny amounts.
-    CAmount additional_fees = replacement_fees - original_fees;
-    if (additional_fees < relay_fee.GetFee(replacement_vsize)) {
+    const CAmount relay_fee_due{relay_fee.GetFee(replacement_vsize)};
+    if (auto required_fees{CheckedAdd(original_fees, relay_fee_due)}; !required_fees || replacement_fees < *required_fees) {
         return strprintf("rejecting replacement %s, not enough additional fees to relay; %s < %s",
                          txid.ToString(),
-                         FormatMoney(additional_fees),
-                         FormatMoney(relay_fee.GetFee(replacement_vsize)));
+                         FormatMoney(replacement_fees - original_fees),
+                         FormatMoney(relay_fee_due));
     }
     return std::nullopt;
 }

--- a/src/test/rbf_tests.cpp
+++ b/src/test/rbf_tests.cpp
@@ -11,6 +11,7 @@
 #include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
+#include <limits>
 #include <optional>
 #include <vector>
 
@@ -159,6 +160,8 @@ BOOST_FIXTURE_TEST_CASE(rbf_helper_functions, TestChain100Setup)
     BOOST_CHECK(PaysForRBF(high_fee, high_fee + 4, 20, higher_relay_feerate, unused_txid) == std::nullopt);
     BOOST_CHECK(PaysForRBF(low_fee, high_fee, 99999999, incremental_relay_feerate, unused_txid).has_value());
     BOOST_CHECK(PaysForRBF(low_fee, high_fee + 99999999, 99999999, incremental_relay_feerate, unused_txid) == std::nullopt);
+    BOOST_CHECK(PaysForRBF(std::numeric_limits<CAmount>::min() + high_fee, high_fee, 1, CFeeRate(0), unused_txid) == std::nullopt);
+    BOOST_CHECK(PaysForRBF(std::numeric_limits<CAmount>::max(), std::numeric_limits<CAmount>::max(), 1, incremental_relay_feerate, unused_txid).has_value());
 }
 
 BOOST_FIXTURE_TEST_CASE(rbf_conflicts_calculator, TestChain100Setup)

--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -464,6 +464,24 @@ class ReplaceByFeeTest(BitcoinTestFramework):
 
         assert tx2b_txid in self.nodes[0].getrawmempool()
 
+        # 3. Check that extreme negative modified fees do not overflow Rule #4.
+        tx3_outpoint = self.make_utxo(self.nodes[0], int(1.1 * COIN))
+        tx3a = self.wallet.send_self_transfer(
+            from_node=self.nodes[0],
+            utxo_to_spend=tx3_outpoint,
+            sequence=0,
+            fee=Decimal("0.00010000"),
+        )
+        self.nodes[0].prioritisetransaction(txid=tx3a["txid"], fee_delta=-(2**63))
+        assert self.nodes[0].testmempoolaccept(rawtxs=[
+            self.wallet.create_self_transfer(
+                utxo_to_spend=tx3_outpoint,
+                sequence=0,
+                fee=Decimal("0.00011000"),
+            )["hex"]
+        ])[0]["allowed"]
+        self.nodes[0].prioritisetransaction(txid=tx3a["txid"], fee_delta=2**63 - 1)
+
     def test_rpc(self):
         us0 = self.wallet.get_utxo()
         ins = [us0]


### PR DESCRIPTION
**Problem:** `prioritisetransaction` changes the modified fee used by mempool policy, and can make the transaction being replaced have an extremely negative modified fee.
`PaysForRBF()` subtracts `original_fees` from `replacement_fees` for BIP125 rule #4 after rule #3 has only checked ordering; with extreme modified fees, that subtraction may overflow before the rule #4 comparison.

**Fix:** Compare `replacement_fees` with the checked sum of `original_fees` and the incremental relay fee.
If the required total does not fit in `CAmount`, no replacement can pay enough additional fee.
The rejection message still prints the additional fee only on the path where the checked comparison keeps it representable.