### PR TITLE
validation: reject duplicate snapshot coins

### DIFF
--- a/src/node/utxo_snapshot.h
+++ b/src/node/utxo_snapshot.h
@@ -46,7 +46,7 @@ public:
 
 
     //! The number of coins in the UTXO set contained in this snapshot. Used
-    //! during snapshot load to estimate progress of UTXO set reconstruction.
+    //! during snapshot load to estimate progress and validate the loaded set.
     uint64_t m_coins_count = 0;
 
     SnapshotMetadata(

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5920,6 +5920,11 @@ util::Result<void> ChainstateManager::PopulateAndValidateSnapshot(
         return util::Error{Untranslated("Failed to generate coins stats")};
     }
 
+    if (maybe_stats->coins_count != coins_count) {
+        return util::Error{Untranslated(strprintf("Bad snapshot coins count: expected %d, got %d",
+            coins_count, maybe_stats->coins_count))};
+    }
+
     // Assert that the deserialized chainstate contents match the expected assumeutxo value.
     if (AssumeutxoHash{maybe_stats->hashSerialized} != au_data.hash_serialized) {
         return util::Error{Untranslated(strprintf("Bad snapshot content hash: expected %s, got %s",

--- a/test/functional/feature_assumeutxo.py
+++ b/test/functional/feature_assumeutxo.py
@@ -136,6 +136,15 @@ class AssumeutxoTest(BitcoinTestFramework):
                 f.write(valid_snapshot_contents[43 + 8:])
             expected_error(msg="Bad snapshot - coins left over after deserializing 298 coins." if off == -1 else "Bad snapshot format or truncated snapshot after deserializing 299 coins.")
 
+        self.log.info("  - snapshot file with duplicate coin records")
+        snapshot_coin_data = valid_snapshot_contents[43 + 8:]
+        with open(bad_snapshot_path, 'wb') as f:
+            f.write(valid_snapshot_contents[:43])
+            f.write((valid_num_coins * 2).to_bytes(8, "little"))
+            f.write(snapshot_coin_data)
+            f.write(snapshot_coin_data)
+        expected_error(msg=f"Bad snapshot coins count: expected {valid_num_coins * 2}, got {valid_num_coins}")
+
         self.log.info("  - snapshot file with alternated but parsable UTXO data results in different hash")
         cases = [
             # (content, offset, wrong_hash, custom_message)


### PR DESCRIPTION
**Problem:** Snapshot metadata declares how many coins the file contains, but snapshot loading inserts records into a UTXO set keyed by outpoint.
A malformed snapshot can repeat records with the same outpoint and raise the metadata count while the final UTXO set stays unchanged.
The assumeutxo hash can still match, because it commits to the final set rather than the serialized record count.

**Fix:** Reject the snapshot when `ComputeUTXOStats()` reports a unique coin count different from the metadata count.
Checking after load catches duplicates across flush boundaries without a per-coin disk lookup, and the stats pass is already required for the hash check.