### PR TITLE
index: handle synced indexes before genesis

### DIFF
--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -441,7 +441,11 @@ bool BaseIndex::BlockUntilSyncedToCurrentChain() const
         LOCK(cs_main);
         const CBlockIndex* chain_tip = m_chainstate->m_chain.Tip();
         const CBlockIndex* best_block_index = m_best_block_index.load();
-        if (best_block_index->GetAncestor(chain_tip->nHeight) == chain_tip) {
+        if (!chain_tip) {
+            Assume(!best_block_index);
+            return true;
+        }
+        if (best_block_index && best_block_index->GetAncestor(chain_tip->nHeight) == chain_tip) {
             return true;
         }
     }

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -411,13 +411,14 @@ void BaseIndex::ChainStateFlushed(const ChainstateRole& role, const CBlockLocato
     // immediately after the sync thread catches up and sets m_synced. Consider the case where
     // there is a reorg and the blocks on the stale branch are in the ValidationInterface queue
     // backlog even after the sync thread has caught up to the new chain tip. In this unlikely
-    // event, log a warning and let the queue clear.
+    // event, log a warning and let the queue clear. The index may also have no best block at all
+    // yet if it became synced before genesis was connected.
     const CBlockIndex* best_block_index = m_best_block_index.load();
-    if (best_block_index->GetAncestor(locator_tip_index->nHeight) != locator_tip_index) {
+    if (!best_block_index || best_block_index->GetAncestor(locator_tip_index->nHeight) != locator_tip_index) {
         LogWarning("Locator contains block (hash=%s) not on known best "
                   "chain (tip=%s); not writing index locator",
                   locator_tip_hash.ToString(),
-                  best_block_index->GetBlockHash().ToString());
+                  best_block_index ? best_block_index->GetBlockHash().ToString() : "null");
         return;
     }
 

--- a/src/test/txindex_tests.cpp
+++ b/src/test/txindex_tests.cpp
@@ -6,13 +6,50 @@
 #include <chainparams.h>
 #include <index/txindex.h>
 #include <interfaces/chain.h>
+#include <node/mining_types.h>
+#include <test/util/mining.h>
 #include <test/util/setup_common.h>
+#include <util/check.h>
 #include <util/byte_units.h>
 #include <validation.h>
 
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE(txindex_tests)
+
+struct TxIndexChainTestingSetup : public ChainTestingSetup {
+    TxIndexChainTestingSetup() : ChainTestingSetup{ChainType::REGTEST} {}
+};
+
+BOOST_FIXTURE_TEST_CASE(txindex_block_until_synced_before_genesis_activation, TxIndexChainTestingSetup)
+{
+    auto& chainman{*Assert(m_node.chainman)};
+    LoadVerifyChainstate();
+
+    BOOST_REQUIRE(!WITH_LOCK(::cs_main, return chainman.ActiveChain().Tip()));
+
+    TxIndex txindex(interfaces::MakeChain(m_node), 1_MiB, true);
+    BOOST_REQUIRE(txindex.Init());
+    BOOST_CHECK(txindex.BlockUntilSyncedToCurrentChain());
+
+    BlockValidationState state;
+    BOOST_REQUIRE(chainman.ActiveChainstate().ActivateBestChain(state));
+    BOOST_REQUIRE(WITH_LOCK(::cs_main, return chainman.ActiveChain().Tip() != nullptr));
+    BOOST_CHECK(txindex.BlockUntilSyncedToCurrentChain());
+
+    const COutPoint coinbase{MineBlock(m_node, {
+        .use_mempool = false,
+        .coinbase_output_script = CScript{} << OP_TRUE,
+    })};
+    BOOST_REQUIRE(!coinbase.IsNull());
+    BOOST_CHECK(txindex.BlockUntilSyncedToCurrentChain());
+    CTransactionRef tx_disk;
+    uint256 block_hash;
+    BOOST_REQUIRE(txindex.FindTx(coinbase.hash, block_hash, tx_disk));
+    BOOST_CHECK(tx_disk->GetHash() == coinbase.hash);
+
+    txindex.Stop();
+}
 
 BOOST_FIXTURE_TEST_CASE(txindex_initial_sync, TestChain100Setup)
 {

--- a/src/test/txindex_tests.cpp
+++ b/src/test/txindex_tests.cpp
@@ -6,12 +6,14 @@
 #include <chainparams.h>
 #include <index/txindex.h>
 #include <interfaces/chain.h>
+#include <kernel/types.h>
 #include <node/mining_types.h>
 #include <test/util/mining.h>
 #include <test/util/setup_common.h>
 #include <util/check.h>
 #include <util/byte_units.h>
 #include <validation.h>
+#include <validationinterface.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -30,6 +32,12 @@ BOOST_FIXTURE_TEST_CASE(txindex_block_until_synced_before_genesis_activation, Tx
 
     TxIndex txindex(interfaces::MakeChain(m_node), 1_MiB, true);
     BOOST_REQUIRE(txindex.Init());
+    BOOST_CHECK(txindex.BlockUntilSyncedToCurrentChain());
+
+    const uint256 genesis_hash{Params().GenesisBlock().GetHash()};
+    BOOST_REQUIRE(WITH_LOCK(::cs_main, return chainman.m_blockman.LookupBlockIndex(genesis_hash) != nullptr));
+    m_node.validation_signals->ChainStateFlushed(kernel::ChainstateRole{}, CBlockLocator{{genesis_hash}});
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
     BOOST_CHECK(txindex.BlockUntilSyncedToCurrentChain());
 
     BlockValidationState state;

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -346,7 +346,7 @@ ChainTestingSetup::~ChainTestingSetup()
     m_node.scheduler.reset();
 }
 
-void ChainTestingSetup::LoadVerifyActivateChainstate()
+void ChainTestingSetup::LoadVerifyChainstate()
 {
     auto& chainman{*Assert(m_node.chainman)};
     node::ChainstateLoadOptions options;
@@ -364,9 +364,14 @@ void ChainTestingSetup::LoadVerifyActivateChainstate()
     assert(status == node::ChainstateLoadStatus::SUCCESS);
 
     m_node.notifications->setChainstateLoaded(true);
+}
+
+void ChainTestingSetup::LoadVerifyActivateChainstate()
+{
+    LoadVerifyChainstate();
 
     BlockValidationState state;
-    if (!chainman.ActiveChainstate().ActivateBestChain(state)) {
+    if (!Assert(m_node.chainman)->ActiveChainstate().ActivateBestChain(state)) {
         throw std::runtime_error(strprintf("ActivateBestChain failed. (%s)", state.ToString()));
     }
 }

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -108,6 +108,8 @@ struct ChainTestingSetup : public BasicTestingSetup {
 
     // Supplies a chainstate, if one is needed
     void LoadVerifyActivateChainstate();
+    // Same, but stops before activating the best chain, leaving the active chain without a tip.
+    void LoadVerifyChainstate();
 };
 
 /** Testing setup that configures a complete environment.


### PR DESCRIPTION
**Problem:** `BaseIndex::Init()` can mark an index synced before genesis is connected when startup begins with no index best block and no active chain tip yet: https://github.com/bitcoin/bitcoin/blob/2063f02bd5edebe1b5c9635db8850220811ebc90/src/index/base.cpp#L142-L145

That pre-genesis synced state exists during first startup with an index enabled, because indexes are initialized before genesis is activated. Two synced-index paths still assumed non-null pointers. `BlockUntilSyncedToCurrentChain()` dereferenced both the active tip and the index best block, and `ChainStateFlushed()` could dereference the null index best block if a flushed genesis locator arrived before the `BlockConnected` callback: https://github.com/bitcoin/bitcoin/blob/2063f02bd5edebe1b5c9635db8850220811ebc90/src/index/base.cpp#L415-L444

**Reachability:** RPC and REST callers are warmup-gated until after genesis activation, and normal validation notifications deliver `BlockConnected(genesis)` before a flush notification. This is hardening for a documented startup state that can persist if block import is interrupted, as in #35652, and for future callers or notification reorderings.

**Fix:** Treat a null active tip as already caught up, and skip flushed locator commits until the index has a best block. The txindex test builds the pre-genesis synced state directly, checks `BlockUntilSyncedToCurrentChain()`, sends a genesis flush notification before genesis is connected, then activates genesis and mines one block to verify a normal block notification still reaches txindex through `FindTx`.

**Related:** #35652 fixes the init deadlock when `-reindex` is interrupted before genesis activation; that interruption is also the case where the pre-genesis synced index state persists longest. The two are complementary, with no overlapping code or symptom.
