### PR TITLE
script: reset precomputed txdata on reuse

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1412,7 +1412,10 @@ uint256 GetSpentScriptsSHA256(const std::vector<CTxOut>& outputs_spent)
 template <class T>
 void PrecomputedTransactionData::Init(const T& txTo, std::vector<CTxOut>&& spent_outputs, bool force)
 {
-    assert(!m_spent_outputs_ready);
+    // Clear optional readiness flags before recomputing this transaction's state.
+    m_spent_outputs_ready = false;
+    m_bip143_segwit_ready = false;
+    m_bip341_taproot_ready = false;
 
     m_spent_outputs = std::move(spent_outputs);
     if (!m_spent_outputs.empty()) {

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -316,10 +316,10 @@ BOOST_AUTO_TEST_CASE(precomputed_transaction_data_reuse)
     tx.vin[0].prevout.n = 1; // stale hashPrevouts
     tx.vout[0].nValue = 2;   // stale hashOutputs
     txdata.Init(tx, /*spent_outputs=*/{}, /*force=*/false);
-    check_ready(/*bip143=*/true, /*bip341=*/false, /*spent_outputs=*/false); // TODO: clear stale BIP143
+    check_ready(/*bip143=*/false, /*bip341=*/false, /*spent_outputs=*/false);
 
     const CScript scriptcode{CScript{} << OP_TRUE};
-    BOOST_CHECK_NE( // TODO: match uncached path
+    BOOST_CHECK_EQUAL(
         SignatureHash(scriptcode, tx, /*nIn=*/0, SIGHASH_ALL, /*amount=*/3, SigVersion::WITNESS_V0),
         SignatureHash(scriptcode, tx, /*nIn=*/0, SIGHASH_ALL, /*amount=*/3, SigVersion::WITNESS_V0, &txdata));
 
@@ -329,7 +329,7 @@ BOOST_AUTO_TEST_CASE(precomputed_transaction_data_reuse)
     // Match the old one-flag guard without clearing the other readiness flags
     txdata.m_spent_outputs_ready = false;
     txdata.Init(tx, /*spent_outputs=*/{}, /*force=*/false);
-    check_ready(/*bip143=*/true, /*bip341=*/true, /*spent_outputs=*/false); // TODO: clear stale readiness
+    check_ready(/*bip143=*/false, /*bip341=*/false, /*spent_outputs=*/false);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -297,4 +297,39 @@ BOOST_AUTO_TEST_CASE(sighash_caching)
     }
 }
 
+BOOST_AUTO_TEST_CASE(precomputed_transaction_data_reuse)
+{
+    CMutableTransaction tx;
+    tx.vin.emplace_back(Txid::FromUint256(uint256::ONE), 0);
+    tx.vout.emplace_back(1, CScript{} << OP_TRUE);
+
+    PrecomputedTransactionData txdata;
+    auto check_ready{[&](bool bip143, bool bip341, bool spent_outputs) {
+        BOOST_CHECK_EQUAL(txdata.m_bip143_segwit_ready, bip143);
+        BOOST_CHECK_EQUAL(txdata.m_bip341_taproot_ready, bip341);
+        BOOST_CHECK_EQUAL(txdata.m_spent_outputs_ready, spent_outputs);
+    }};
+
+    txdata.Init(tx, /*spent_outputs=*/{}, /*force=*/true);
+    check_ready(/*bip143=*/true, /*bip341=*/false, /*spent_outputs=*/false);
+
+    tx.vin[0].prevout.n = 1; // stale hashPrevouts
+    tx.vout[0].nValue = 2;   // stale hashOutputs
+    txdata.Init(tx, /*spent_outputs=*/{}, /*force=*/false);
+    check_ready(/*bip143=*/true, /*bip341=*/false, /*spent_outputs=*/false); // TODO: clear stale BIP143
+
+    const CScript scriptcode{CScript{} << OP_TRUE};
+    BOOST_CHECK_NE( // TODO: match uncached path
+        SignatureHash(scriptcode, tx, /*nIn=*/0, SIGHASH_ALL, /*amount=*/3, SigVersion::WITNESS_V0),
+        SignatureHash(scriptcode, tx, /*nIn=*/0, SIGHASH_ALL, /*amount=*/3, SigVersion::WITNESS_V0, &txdata));
+
+    txdata.Init(tx, /*spent_outputs=*/{CTxOut{3, CScript{} << OP_TRUE}}, /*force=*/true);
+    check_ready(/*bip143=*/true, /*bip341=*/true, /*spent_outputs=*/true);
+
+    // Match the old one-flag guard without clearing the other readiness flags
+    txdata.m_spent_outputs_ready = false;
+    txdata.Init(tx, /*spent_outputs=*/{}, /*force=*/false);
+    check_ready(/*bip143=*/true, /*bip341=*/true, /*spent_outputs=*/false); // TODO: clear stale readiness
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
**Problem:** `PrecomputedTransactionData::Init()` can be called again after a forced initialization with no spent outputs, because the old code guarded only [`m_spent_outputs_ready`](https://github.com/bitcoin/bitcoin/blob/2063f02bd5edebe1b5c9635db8850220811ebc90/src/script/interpreter.cpp#L1415) and set that flag [only when spent outputs were present](https://github.com/bitcoin/bitcoin/blob/2063f02bd5edebe1b5c9635db8850220811ebc90/src/script/interpreter.cpp#L1417-L1420), while `force=true` [enabled BIP143 precomputation](https://github.com/bitcoin/bitcoin/blob/2063f02bd5edebe1b5c9635db8850220811ebc90/src/script/interpreter.cpp#L1423-L1425) and [set `m_bip143_segwit_ready`](https://github.com/bitcoin/bitcoin/blob/2063f02bd5edebe1b5c9635db8850220811ebc90/src/script/interpreter.cpp#L1451-L1455).
If the transaction changes before the next `Init()`, the stale BIP143 readiness flag can make witness-v0 [`SignatureHash()` use cached prevout, sequence, and output hashes](https://github.com/bitcoin/bitcoin/blob/2063f02bd5edebe1b5c9635db8850220811ebc90/src/script/interpreter.cpp#L1637-L1648) from the previous transaction.

Current validation, mempool, wallet, and signing paths initialize fresh `PrecomputedTransactionData` objects for each transaction, so their behavior stays the same.

**Fix:** Harden the helper for external callers and future code that reuses txdata objects by resetting optional readiness flags at the start of `Init()` before recomputing the current transaction state.
