### PR TITLE
banman: saturate relative ban expiry, sweep expired bans

### DIFF
--- a/src/banman.cpp
+++ b/src/banman.cpp
@@ -191,7 +191,7 @@ void BanMan::SweepBanned()
     while (it != m_banned.end()) {
         CSubNet sub_net = (*it).first;
         CBanEntry ban_entry = (*it).second;
-        if (!sub_net.IsValid() || now > ban_entry.nBanUntil) {
+        if (!sub_net.IsValid() || now >= ban_entry.nBanUntil) {
             m_banned.erase(it++);
             m_is_dirty = true;
             notify_ui = true;

--- a/src/banman.cpp
+++ b/src/banman.cpp
@@ -10,6 +10,7 @@
 #include <node/interface_ui.h>
 #include <sync.h>
 #include <util/log.h>
+#include <util/overflow.h>
 #include <util/time.h>
 #include <util/translation.h>
 
@@ -129,7 +130,8 @@ void BanMan::Discourage(const CNetAddr& net_addr)
 
 void BanMan::Ban(const CSubNet& sub_net, int64_t ban_time_offset, bool since_unix_epoch)
 {
-    CBanEntry ban_entry(GetTime());
+    const int64_t now{GetTime()};
+    CBanEntry ban_entry(now);
 
     int64_t normalized_ban_time_offset = ban_time_offset;
     bool normalized_since_unix_epoch = since_unix_epoch;
@@ -137,7 +139,7 @@ void BanMan::Ban(const CSubNet& sub_net, int64_t ban_time_offset, bool since_uni
         normalized_ban_time_offset = m_default_ban_time;
         normalized_since_unix_epoch = false;
     }
-    ban_entry.nBanUntil = (normalized_since_unix_epoch ? 0 : GetTime()) + normalized_ban_time_offset;
+    ban_entry.nBanUntil = normalized_since_unix_epoch ? normalized_ban_time_offset : SaturatingAdd(now, normalized_ban_time_offset);
 
     {
         LOCK(m_banned_mutex);

--- a/src/test/banman_tests.cpp
+++ b/src/test/banman_tests.cpp
@@ -42,6 +42,27 @@ BOOST_AUTO_TEST_CASE(file)
     }
 }
 
+BOOST_AUTO_TEST_CASE(expired_at_boundary_is_not_returned)
+{
+    FakeNodeClock clock{777s};
+    const fs::path banlist_path{m_args.GetDataDirBase() / "banlist_expiry_boundary_test"};
+
+    const CSubNet subnet{LookupSubNet("1.2.3.0/24")};
+    const CNetAddr subnet_addr{LookupHost("1.2.3.4", /*fAllowLookup=*/false).value()};
+    BOOST_REQUIRE(subnet.IsValid());
+
+    {
+        BanMan banman{banlist_path, /*client_interface=*/nullptr, /*default_ban_time=*/0};
+        banman.Ban(subnet, /*ban_time_offset=*/777, /*since_unix_epoch=*/true);
+        BOOST_CHECK(!banman.IsBanned(subnet));
+        BOOST_CHECK(!banman.IsBanned(subnet_addr));
+
+        banmap_t entries;
+        banman.GetBanned(entries);
+        BOOST_CHECK(entries.empty());
+    }
+}
+
 BOOST_AUTO_TEST_CASE(relative_ban_time_saturates)
 {
     FakeNodeClock clock{777s};

--- a/src/test/banman_tests.cpp
+++ b/src/test/banman_tests.cpp
@@ -13,6 +13,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <limits>
+
 BOOST_FIXTURE_TEST_SUITE(banman_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(file)
@@ -37,6 +39,39 @@ BOOST_AUTO_TEST_CASE(file)
             banman.GetBanned(entries_read);
             BOOST_CHECK_EQUAL(entries_read.size(), 1);
         }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(relative_ban_time_saturates)
+{
+    FakeNodeClock clock{777s};
+    const fs::path banlist_path{m_args.GetDataDirBase() / "banlist_saturating_time_test"};
+
+    const CSubNet subnet{LookupSubNet("1.2.3.0/24")};
+    const CNetAddr subnet_addr{LookupHost("1.2.3.4", /*fAllowLookup=*/false).value()};
+    BOOST_REQUIRE(subnet.IsValid());
+
+    {
+        BanMan banman{banlist_path, /*client_interface=*/nullptr, /*default_ban_time=*/0};
+        banman.Ban(subnet, /*ban_time_offset=*/std::numeric_limits<int64_t>::max(), /*since_unix_epoch=*/false);
+
+        BOOST_CHECK(banman.IsBanned(subnet));
+        BOOST_CHECK(banman.IsBanned(subnet_addr));
+
+        banmap_t entries;
+        banman.GetBanned(entries);
+        BOOST_REQUIRE_EQUAL(entries.count(subnet), 1U);
+        BOOST_CHECK_EQUAL(entries.at(subnet).nBanUntil, std::numeric_limits<int64_t>::max());
+    }
+
+    {
+        BanMan banman{banlist_path, /*client_interface=*/nullptr, /*default_ban_time=*/0};
+
+        banmap_t entries;
+        banman.GetBanned(entries);
+        BOOST_REQUIRE_EQUAL(entries.count(subnet), 1U);
+        BOOST_CHECK_EQUAL(entries.at(subnet).nBanUntil, std::numeric_limits<int64_t>::max());
+        BOOST_CHECK(banman.IsBanned(subnet_addr));
     }
 }
 

--- a/src/test/fuzz/banman.cpp
+++ b/src/test/fuzz/banman.cpp
@@ -16,18 +16,8 @@
 
 #include <cassert>
 #include <cstdint>
-#include <limits>
 #include <string>
 #include <vector>
-
-namespace {
-int64_t ConsumeBanTimeOffset(FuzzedDataProvider& fuzzed_data_provider) noexcept
-{
-    // Avoid signed integer overflow by capping to int32_t max:
-    // banman.cpp:137:73: runtime error: signed integer overflow: 1591700817 + 9223372036854775807 cannot be represented in type 'long'
-    return fuzzed_data_provider.ConsumeIntegralInRange<int64_t>(std::numeric_limits<int64_t>::min(), std::numeric_limits<int32_t>::max());
-}
-} // namespace
 
 void initialize_banman()
 {
@@ -61,7 +51,7 @@ FUZZ_TARGET(banman, .init = initialize_banman)
     }
 
     {
-        BanMan ban_man{banlist_file, /*client_interface=*/nullptr, /*default_ban_time=*/ConsumeBanTimeOffset(fuzzed_data_provider)};
+        BanMan ban_man{banlist_file, /*client_interface=*/nullptr, /*default_ban_time=*/fuzzed_data_provider.ConsumeIntegral<int64_t>()};
         // The complexity is O(N^2), where N is the input size, because each call
         // might call DumpBanlist (or other methods that are at least linear
         // complexity of the input size).
@@ -80,8 +70,8 @@ FUZZ_TARGET(banman, .init = initialize_banman)
                             contains_invalid = true;
                         }
                     }
-                    auto ban_time_offset = ConsumeBanTimeOffset(fuzzed_data_provider);
-                    auto since_unix_epoch = fuzzed_data_provider.ConsumeBool();
+                    const int64_t ban_time_offset{fuzzed_data_provider.ConsumeIntegral<int64_t>()};
+                    const bool since_unix_epoch{fuzzed_data_provider.ConsumeBool()};
                     ban_man.Ban(net_addr, ban_time_offset, since_unix_epoch);
                 },
                 [&] {
@@ -90,8 +80,8 @@ FUZZ_TARGET(banman, .init = initialize_banman)
                     if (!subnet.IsValid()) {
                         contains_invalid = true;
                     }
-                    auto ban_time_offset = ConsumeBanTimeOffset(fuzzed_data_provider);
-                    auto since_unix_epoch = fuzzed_data_provider.ConsumeBool();
+                    const int64_t ban_time_offset{fuzzed_data_provider.ConsumeIntegral<int64_t>()};
+                    const bool since_unix_epoch{fuzzed_data_provider.ConsumeBool()};
                     ban_man.Ban(subnet, ban_time_offset, since_unix_epoch);
                 },
                 [&] {

--- a/test/functional/rpc_setban.py
+++ b/test/functional/rpc_setban.py
@@ -97,5 +97,12 @@ class SetBanTests(BitcoinTestFramework):
         assert_equal(banned["ban_duration"], max_bantime - mocktime)
         assert_equal(banned["time_remaining"], max_bantime - mocktime)
 
+        self.log.info("Test ban expiry at exact timestamp")
+        self.nodes[1].clearbanned()
+        self.nodes[1].setban("192.0.2.2", "add", mocktime + 1, absolute=True)
+        assert self.is_banned(self.nodes[1], "192.0.2.2/32")
+        self.nodes[1].setmocktime(mocktime + 1)
+        assert_equal(self.nodes[1].listbanned(), [])
+
 if __name__ == '__main__':
     SetBanTests(__file__).main()

--- a/test/functional/rpc_setban.py
+++ b/test/functional/rpc_setban.py
@@ -5,6 +5,8 @@
 """Test the setban rpc call."""
 
 from contextlib import ExitStack
+import time
+
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     p2p_port,
@@ -82,6 +84,18 @@ class SetBanTests(BitcoinTestFramework):
         self.nodes[1].setban("127.0.0.1", "add")
         banned = self.nodes[1].listbanned()[0]
         assert_equal(banned['ban_duration'], 1234)
+
+        self.log.info("Test large relative bantime")
+        self.nodes[1].clearbanned()
+        mocktime = int(time.time())
+        self.nodes[1].setmocktime(mocktime)
+        max_bantime = 2**63 - 1
+        self.nodes[1].setban("192.0.2.1", "add", max_bantime)
+        banned = self.nodes[1].listbanned()[0]
+        assert_equal(banned["address"], "192.0.2.1/32")
+        assert_equal(banned["banned_until"], max_bantime)
+        assert_equal(banned["ban_duration"], max_bantime - mocktime)
+        assert_equal(banned["time_remaining"], max_bantime - mocktime)
 
 if __name__ == '__main__':
     SetBanTests(__file__).main()


### PR DESCRIPTION
**Problem:** A large relative `setban` bantime could overflow the [plain signed addition](https://github.com/bitcoin/bitcoin/blob/2063f02bd5edebe1b5c9635db8850220811ebc90/src/banman.cpp#L130-L140) in `BanMan::Ban()`. The RPC would return success, but the wrapped expiry could be lower than the existing entry, leaving the banlist unchanged. The fuzz target avoided this UB by [capping offsets](https://github.com/bitcoin/bitcoin/blob/2063f02bd5edebe1b5c9635db8850220811ebc90/src/test/fuzz/banman.cpp#L24-L29).

`SweepBanned()` also kept entries until [`now > nBanUntil`](https://github.com/bitcoin/bitcoin/blob/2063f02bd5edebe1b5c9635db8850220811ebc90/src/banman.cpp#L182-L192), while `IsBanned()` treats an entry as active only while current time is [strictly less than `nBanUntil`](https://github.com/bitcoin/bitcoin/blob/2063f02bd5edebe1b5c9635db8850220811ebc90/src/banman.cpp#L89-L116). At the exact expiry time, `listbanned` could still return an inactive entry.

**Fix:** Saturate relative expiry arithmetic and let the fuzz target exercise the full `int64_t` range. Sweep entries at `now >= nBanUntil`, matching `IsBanned()` and the same boundary fix from [Bitcoin Knots PR #277](https://github.com/bitcoinknots/bitcoin/pull/277).
