### PR TITLE
p2p: ignore txs from unregistered peers

### DIFF
--- a/src/node/txdownloadman.h
+++ b/src/node/txdownloadman.h
@@ -154,7 +154,7 @@ public:
 
     /** Marks a tx as ReceivedResponse in txrequest and checks whether AlreadyHaveTx.
      * Return a bool indicating whether this tx should be validated. If false, optionally, a
-     * PackageToValidate. */
+     * PackageToValidate. For unregistered peers, returns {false, std::nullopt}. */
     std::pair<bool, std::optional<PackageToValidate>> ReceivedTx(NodeId nodeid, const CTransactionRef& ptx);
 
     /** Whether there are any orphans to reconsider for this peer. */

--- a/src/node/txdownloadman_impl.cpp
+++ b/src/node/txdownloadman_impl.cpp
@@ -8,6 +8,7 @@
 #include <chain.h>
 #include <consensus/validation.h>
 #include <txmempool.h>
+#include <util/check.h>
 #include <util/log.h>
 #include <validation.h>
 #include <validationinterface.h>
@@ -506,6 +507,11 @@ std::pair<bool, std::optional<PackageToValidate>> TxDownloadManagerImpl::Receive
 {
     const Txid& txid = ptx->GetHash();
     const Wtxid& wtxid = ptx->GetWitnessHash();
+
+    if (!m_peer_info.contains(nodeid)) {
+        Assume(m_txrequest.Count(nodeid) == 0);
+        return {false, std::nullopt};
+    }
 
     // Mark that we have received a response
     m_txrequest.ReceivedResponse(nodeid, txid.ToUint256());

--- a/src/test/txdownload_tests.cpp
+++ b/src/test/txdownload_tests.cpp
@@ -184,7 +184,7 @@ BOOST_FIXTURE_TEST_CASE(unregistered_peer_tx_handling, TestingSetup)
         BOOST_CHECK(!package_to_validate);
     }};
 
-    check_tx(/*expected_should_validate=*/true); // TODO: Should not validate txs from unregistered peers
+    check_tx(/*expected_should_validate=*/false);
     txdownload_impl.CheckIsEmpty();
 
     txdownload_impl.ConnectedPeer(peer, node::TxDownloadConnectionInfo{/*m_preferred=*/false, /*m_relay_permissions=*/false, /*m_wtxid_relay=*/true});
@@ -194,7 +194,7 @@ BOOST_FIXTURE_TEST_CASE(unregistered_peer_tx_handling, TestingSetup)
     txdownload_impl.DisconnectedPeer(peer);
     txdownload_impl.CheckIsEmpty(peer);
 
-    check_tx(/*expected_should_validate=*/true); // TODO: Should not validate txs from disconnected peers
+    check_tx(/*expected_should_validate=*/false);
     txdownload_impl.CheckIsEmpty();
 }
 

--- a/src/test/txdownload_tests.cpp
+++ b/src/test/txdownload_tests.cpp
@@ -169,6 +169,35 @@ BOOST_FIXTURE_TEST_CASE(tx_rejection_types, TestChain100Setup)
     }
 }
 
+BOOST_FIXTURE_TEST_CASE(unregistered_peer_tx_handling, TestingSetup)
+{
+    CTxMemPool& pool{*Assert(m_node.mempool)};
+    FastRandomContext det_rand{true};
+    node::TxDownloadOptions opts{pool, det_rand, /*m_deterministic_txrequest=*/true};
+    const NodeId peer{0};
+    const CTransactionRef tx{CreatePlaceholderTx(/*segwit=*/true)};
+
+    node::TxDownloadManagerImpl txdownload_impl{opts};
+    const auto check_tx{[&](bool expected_should_validate) {
+        const auto [should_validate, package_to_validate]{txdownload_impl.ReceivedTx(peer, tx)};
+        BOOST_CHECK_EQUAL(should_validate, expected_should_validate);
+        BOOST_CHECK(!package_to_validate);
+    }};
+
+    check_tx(/*expected_should_validate=*/true); // TODO: Should not validate txs from unregistered peers
+    txdownload_impl.CheckIsEmpty();
+
+    txdownload_impl.ConnectedPeer(peer, node::TxDownloadConnectionInfo{/*m_preferred=*/false, /*m_relay_permissions=*/false, /*m_wtxid_relay=*/true});
+    check_tx(/*expected_should_validate=*/true);
+
+    BOOST_CHECK(!txdownload_impl.AddTxAnnouncement(peer, tx->GetWitnessHash(), std::chrono::microseconds{0}));
+    txdownload_impl.DisconnectedPeer(peer);
+    txdownload_impl.CheckIsEmpty(peer);
+
+    check_tx(/*expected_should_validate=*/true); // TODO: Should not validate txs from disconnected peers
+    txdownload_impl.CheckIsEmpty();
+}
+
 BOOST_FIXTURE_TEST_CASE(handle_missing_inputs, TestChain100Setup)
 {
     CTxMemPool& pool = *Assert(m_node.mempool);


### PR DESCRIPTION
**Problem:** [`ReceivedTx()`](https://github.com/bitcoin/bitcoin/blob/2063f02bd5edebe1b5c9635db8850220811ebc90/src/node/txdownloadman_impl.cpp#L505-L517) accepted peer ids with no txdownload state. In that state there is no txrequest response to mark and no registered peer metadata to use, yet the method could still return validation work.

**Reachability:** Current net processing protects the production `tx` path: peers are registered before `tx` messages are handled, and disconnect cleanup runs after message processing for that node. The fuzz target and direct component API can still call `ReceivedTx()` for arbitrary peer ids, and future lifecycle changes should keep unregistered peers from producing validation work.

**Fix:** Return `{false, std::nullopt}` for unregistered peers, with an `Assume` that txrequest cleanup stayed in sync. The unit test covers an unregistered peer, a registered-peer positive control, and a disconnected peer after a queued announcement.
