### PR TITLE
streams: enforce buffered stream boundaries

### DIFF
--- a/src/streams.cpp
+++ b/src/streams.cpp
@@ -53,6 +53,9 @@ void AutoFile::seek(int64_t offset, int origin)
 
 int64_t AutoFile::tell()
 {
+    if (IsNull()) {
+        throw std::ios_base::failure("AutoFile::tell: file handle is nullptr");
+    }
     if (!m_position.has_value()) throw std::ios_base::failure("AutoFile::tell: position unknown");
     return *m_position;
 }

--- a/src/streams.h
+++ b/src/streams.h
@@ -589,14 +589,15 @@ public:
     //! rewind to a given reading position
     bool SetPos(uint64_t nPos) {
         size_t bufsize = vchBuf.size();
+        const uint64_t max_pos{std::min(nSrcPos, nReadLimit)};
+        if (nPos > max_pos) {
+            // can't go this far forward, go as far as possible
+            m_read_pos = max_pos;
+            return false;
+        }
         if (nPos + bufsize < nSrcPos) {
             // rewinding too far, rewind as far as possible
             m_read_pos = nSrcPos - bufsize;
-            return false;
-        }
-        if (nPos > nSrcPos) {
-            // can't go this far forward, go as far as possible
-            m_read_pos = nSrcPos;
             return false;
         }
         m_read_pos = nPos;

--- a/src/streams.h
+++ b/src/streams.h
@@ -624,13 +624,20 @@ public:
         // For best performance, avoid mod operation within the loop.
         size_t buf_offset{size_t(m_read_pos % uint64_t(vchBuf.size()))};
         while (true) {
+            if (m_read_pos >= nReadLimit) {
+                throw std::ios_base::failure("Attempt to position past buffer limit");
+            }
             if (m_read_pos == nSrcPos) {
                 // No more bytes available; read from the file into the buffer,
                 // setting nSrcPos to one beyond the end of the new data.
                 // Throws exception if end-of-file reached.
                 Fill();
             }
-            const size_t len{std::min<size_t>(vchBuf.size() - buf_offset, nSrcPos - m_read_pos)};
+            const size_t len{static_cast<size_t>(std::min<uint64_t>({
+                static_cast<uint64_t>(vchBuf.size() - buf_offset),
+                nSrcPos - m_read_pos,
+                nReadLimit - m_read_pos,
+            }))};
             const auto it_start{vchBuf.begin() + buf_offset};
             const auto it_find{std::find(it_start, it_start + len, byte)};
             const size_t inc{size_t(std::distance(it_start, it_find))};

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -168,6 +168,32 @@ BOOST_AUTO_TEST_CASE(xor_file)
     }
 }
 
+BOOST_AUTO_TEST_CASE(autofile_tell_after_close)
+{
+    const fs::path path{m_args.GetDataDirBase() / "test_autofile_tell_after_close.bin"};
+
+    {
+        AutoFile file{fsbridge::fopen(path, "w+b")};
+        file << uint8_t{1};
+        BOOST_CHECK_EQUAL(file.tell(), 1);
+        BOOST_REQUIRE_EQUAL(file.fclose(), 0);
+        BOOST_CHECK(file.IsNull());
+        BOOST_CHECK_EQUAL(file.tell(), 1); // TODO: tell() should reject closed files.
+    }
+
+    {
+        AutoFile file{fsbridge::fopen(path, "rb")};
+        BOOST_CHECK_EQUAL(file.tell(), 0);
+        FILE* raw_file{file.release()};
+        BOOST_REQUIRE(raw_file != nullptr);
+        BOOST_CHECK(file.IsNull());
+        BOOST_CHECK_EQUAL(file.tell(), 0); // TODO: tell() should reject released files.
+        BOOST_REQUIRE_EQUAL(std::fclose(raw_file), 0);
+    }
+
+    fs::remove(path);
+}
+
 BOOST_AUTO_TEST_CASE(streams_vector_writer)
 {
     unsigned char a(1);
@@ -539,6 +565,34 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file_skip)
     // We can position exactly to the transfer limit.
     bf.SkipTo(13);
     BOOST_CHECK_EQUAL(bf.GetPos(), 13U);
+
+    BOOST_REQUIRE_EQUAL(file.fclose(), 0);
+    fs::remove(streams_test_filename);
+}
+
+BOOST_AUTO_TEST_CASE(streams_buffered_file_limit_boundary)
+{
+    const fs::path streams_test_filename{m_args.GetDataDirBase() / "streams_test_tmp"};
+    AutoFile file{fsbridge::fopen(streams_test_filename, "w+b")};
+    for (uint8_t j{0}; j < 40; ++j) {
+        file << j;
+    }
+    file.seek(0, SEEK_SET);
+
+    BufferedFile bf{file, 25, 10};
+    bf.SkipTo(5);
+    BOOST_CHECK_EQUAL(bf.GetPos(), 5U);
+    BOOST_CHECK(bf.SetLimit(5));
+
+    BOOST_CHECK(bf.SetPos(6)); // TODO: SetPos() should stay within the active limit.
+    BOOST_CHECK_EQUAL(bf.GetPos(), 6U);
+
+    BOOST_CHECK(bf.SetLimit());
+    BOOST_CHECK(bf.SetPos(5));
+    BOOST_CHECK(bf.SetLimit(5));
+
+    bf.FindByte(std::byte{6}); // TODO: FindByte() should stay within the active limit.
+    BOOST_CHECK_EQUAL(bf.GetPos(), 6U);
 
     BOOST_REQUIRE_EQUAL(file.fclose(), 0);
     fs::remove(streams_test_filename);

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -584,8 +584,8 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file_limit_boundary)
     BOOST_CHECK_EQUAL(bf.GetPos(), 5U);
     BOOST_CHECK(bf.SetLimit(5));
 
-    BOOST_CHECK(bf.SetPos(6)); // TODO: SetPos() should stay within the active limit.
-    BOOST_CHECK_EQUAL(bf.GetPos(), 6U);
+    BOOST_CHECK(!bf.SetPos(6));
+    BOOST_CHECK_EQUAL(bf.GetPos(), 5U);
 
     BOOST_CHECK(bf.SetLimit());
     BOOST_CHECK(bf.SetPos(5));
@@ -695,6 +695,7 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file_rand)
                 break;
             }
             case 5: {
+                bf.SetLimit();
                 size_t requestPos = m_rng.randrange(maxPos + 4);
                 bool okay = bf.SetPos(requestPos);
                 // The new position may differ from the requested position

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -178,7 +178,7 @@ BOOST_AUTO_TEST_CASE(autofile_tell_after_close)
         BOOST_CHECK_EQUAL(file.tell(), 1);
         BOOST_REQUIRE_EQUAL(file.fclose(), 0);
         BOOST_CHECK(file.IsNull());
-        BOOST_CHECK_EQUAL(file.tell(), 1); // TODO: tell() should reject closed files.
+        BOOST_CHECK_EXCEPTION(file.tell(), std::ios_base::failure, HasReason{"AutoFile::tell: file handle is nullptr"});
     }
 
     {
@@ -187,7 +187,7 @@ BOOST_AUTO_TEST_CASE(autofile_tell_after_close)
         FILE* raw_file{file.release()};
         BOOST_REQUIRE(raw_file != nullptr);
         BOOST_CHECK(file.IsNull());
-        BOOST_CHECK_EQUAL(file.tell(), 0); // TODO: tell() should reject released files.
+        BOOST_CHECK_EXCEPTION(file.tell(), std::ios_base::failure, HasReason{"AutoFile::tell: file handle is nullptr"});
         BOOST_REQUIRE_EQUAL(std::fclose(raw_file), 0);
     }
 

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -591,8 +591,8 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file_limit_boundary)
     BOOST_CHECK(bf.SetPos(5));
     BOOST_CHECK(bf.SetLimit(5));
 
-    bf.FindByte(std::byte{6}); // TODO: FindByte() should stay within the active limit.
-    BOOST_CHECK_EQUAL(bf.GetPos(), 6U);
+    BOOST_CHECK_EXCEPTION(bf.FindByte(std::byte{6}), std::ios_base::failure, HasReason{"Attempt to position past buffer limit"});
+    BOOST_CHECK_EQUAL(bf.GetPos(), 5U);
 
     BOOST_REQUIRE_EQUAL(file.fclose(), 0);
     fs::remove(streams_test_filename);
@@ -681,6 +681,7 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file_rand)
                 size_t find = currentPos + m_rng.randrange(8);
                 if (find >= fileSize)
                     find = fileSize - 1;
+                bf.SetLimit();
                 bf.FindByte(std::byte(find));
                 // The value at each offset is the offset.
                 BOOST_CHECK_EQUAL(bf.GetPos(), find);


### PR DESCRIPTION
**Problem:** `BufferedFile::SetLimit()` is enforced by [`AdvanceStream()`](https://github.com/bitcoin/bitcoin/blob/bc33509ae20ad4f52771f7e13bc9a017a48c4621/src/streams.h#L536-L541), so `read()` and `SkipTo()` stop at the active limit. [`SetPos()`](https://github.com/bitcoin/bitcoin/blob/bc33509ae20ad4f52771f7e13bc9a017a48c4621/src/streams.h#L590-L604) could still move past that limit if the requested byte was already buffered, and [`FindByte()`](https://github.com/bitcoin/bitcoin/blob/bc33509ae20ad4f52771f7e13bc9a017a48c4621/src/streams.h#L621-L633) searched to `nSrcPos` without capping at `nReadLimit`. `AutoFile::release()` [invalidates the object](https://github.com/bitcoin/bitcoin/blob/bc33509ae20ad4f52771f7e13bc9a017a48c4621/src/streams.h#L435-L443), but [`tell()`](https://github.com/bitcoin/bitcoin/blob/bc33509ae20ad4f52771f7e13bc9a017a48c4621/src/streams.cpp#L54-L57) could still return the cached position after `release()` or `fclose()`.

**Fix:** Cap `BufferedFile` positioning/searching at the active read limit and make `AutoFile::tell()` reject null handles like the other file operations. The stream unit tests first characterize the old boundary-crossing and stale-position behavior, then the fix commits flip those expectations.
