### PR TITLE
rbf: handle extreme modified-fee replacements

### DIFF
--- a/src/policy/rbf.cpp
+++ b/src/policy/rbf.cpp
@@ -14,12 +14,28 @@
 #include <uint256.h>
 #include <util/check.h>
 #include <util/moneystr.h>
+#include <util/overflow.h>
 #include <util/rbf.h>
 
 #include <limits>
+#include <span>
 #include <vector>
 
 #include <compare>
+
+namespace {
+bool DiagramTotalIsRepresentable(std::span<const FeeFrac> chunks)
+{
+    FeeFrac total;
+    for (const FeeFrac& chunk : chunks) {
+        const auto fee{CheckedAdd(total.fee, chunk.fee)};
+        const auto size{CheckedAdd(total.size, chunk.size)};
+        if (!fee || !size) return false;
+        total = FeeFrac{*fee, *size};
+    }
+    return true;
+}
+} // namespace
 
 RBFTransactionState IsRBFOptIn(const CTransaction& tx, const CTxMemPool& pool)
 {
@@ -131,6 +147,12 @@ std::optional<std::pair<DiagramCheckError, std::string>> ImprovesFeerateDiagram(
 
     if (!chunk_results.has_value()) {
         return std::make_pair(DiagramCheckError::UNCALCULABLE, util::ErrorString(chunk_results).original);
+    }
+
+    const bool old_diagram_total_representable{DiagramTotalIsRepresentable(chunk_results->first)};
+    const bool new_diagram_total_representable{DiagramTotalIsRepresentable(chunk_results->second)};
+    if (!old_diagram_total_representable || !new_diagram_total_representable) {
+        return std::make_pair(DiagramCheckError::UNCALCULABLE, "feerate diagram total overflow");
     }
 
     if (!std::is_gt(CompareChunks(chunk_results.value().second, chunk_results.value().first))) {

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -3,15 +3,18 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <common/system.h>
+#include <key_io.h>
 #include <policy/policy.h>
 #include <test/util/time.h>
 #include <test/util/txmempool.h>
 #include <txmempool.h>
 #include <util/time.h>
+#include <validation.h>
 
 #include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
+#include <limits>
 #include <vector>
 
 BOOST_FIXTURE_TEST_SUITE(mempool_tests, TestingSetup)
@@ -501,3 +504,39 @@ BOOST_AUTO_TEST_CASE(MempoolAncestryTestsDiamond)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_FIXTURE_TEST_CASE(MempoolCheckSaturatingFeeDiagram, TestChain100Setup)
+{
+    CTxMemPool& pool{*Assert(m_node.mempool)};
+    const CScript output_script{GetScriptForDestination(PKHash(coinbaseKey.GetPubKey()))};
+    mineBlocks(3);
+
+    constexpr CAmount fee{10'000};
+    const auto submit = [&](const CTransactionRef& tx) {
+        LOCK(cs_main);
+        const MempoolAcceptResult result{m_node.chainman->ProcessTransaction(tx)};
+        BOOST_REQUIRE_MESSAGE(result.m_result_type == MempoolAcceptResult::ResultType::VALID, result.m_state.ToString());
+    };
+
+    std::vector<CTransactionRef> txs;
+    for (size_t i{0}; i < 2; ++i) {
+        const auto& coinbase{m_coinbase_txns.at(i)};
+        auto tx{MakeTransactionRef(CreateValidMempoolTransaction(
+            coinbase, /*input_vout=*/0, /*input_height=*/0, coinbaseKey,
+            output_script, coinbase->vout.at(0).nValue - fee, /*submit=*/false))};
+        submit(tx);
+        txs.push_back(tx);
+    }
+
+    for (const auto& tx : txs) {
+        pool.PrioritiseTransaction(tx->GetHash(), std::numeric_limits<CAmount>::min());
+    }
+
+    {
+        LOCK(pool.cs);
+        const auto diagram{pool.GetFeerateDiagram()};
+        BOOST_REQUIRE(!diagram.empty());
+        BOOST_CHECK_EQUAL(diagram.back().fee, std::numeric_limits<CAmount>::min());
+    }
+    WITH_LOCK(::cs_main, pool.check(m_node.chainman->ActiveChainstate().CoinsTip(), m_node.chainman->ActiveChain().Height() + 1));
+}

--- a/src/test/rbf_tests.cpp
+++ b/src/test/rbf_tests.cpp
@@ -336,6 +336,50 @@ BOOST_FIXTURE_TEST_CASE(improves_feerate, TestChain100Setup)
     BOOST_CHECK(res3 == std::nullopt);
 }
 
+BOOST_FIXTURE_TEST_CASE(improves_feerate_diagram_rejects_overflowing_totals, TestChain100Setup)
+{
+    CTxMemPool& pool = *Assert(m_node.mempool);
+    LOCK2(::cs_main, pool.cs);
+    TestMemPoolEntryHelper entry;
+
+    constexpr CAmount fee{10'000};
+    const CAmount max_delta{std::numeric_limits<CAmount>::max() - fee};
+
+    const auto old_tx_1 = make_tx(/*inputs=*/{m_coinbase_txns[0]}, /*output_values=*/{10 * COIN});
+    const auto old_tx_2 = make_tx(/*inputs=*/{m_coinbase_txns[1]}, /*output_values=*/{10 * COIN});
+    TryAddToMempool(pool, entry.Fee(fee).FromTx(old_tx_1));
+    TryAddToMempool(pool, entry.Fee(fee).FromTx(old_tx_2));
+    pool.PrioritiseTransaction(old_tx_1->GetHash(), max_delta);
+    pool.PrioritiseTransaction(old_tx_2->GetHash(), max_delta);
+
+    const auto old_entry_1 = pool.GetIter(old_tx_1->GetHash()).value();
+    const auto old_entry_2 = pool.GetIter(old_tx_2->GetHash()).value();
+    BOOST_CHECK_EQUAL(old_entry_1->GetModifiedFee(), std::numeric_limits<CAmount>::max());
+    BOOST_CHECK_EQUAL(old_entry_2->GetModifiedFee(), std::numeric_limits<CAmount>::max());
+
+    const auto replacement_tx = make_tx(/*inputs=*/{m_coinbase_txns[2]}, /*output_values=*/{9 * COIN});
+    auto changeset = pool.GetChangeSet();
+    changeset->StageRemoval(old_entry_1);
+    changeset->StageRemoval(old_entry_2);
+    changeset->StageAddition(replacement_tx,
+                             std::numeric_limits<CAmount>::max(),
+                             /*time=*/0,
+                             /*entry_height=*/1,
+                             /*entry_sequence=*/0,
+                             /*spends_coinbase=*/false,
+                             /*sigops_cost=*/4,
+                             LockPoints());
+
+    const auto chunks{changeset->CalculateChunksForRBF()};
+    BOOST_REQUIRE(chunks.has_value());
+    BOOST_REQUIRE_GE(chunks->first.size(), 2U);
+
+    const auto result{ImprovesFeerateDiagram(*changeset)};
+    BOOST_REQUIRE(result.has_value());
+    BOOST_CHECK(result->first == DiagramCheckError::UNCALCULABLE);
+    BOOST_CHECK_EQUAL(result->second, "feerate diagram total overflow");
+}
+
 BOOST_FIXTURE_TEST_CASE(calc_feerate_diagram_rbf, TestChain100Setup)
 {
     CTxMemPool& pool = *Assert(m_node.mempool);

--- a/src/test/txvalidation_tests.cpp
+++ b/src/test/txvalidation_tests.cpp
@@ -18,6 +18,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <limits>
+#include <string>
 
 BOOST_AUTO_TEST_SUITE(txvalidation_tests)
 
@@ -52,6 +54,60 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_reject_coinbase, TestChain100Setup)
     BOOST_CHECK(result.m_state.IsInvalid());
     BOOST_CHECK_EQUAL(result.m_state.GetRejectReason(), "coinbase");
     BOOST_CHECK(result.m_state.GetResult() == TxValidationResult::TX_CONSENSUS);
+}
+
+BOOST_FIXTURE_TEST_CASE(tx_mempool_rbf_conflicting_fees_saturate, TestChain100Setup)
+{
+    CTxMemPool& pool{*Assert(m_node.mempool)};
+    const CScript output_script{GetScriptForDestination(PKHash(coinbaseKey.GetPubKey()))};
+    CreateAndProcessBlock(/*txns=*/{}, output_script);
+    const CAmount fee{10'000};
+    std::vector<CTransactionRef> conflicts;
+
+    for (size_t i{0}; i < 2; ++i) {
+        auto conflict{MakeTransactionRef(CreateValidMempoolTransaction(m_coinbase_txns.at(i), /*input_vout=*/0,
+                                                                       /*input_height=*/0, coinbaseKey,
+                                                                       output_script,
+                                                                       /*output_amount=*/m_coinbase_txns.at(i)->vout.at(0).nValue - fee,
+                                                                       /*submit=*/false))};
+        {
+            LOCK(cs_main);
+            const MempoolAcceptResult result{m_node.chainman->ProcessTransaction(conflict)};
+            BOOST_REQUIRE_MESSAGE(result.m_result_type == MempoolAcceptResult::ResultType::VALID, result.m_state.ToString());
+        }
+        conflicts.push_back(conflict);
+    }
+
+    for (const auto& conflict : conflicts) {
+        pool.PrioritiseTransaction(conflict->GetHash(), std::numeric_limits<CAmount>::max());
+        LOCK(pool.cs);
+        const auto entry{pool.GetIter(conflict->GetHash())};
+        BOOST_REQUIRE(entry.has_value());
+        BOOST_CHECK_EQUAL((*entry)->GetModifiedFee(), std::numeric_limits<CAmount>::max());
+    }
+
+    std::vector<COutPoint> replacement_inputs{
+        {m_coinbase_txns.at(0)->GetHash(), 0},
+        {m_coinbase_txns.at(1)->GetHash(), 0},
+    };
+    auto replacement{MakeTransactionRef(CreateValidMempoolTransaction(
+        /*input_transactions=*/{m_coinbase_txns.at(0), m_coinbase_txns.at(1)},
+        /*inputs=*/replacement_inputs,
+        /*input_height=*/0,
+        /*input_signing_keys=*/{coinbaseKey},
+        /*outputs=*/{CTxOut{m_coinbase_txns.at(0)->vout.at(0).nValue + m_coinbase_txns.at(1)->vout.at(0).nValue - fee, output_script}},
+        /*submit=*/false))};
+
+    LOCK(cs_main);
+    const MempoolAcceptResult result{m_node.chainman->ProcessTransaction(replacement)};
+    BOOST_CHECK(result.m_result_type == MempoolAcceptResult::ResultType::INVALID);
+    BOOST_CHECK_EQUAL(result.m_state.GetResult(), TxValidationResult::TX_RECONSIDERABLE);
+    BOOST_CHECK_EQUAL(result.m_state.GetRejectReason(), "insufficient fee");
+    BOOST_CHECK(result.m_state.GetDebugMessage().find("less fees than conflicting txs") != std::string::npos);
+    BOOST_CHECK(!pool.exists(replacement->GetHash()));
+    for (const auto& conflict : conflicts) {
+        BOOST_CHECK(pool.exists(conflict->GetHash()));
+    }
 }
 
 // Generate a number of random, nonexistent outpoints.

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -443,6 +443,10 @@ void CTxMemPool::check(const CCoinsViewCache& active_coins_tip, int64_t spendhei
     uint64_t checkTotal = 0;
     CAmount check_total_fee{0};
     CAmount check_total_modified_fee{0};
+    // Saturating addition is order-dependent after overflow, so fee diagram
+    // points can only be compared with the transaction-order prefix while the
+    // prefix sum remains representable.
+    bool check_total_modified_fee_overflowed{false};
     int64_t check_total_adjusted_weight{0};
     uint64_t innerUsage = 0;
 
@@ -469,14 +473,18 @@ void CTxMemPool::check(const CCoinsViewCache& active_coins_tip, int64_t spendhei
         // The feerate diagram should never get behind the current transaction
         // size totals.
         assert(diagram_iter->size >= check_total_adjusted_weight);
-        if (diagram_iter->fee == check_total_modified_fee &&
-                diagram_iter->size == check_total_adjusted_weight) {
+        if (diagram_iter->size == check_total_adjusted_weight) {
+            if (!check_total_modified_fee_overflowed) {
+                assert(diagram_iter->fee == check_total_modified_fee);
+            }
             ++diagram_iter;
         }
         checkTotal += it->GetTxSize();
         check_total_adjusted_weight += it->GetAdjustedWeight();
         check_total_fee += it->GetFee();
-        check_total_modified_fee += it->GetModifiedFee();
+        const auto new_check_total_modified_fee{CheckedAdd(check_total_modified_fee, it->GetModifiedFee())};
+        check_total_modified_fee_overflowed |= !new_check_total_modified_fee.has_value();
+        check_total_modified_fee = new_check_total_modified_fee.value_or(SaturatingAdd(check_total_modified_fee, it->GetModifiedFee()));
         innerUsage += it->DynamicMemoryUsage();
         const CTransaction& tx = it->GetTx();
 
@@ -548,7 +556,9 @@ void CTxMemPool::check(const CCoinsViewCache& active_coins_tip, int64_t spendhei
 
     assert(totalTxSize == checkTotal);
     assert(m_total_fee == check_total_fee);
-    assert(diagram.back().fee == check_total_modified_fee);
+    if (!check_total_modified_fee_overflowed) {
+        assert(diagram.back().fee == check_total_modified_fee);
+    }
     assert(diagram.back().size == check_total_adjusted_weight);
     assert(innerUsage == cachedInnerUsage);
 }
@@ -1092,7 +1102,10 @@ std::vector<FeePerWeight> CTxMemPool::GetFeerateDiagram() const
 
     FeePerWeight last_selection = GetBlockBuilderChunk(dummy);
     while (last_selection != FeePerWeight{}) {
-        last_selection += ret.back();
+        last_selection = FeePerWeight{
+            SaturatingAdd(last_selection.fee, ret.back().fee),
+            SaturatingAdd(last_selection.size, ret.back().size),
+        };
         ret.emplace_back(last_selection);
         IncludeBuilderChunk();
         last_selection = GetBlockBuilderChunk(dummy);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1029,8 +1029,9 @@ bool MemPoolAccept::ReplacementChecks(Workspace& ws)
     }
 
     if (const auto err_string{ImprovesFeerateDiagram(*m_subpackage.m_changeset)}) {
-        // We checked above for the cluster size limits being respected, so a
-        // failure here can only be due to an insufficient fee.
+        if (err_string->first == DiagramCheckError::UNCALCULABLE) {
+            return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "replacement-failed", err_string->second);
+        }
         Assume(err_string->first == DiagramCheckError::FAILURE);
         return state.Invalid(TxValidationResult::TX_RECONSIDERABLE, "replacement-failed", err_string->second);
     }
@@ -1122,7 +1123,7 @@ bool MemPoolAccept::PackageRBFChecks(const std::vector<CTransactionRef>& txns,
 
     // Check if it's economically rational to mine this package rather than the ones it replaces.
     if (const auto err_tup{ImprovesFeerateDiagram(*m_subpackage.m_changeset)}) {
-        Assume(err_tup->first == DiagramCheckError::FAILURE);
+        Assume(err_tup->first == DiagramCheckError::FAILURE || err_tup->first == DiagramCheckError::UNCALCULABLE);
         return package_state.Invalid(PackageValidationResult::PCKG_POLICY,
                                      "package RBF failed: " + err_tup.value().second, "");
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -55,6 +55,7 @@
 #include <util/hasher.h>
 #include <util/log.h>
 #include <util/moneystr.h>
+#include <util/overflow.h>
 #include <util/rbf.h>
 #include <util/result.h>
 #include <util/signalinterrupt.h>
@@ -69,6 +70,7 @@
 #include <cassert>
 #include <chrono>
 #include <deque>
+#include <limits>
 #include <numeric>
 #include <optional>
 #include <ranges>
@@ -118,6 +120,12 @@ static bool ShouldCompactChainstate(bool in_ibd)
 {
     static constexpr uint32_t flush_ratio{320}; // Roughly every 2 weeks with hourly flushes
     return !in_ibd && FastRandomContext().randrange(flush_ratio) == 0;
+}
+
+static CAmount SaturatingSub(const CAmount left, const CAmount right)
+{
+    if (right == std::numeric_limits<CAmount>::min()) return std::numeric_limits<CAmount>::max();
+    return SaturatingAdd(left, -right);
 }
 
 TRACEPOINT_SEMAPHORE(validation, block_connected);
@@ -1007,7 +1015,7 @@ bool MemPoolAccept::ReplacementChecks(Workspace& ws)
     // Check if it's economically rational to mine this transaction rather than the ones it
     // replaces and pays for its own relay fees. Enforce Rules #3 and #4.
     for (CTxMemPool::txiter it : all_conflicts) {
-        m_subpackage.m_conflicting_fees += it->GetModifiedFee();
+        m_subpackage.m_conflicting_fees = SaturatingAdd(m_subpackage.m_conflicting_fees, it->GetModifiedFee());
         m_subpackage.m_conflicting_size += it->GetTxSize();
     }
 
@@ -1092,7 +1100,7 @@ bool MemPoolAccept::PackageRBFChecks(const std::vector<CTransactionRef>& txns,
 
     for (CTxMemPool::txiter it : all_conflicts) {
         m_subpackage.m_changeset->StageRemoval(it);
-        m_subpackage.m_conflicting_fees += it->GetModifiedFee();
+        m_subpackage.m_conflicting_fees = SaturatingAdd(m_subpackage.m_conflicting_fees, it->GetModifiedFee());
         m_subpackage.m_conflicting_size += it->GetTxSize();
     }
 
@@ -1294,7 +1302,7 @@ bool MemPoolAccept::SubmitPackage(const ATMPArgs& args, std::vector<Workspace>& 
     if (!m_subpackage.m_replaced_transactions.empty()) {
         LogDebug(BCLog::MEMPOOL, "replaced %u mempool transactions with %u new one(s) for %s additional fees, %d delta bytes\n",
                  m_subpackage.m_replaced_transactions.size(), workspaces.size(),
-                 m_subpackage.m_total_modified_fees - m_subpackage.m_conflicting_fees,
+                 SaturatingSub(m_subpackage.m_total_modified_fees, m_subpackage.m_conflicting_fees),
                  m_subpackage.m_total_vsize - static_cast<int>(m_subpackage.m_conflicting_size));
     }
 
@@ -1428,7 +1436,7 @@ MempoolAcceptResult MemPoolAccept::AcceptSingleTransactionInternal(const CTransa
     if (!m_subpackage.m_replaced_transactions.empty()) {
         LogDebug(BCLog::MEMPOOL, "replaced %u mempool transactions with 1 new transaction for %s additional fees, %d delta bytes\n",
                  m_subpackage.m_replaced_transactions.size(),
-                 ws.m_modified_fees - m_subpackage.m_conflicting_fees,
+                 SaturatingSub(ws.m_modified_fees, m_subpackage.m_conflicting_fees),
                  ws.m_vsize - static_cast<int>(m_subpackage.m_conflicting_size));
     }
 
@@ -1504,7 +1512,7 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptMultipleTransactionsInternal(con
     m_subpackage.m_total_vsize = std::accumulate(workspaces.cbegin(), workspaces.cend(), int64_t{0},
         [](int64_t sum, auto& ws) { return sum + ws.m_vsize; });
     m_subpackage.m_total_modified_fees = std::accumulate(workspaces.cbegin(), workspaces.cend(), CAmount{0},
-        [](CAmount sum, auto& ws) { return sum + ws.m_modified_fees; });
+        [](CAmount sum, auto& ws) { return SaturatingAdd(sum, ws.m_modified_fees); });
     const CFeeRate package_feerate(m_subpackage.m_total_modified_fees, m_subpackage.m_total_vsize);
     std::vector<Wtxid> all_package_wtxids;
     all_package_wtxids.reserve(workspaces.size());

--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -28,7 +28,7 @@ class ReplaceByFeeTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
         self.uses_wallet = None
-        self.extra_args = [["-deprecatedrpc=fullrbf", "-deprecatedrpc=bip125"], []]
+        self.extra_args = [["-checkmempool=1", "-deprecatedrpc=fullrbf", "-deprecatedrpc=bip125"], []]
 
     def run_test(self):
         self.wallet = MiniWallet(self.nodes[0])

--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -464,6 +464,31 @@ class ReplaceByFeeTest(BitcoinTestFramework):
 
         assert tx2b_txid in self.nodes[0].getrawmempool()
 
+        # 3. Check summing multiple extreme conflict fees fails cleanly.
+        tx4_outpoints = [self.make_utxo(self.nodes[0], int(1.1 * COIN)) for _ in range(2)]
+        tx4a_txids = []
+        for outpoint in tx4_outpoints:
+            tx4a = self.wallet.send_self_transfer(
+                from_node=self.nodes[0],
+                utxo_to_spend=outpoint,
+                sequence=0,
+                fee=Decimal("0.00010000"),
+            )
+            tx4a_txids.append(tx4a["txid"])
+            self.nodes[0].prioritisetransaction(txid=tx4a["txid"], fee_delta=2**63 - 1)
+        assert_equal(self.nodes[0].getmempoolfeeratediagram()[-1]["fee"], Decimal(2**63 - 1) / COIN)
+
+        tx4b = self.wallet.create_self_transfer_multi(
+            utxos_to_spend=tx4_outpoints,
+            sequence=0,
+            fee_per_output=10000,
+        )
+        assert_raises_rpc_error(-26, "insufficient fee", self.nodes[0].sendrawtransaction, tx4b["hex"], 0)
+        mempool = self.nodes[0].getrawmempool()
+        for txid in tx4a_txids:
+            assert txid in mempool
+        assert tx4b["txid"] not in mempool
+
     def test_rpc(self):
         us0 = self.wallet.get_utxo()
         ins = [us0]


### PR DESCRIPTION
**Problem:** `prioritisetransaction` can push mempool entries to extreme modified fees. The single replacement-fee delta is handled separately; replacements can still involve multiple conflicts, so fee-diagram totals, mempool diagram accumulation, and validation conflict-fee aggregates could overflow before returning a policy result.

**Fix:** Reject RBF fee diagrams whose total fee or size is not representable before calling `CompareChunks()`, accumulate mempool fee-diagram totals with saturating arithmetic, and saturate validation-side modified-fee aggregates. Unit tests cover the diagram guard, mempool diagram/check path, and validation aggregate path; `feature_rbf.py` exercises the RPC path with `prioritisetransaction`, `getmempoolfeeratediagram`, and `sendrawtransaction` under `-checkmempool=1`.
