### PR TITLE
validation: fix block index bookkeeping for pruned blocks

### DIFF
--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -259,12 +259,27 @@ void BlockManager::AddUnlinkedBlock(CBlockIndex* block)
 {
     AssertLockHeld(cs_main);
     Assume(block != nullptr);
-    Assume(block->nStatus & BLOCK_HAVE_DATA);
+    Assume(block->pprev != nullptr);
+    Assume(block->nTx > 0);
     auto range = m_blocks_unlinked.equal_range(block->pprev);
     for (auto it = range.first; it != range.second; ++it) {
         if (it->second == block) return;  // don't insert duplicates
     }
     m_blocks_unlinked.emplace(block->pprev, block);
+}
+
+void BlockManager::RemoveUnlinkedBlock(CBlockIndex* block)
+{
+    AssertLockHeld(cs_main);
+    Assume(block != nullptr);
+    if (block->pprev == nullptr) return;
+    auto range = m_blocks_unlinked.equal_range(block->pprev);
+    for (auto it = range.first; it != range.second; ++it) {
+        if (it->second == block) {
+            m_blocks_unlinked.erase(it);
+            return; // AddUnlinkedBlock keeps pairs unique, so at most one match
+        }
+    }
 }
 
 void BlockManager::PruneOneBlockFile(const int fileNumber)
@@ -281,17 +296,13 @@ void BlockManager::PruneOneBlockFile(const int fileNumber)
             pindex->nUndoPos = 0;
             m_dirty_blockindex.insert(pindex);
 
-            // Prune from m_blocks_unlinked -- any block we prune would have
-            // to be downloaded again in order to consider its chain, at which
-            // point it would be considered as a candidate for
-            // m_blocks_unlinked or setBlockIndexCandidates.
-            auto range = m_blocks_unlinked.equal_range(pindex->pprev);
-            while (range.first != range.second) {
-                std::multimap<CBlockIndex*, CBlockIndex*>::iterator _it = range.first;
-                range.first++;
-                if (_it->second == pindex) {
-                    m_blocks_unlinked.erase(_it);
-                }
+            // Prune from m_blocks_unlinked unless this block is still waiting
+            // for ancestor transaction counts. A pruned block with a known
+            // transaction count still needs to be linked when its parent count
+            // becomes known, even though it will need to be downloaded again
+            // before its chain can be considered.
+            if (pindex->HaveNumChainTxs()) {
+                RemoveUnlinkedBlock(pindex);
             }
         }
     }
@@ -498,9 +509,7 @@ bool BlockManager::LoadBlockIndex(const std::optional<uint256>& snapshot_blockha
                     pindex->m_chain_tx_count = pindex->pprev->m_chain_tx_count + pindex->nTx;
                 } else {
                     pindex->m_chain_tx_count = 0;
-                    if (pindex->nStatus & BLOCK_HAVE_DATA) {
-                        AddUnlinkedBlock(pindex);
-                    }
+                    AddUnlinkedBlock(pindex);
                 }
             } else {
                 pindex->m_chain_tx_count = pindex->nTx;

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -351,10 +351,16 @@ public:
     std::vector<CBlockIndex*> GetAllBlockIndices() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /**
-     * All pairs A->B, where A (or one of its ancestors) misses transactions, but B has transactions.
+     * All pairs A->B, where A == B->pprev and B has a transaction count (nTx > 0).
+     * Either B lacks a chain transaction count and waits for A to acquire one so
+     * B can be linked (B's own block data may have been pruned in the meantime),
+     * or B has a chain transaction count and block data but was removed from
+     * setBlockIndexCandidates because block data of A or one of A's ancestors was
+     * pruned and must be downloaded again.
      */
     std::multimap<CBlockIndex*, CBlockIndex*> m_blocks_unlinked;
     void AddUnlinkedBlock(CBlockIndex* block) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    void RemoveUnlinkedBlock(CBlockIndex* block) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     std::unique_ptr<BlockTreeDB> m_block_tree_db GUARDED_BY(::cs_main);
 

--- a/src/test/fuzz/block_index_tree.cpp
+++ b/src/test/fuzz/block_index_tree.cpp
@@ -170,7 +170,7 @@ FUZZ_TARGET(block_index_tree, .init = initialize_block_index_tree)
                     while (range.first != range.second) {
                         std::multimap<CBlockIndex*, CBlockIndex*>::iterator _it = range.first;
                         range.first++;
-                        if (_it->second == prune_block) {
+                        if (_it->second == prune_block && prune_block->HaveNumChainTxs()) {
                             blockman.m_blocks_unlinked.erase(_it);
                         }
                     }

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -689,6 +689,47 @@ BOOST_FIXTURE_TEST_CASE(received_block_transactions_readds_pruned_candidate, Tes
     BOOST_CHECK(candidates_sorted());
     chainman.CheckBlockIndex();
 }
+
+BOOST_FIXTURE_TEST_CASE(received_block_transactions_links_pruned_unlinked_child, TestChain100Setup)
+{
+    ChainstateManager& chainman{*Assert(m_node.chainman)};
+    Chainstate& chainstate{chainman.ActiveChainstate()};
+    auto& blockman{chainman.m_blockman};
+
+    LOCK(chainman.GetMutex());
+    CBlockIndex* tip{chainman.ActiveChain().Tip()};
+    CBlockIndex* parent{blockman.AddToBlockIndex(ChildHeader(*tip, /*nonce=*/9), chainman.m_best_header)};
+    CBlockIndex* child{blockman.AddToBlockIndex(ChildHeader(*parent, /*nonce=*/10), chainman.m_best_header)};
+
+    CBlock child_block{DummyBlockWithTransactions(/*tx_count=*/2)};
+    const FlatFilePos child_pos{1, 1};
+    blockman.UpdateBlockInfo(child_block, child->nHeight, child_pos);
+    chainman.ReceivedBlockTransactions(child_block, child, child_pos);
+    BOOST_REQUIRE(child->nStatus & BLOCK_HAVE_DATA);
+    BOOST_REQUIRE(!child->HaveNumChainTxs());
+    BOOST_CHECK_EQUAL(blockman.m_blocks_unlinked.count(parent), 1U);
+
+    blockman.m_have_pruned = true;
+    blockman.PruneOneBlockFile(child_pos.nFile);
+    BOOST_CHECK(!(child->nStatus & BLOCK_HAVE_DATA));
+    BOOST_CHECK(!child->HaveNumChainTxs());
+    BOOST_CHECK_EQUAL(blockman.m_blocks_unlinked.count(parent), 1U);
+    chainman.CheckBlockIndex();
+
+    CBlock parent_block{DummyBlockWithTransactions(/*tx_count=*/3)};
+    const FlatFilePos parent_pos{2, 1};
+    blockman.UpdateBlockInfo(parent_block, parent->nHeight, parent_pos);
+    chainman.ReceivedBlockTransactions(parent_block, parent, parent_pos);
+
+    BOOST_CHECK(parent->HaveNumChainTxs());
+    BOOST_CHECK(child->HaveNumChainTxs());
+    BOOST_CHECK_EQUAL(child->m_chain_tx_count, parent->m_chain_tx_count + child->nTx);
+    BOOST_CHECK(!(child->nStatus & BLOCK_HAVE_DATA));
+    BOOST_CHECK_EQUAL(blockman.m_blocks_unlinked.count(parent), 0U);
+    BOOST_CHECK_EQUAL(chainstate.setBlockIndexCandidates.count(parent), 1U);
+    BOOST_CHECK_EQUAL(chainstate.setBlockIndexCandidates.count(child), 0U);
+    chainman.CheckBlockIndex();
+}
 //! Verify that ReconsiderBlock clears failure flags for the target block, its ancestors, and descendants,
 //! but not for sibling forks that diverge from a shared ancestor.
 BOOST_FIXTURE_TEST_CASE(invalidate_block_and_reconsider_fork, TestChain100Setup)

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -4,10 +4,13 @@
 //
 #include <chainparams.h>
 #include <consensus/validation.h>
+#include <flatfile.h>
 #include <kernel/disconnected_transactions.h>
 #include <node/chainstatemanager_args.h>
 #include <node/kernel_notifications.h>
 #include <node/utxo_snapshot.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
 #include <random.h>
 #include <rpc/blockchain.h>
 #include <sync.h>
@@ -17,6 +20,7 @@
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <test/util/validation.h>
+#include <tinyformat.h>
 #include <uint256.h>
 #include <util/byte_units.h>
 #include <util/result.h>
@@ -24,15 +28,36 @@
 #include <validation.h>
 #include <validationinterface.h>
 
-#include <tinyformat.h>
-
-#include <vector>
-
 #include <boost/test/unit_test.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <vector>
 
 using node::BlockManager;
 using node::KernelNotifications;
 using node::SnapshotMetadata;
+
+namespace {
+CBlockHeader ChildHeader(const CBlockIndex& parent, uint32_t nonce)
+{
+    CBlockHeader header;
+    header.nVersion = 4;
+    header.hashPrevBlock = parent.GetBlockHash();
+    header.hashMerkleRoot = uint256{static_cast<uint8_t>(nonce)};
+    header.nTime = parent.GetBlockTime() + 1;
+    header.nBits = Params().GenesisBlock().nBits;
+    header.nNonce = nonce;
+    return header;
+}
+
+CBlock DummyBlockWithTransactions(size_t tx_count)
+{
+    CBlock block;
+    block.vtx.assign(tx_count, MakeTransactionRef(CMutableTransaction{}));
+    return block;
+}
+} // namespace
 
 BOOST_FIXTURE_TEST_SUITE(validation_chainstatemanager_tests, TestingSetup)
 
@@ -619,6 +644,51 @@ BOOST_FIXTURE_TEST_CASE(loadblockindex_invalid_descendants, TestChain100Setup)
     BOOST_CHECK(child->nStatus & BLOCK_FAILED_VALID);
 }
 
+BOOST_FIXTURE_TEST_CASE(received_block_transactions_readds_pruned_candidate, TestChain100Setup)
+{
+    ChainstateManager& chainman{*Assert(m_node.chainman)};
+    Chainstate& chainstate{chainman.ActiveChainstate()};
+    auto& blockman{chainman.m_blockman};
+
+    LOCK(chainman.GetMutex());
+    CBlockIndex* tip{chainman.ActiveChain().Tip()};
+    CBlockIndex* first{blockman.AddToBlockIndex(ChildHeader(*tip, /*nonce=*/11), chainman.m_best_header)};
+    CBlockIndex* second{blockman.AddToBlockIndex(ChildHeader(*tip, /*nonce=*/12), chainman.m_best_header)};
+    auto candidates_sorted{[&] {
+        return std::ranges::is_sorted(chainstate.setBlockIndexCandidates, chainstate.setBlockIndexCandidates.value_comp());
+    }};
+
+    CBlock block{DummyBlockWithTransactions(/*tx_count=*/2)};
+    const FlatFilePos first_pos{1, 1};
+    blockman.UpdateBlockInfo(block, first->nHeight, first_pos);
+    chainman.ReceivedBlockTransactions(block, first, first_pos);
+    const FlatFilePos second_pos{2, 1};
+    blockman.UpdateBlockInfo(block, second->nHeight, second_pos);
+    chainman.ReceivedBlockTransactions(block, second, second_pos);
+    BOOST_REQUIRE(first->HaveNumChainTxs());
+    BOOST_REQUIRE(second->HaveNumChainTxs());
+    BOOST_REQUIRE(first->nStatus & BLOCK_HAVE_DATA);
+    BOOST_REQUIRE(second->nStatus & BLOCK_HAVE_DATA);
+    BOOST_REQUIRE_EQUAL(chainstate.setBlockIndexCandidates.count(first), 1U);
+    BOOST_REQUIRE_EQUAL(chainstate.setBlockIndexCandidates.count(second), 1U);
+    BOOST_REQUIRE(candidates_sorted());
+
+    blockman.m_have_pruned = true;
+    blockman.PruneOneBlockFile(first_pos.nFile);
+    BOOST_REQUIRE(!(first->nStatus & BLOCK_HAVE_DATA));
+    BOOST_REQUIRE_EQUAL(chainstate.setBlockIndexCandidates.count(first), 1U);
+
+    const FlatFilePos redownloaded_pos{3, 1};
+    blockman.UpdateBlockInfo(block, first->nHeight, redownloaded_pos);
+    chainman.ReceivedBlockTransactions(block, first, redownloaded_pos);
+
+    BOOST_CHECK(first->nStatus & BLOCK_HAVE_DATA);
+    BOOST_CHECK(first->HaveNumChainTxs());
+    BOOST_CHECK_EQUAL(chainstate.setBlockIndexCandidates.count(first), 1U);
+    BOOST_CHECK_EQUAL(chainstate.setBlockIndexCandidates.count(second), 1U);
+    BOOST_CHECK(candidates_sorted());
+    chainman.CheckBlockIndex();
+}
 //! Verify that ReconsiderBlock clears failure flags for the target block, its ancestors, and descendants,
 //! but not for sibling forks that diverge from a shared ancestor.
 BOOST_FIXTURE_TEST_CASE(invalidate_block_and_reconsider_fork, TestChain100Setup)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3823,8 +3823,10 @@ void ChainstateManager::ReceivedBlockTransactions(const CBlock& block, CBlockInd
             }
             pindex->m_chain_tx_count = prev_tx_sum(*pindex);
             pindex->nSequenceId = nBlockSequenceId++;
-            for (const auto& c : m_chainstates) {
-                c->TryAddBlockIndexCandidate(pindex);
+            if (pindex->nStatus & BLOCK_HAVE_DATA) {
+                for (const auto& c : m_chainstates) {
+                    c->TryAddBlockIndexCandidate(pindex);
+                }
             }
             std::pair<std::multimap<CBlockIndex*, CBlockIndex*>::iterator, std::multimap<CBlockIndex*, CBlockIndex*>::iterator> range = m_blockman.m_blocks_unlinked.equal_range(pindex);
             while (range.first != range.second) {
@@ -5380,11 +5382,14 @@ void ChainstateManager::CheckBlockIndex() const
                 foundInUnlinked = true;
             }
         }
-        if (pindex->pprev && (pindex->nStatus & BLOCK_HAVE_DATA) && pindexFirstNeverProcessed != nullptr && pindexFirstInvalid == nullptr) {
-            // If this block has block data available, some parent was never received, and has no invalid parents, it must be in m_blocks_unlinked.
+        if (pindex->pprev && pindex->nTx > 0 && !pindex->HaveNumChainTxs() && pindexFirstInvalid == nullptr) {
+            // If this block has a transaction count, some parent was never received, and has no invalid parents,
+            // it must be in m_blocks_unlinked so it can be linked when the parent arrives. The block itself may
+            // have been pruned after its transaction count was recorded.
             assert(foundInUnlinked);
         }
-        if (!(pindex->nStatus & BLOCK_HAVE_DATA)) assert(!foundInUnlinked); // Can't be in m_blocks_unlinked if we don't HAVE_DATA
+        // A pruned block can only remain in m_blocks_unlinked while it still needs chain transaction counts.
+        if (!(pindex->nStatus & BLOCK_HAVE_DATA) && pindex->HaveNumChainTxs()) assert(!foundInUnlinked);
         if (pindexFirstMissing == nullptr) assert(!foundInUnlinked); // We aren't missing data for any parent -- cannot be in m_blocks_unlinked.
         if (pindex->pprev && (pindex->nStatus & BLOCK_HAVE_DATA) && pindexFirstNeverProcessed == nullptr && pindexFirstMissing != nullptr) {
             // We HAVE_DATA for this block, have received data for all parents at some point, but we're currently missing data for some parent.
@@ -5972,6 +5977,7 @@ util::Result<void> ChainstateManager::PopulateAndValidateSnapshot(
     assert(index);
     assert(index == snapshot_start_block);
     index->m_chain_tx_count = au_data.m_chain_tx_count;
+    m_blockman.RemoveUnlinkedBlock(index);
 
     LogInfo("[snapshot] validated snapshot (%.2f MB)",
         coins_cache.DynamicMemoryUsage() / (1000 * 1000));

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3815,6 +3815,12 @@ void ChainstateManager::ReceivedBlockTransactions(const CBlock& block, CBlockInd
                 LogWarning("Internal bug detected: block %d has unexpected m_chain_tx_count %i that should be %i (%s %s). Please report this issue here: %s\n",
                    pindex->nHeight, pindex->m_chain_tx_count, prev_tx_sum(*pindex), CLIENT_NAME, FormatFullVersion(), CLIENT_BUGREPORT);
             }
+            // nSequenceId participates in setBlockIndexCandidates ordering. Remove
+            // the block before mutating it, then add it back below if it is still a
+            // candidate.
+            for (const auto& c : m_chainstates) {
+                c->setBlockIndexCandidates.erase(pindex);
+            }
             pindex->m_chain_tx_count = prev_tx_sum(*pindex);
             pindex->nSequenceId = nBlockSequenceId++;
             for (const auto& c : m_chainstates) {


### PR DESCRIPTION
**Problem:** Two pruned-block paths could leave block-index bookkeeping inconsistent.
Redownloading a pruned candidate changed `nSequenceId` while the block was still in `setBlockIndexCandidates`, whose ordering uses that field.
Pruning an unlinked child before its parent arrived also removed the child from `m_blocks_unlinked`; when the parent was later processed, the child was not linked and `-checkblockindex` could abort because the child still had no chain transaction count.

**Fix:** Erase candidates before changing `nSequenceId`, then re-add through the existing candidate path.
Keep pruned `m_blocks_unlinked` entries until their chain transaction count is assigned, rebuild that state on `LoadBlockIndex()`, and erase an assumeutxo snapshot base entry when snapshot loading stamps its count directly.
Unit tests cover equal-work candidate redownload and parent-after-pruned-child linking.
