### PR TITLE
ipc: skip empty Data byte copies

### DIFF
--- a/src/ipc/libmultiprocess/include/mp/type-data.h
+++ b/src/ipc/libmultiprocess/include/mp/type-data.h
@@ -33,7 +33,7 @@ requires (std::is_same_v<decltype(output.get()), ::capnp::Data::Builder> && IsBy
 {
     auto data = std::span{value};
     auto result = output.init(data.size());
-    memcpy(result.begin(), data.data(), data.size());
+    if (data.size()) memcpy(result.begin(), data.data(), data.size());
 }
 
 template <typename LocalType, typename Input, typename ReadDest>

--- a/src/ipc/test/fuzz/ipc.cpp
+++ b/src/ipc/test/fuzz/ipc.cpp
@@ -93,6 +93,8 @@ FUZZ_TARGET(ipc, .init = initialize_ipc)
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     const size_t iterations = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(1, 64);
 
+    assert(ipc.m_client->passVectorUint8({}).empty());
+
     for (size_t i = 0; i < iterations; ++i) {
         CallOneOf(
             fuzzed_data_provider,
@@ -111,8 +113,6 @@ FUZZ_TARGET(ipc, .init = initialize_ipc)
             },
             [&] {
                 std::vector<uint8_t> value = ConsumeRandomLengthByteVector<uint8_t>(fuzzed_data_provider, 512);
-                // Empty Data currently trips UBSan in the libmultiprocess byte-span serializer.
-                if (value.empty()) value.push_back(0);
                 std::vector<uint8_t> expected{value.rbegin(), value.rend()};
                 assert(ipc.m_client->passVectorUint8(value) == expected);
             },


### PR DESCRIPTION
**Problem:** The byte-span `capnp::Data` serializer [always called `memcpy()`](https://github.com/bitcoin/bitcoin/blob/e3b026bf56e66baa6e070a00c136da95f3a16ef8/src/ipc/libmultiprocess/include/mp/type-data.h#L33-L36), even when `data.size() == 0`.
In that case there are no bytes to copy, and empty byte-vector inputs may expose a null `data()` pointer.
The IPC fuzz target previously avoided this path by rewriting empty byte vectors to one-byte inputs.

**Fix:** Return the empty `Data` builder without calling `memcpy()`.
The IPC fuzz target now exercises empty byte vectors directly.