### PR TITLE
crypto: accept empty HMAC keys

### DIFF
--- a/src/crypto/hmac_sha256.cpp
+++ b/src/crypto/hmac_sha256.cpp
@@ -13,7 +13,7 @@ CHMAC_SHA256::CHMAC_SHA256(const unsigned char* key, size_t keylen)
 {
     unsigned char rkey[64];
     if (keylen <= 64) {
-        memcpy(rkey, key, keylen);
+        if (keylen) memcpy(rkey, key, keylen);
         memset(rkey + keylen, 0, 64 - keylen);
     } else {
         CSHA256().Write(key, keylen).Finalize(rkey);

--- a/src/crypto/hmac_sha512.cpp
+++ b/src/crypto/hmac_sha512.cpp
@@ -13,7 +13,7 @@ CHMAC_SHA512::CHMAC_SHA512(const unsigned char* key, size_t keylen)
 {
     unsigned char rkey[128];
     if (keylen <= 128) {
-        memcpy(rkey, key, keylen);
+        if (keylen) memcpy(rkey, key, keylen);
         memset(rkey + keylen, 0, 128 - keylen);
     } else {
         CSHA512().Write(key, keylen).Finalize(rkey);

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -468,6 +468,8 @@ BOOST_AUTO_TEST_CASE(sha512_testvectors) {
 }
 
 BOOST_AUTO_TEST_CASE(hmac_sha256_testvectors) {
+    // HMAC with an empty key and message
+    TestHMACSHA256("", "", "b613679a0814d9ec772f95d778c35fc5ff1697c493715653c6c712144292c5ad");
     // test cases 1, 2, 3, 4, 6 and 7 of RFC 4231
     TestHMACSHA256("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
                    "4869205468657265",
@@ -521,6 +523,8 @@ BOOST_AUTO_TEST_CASE(hmac_sha256_testvectors) {
 }
 
 BOOST_AUTO_TEST_CASE(hmac_sha512_testvectors) {
+    // HMAC with an empty key and message
+    TestHMACSHA512("", "", "b936cee86c9f87aa5d3c6f2e84cb5a4239a5fe50480a6ec66b70ab5b1f4ac6730c6c515421b327ec1d69402e53dfb49ad7381eb067b338fd7b0cb22247225d47");
     // test cases 1, 2, 3, 4, 6 and 7 of RFC 4231
     TestHMACSHA512("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
                    "4869205468657265",

--- a/src/test/fuzz/crypto.cpp
+++ b/src/test/fuzz/crypto.cpp
@@ -21,11 +21,6 @@ FUZZ_TARGET(crypto)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     std::vector<uint8_t> data = ConsumeRandomLengthByteVector(fuzzed_data_provider);
-    if (data.empty()) {
-        auto new_size = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(1, 4096);
-        auto x = fuzzed_data_provider.ConsumeIntegral<uint8_t>();
-        data.resize(new_size, x);
-    }
 
     CHash160 hash160;
     CHash256 hash256;
@@ -45,11 +40,6 @@ FUZZ_TARGET(crypto)
             [&] {
                 if (fuzzed_data_provider.ConsumeBool()) {
                     data = ConsumeRandomLengthByteVector(fuzzed_data_provider);
-                    if (data.empty()) {
-                        auto new_size = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(1, 4096);
-                        auto x = fuzzed_data_provider.ConsumeIntegral<uint8_t>();
-                        data.resize(new_size, x);
-                    }
                 }
 
                 (void)hash160.Write(data);

--- a/src/test/fuzz/eval_script.cpp
+++ b/src/test/fuzz/eval_script.cpp
@@ -13,16 +13,7 @@ FUZZ_TARGET(eval_script)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     const auto flags = script_verify_flags::from_int(fuzzed_data_provider.ConsumeIntegral<script_verify_flags::value_type>());
-    const std::vector<uint8_t> script_bytes = [&] {
-        if (fuzzed_data_provider.remaining_bytes() != 0) {
-            return fuzzed_data_provider.ConsumeRemainingBytes<uint8_t>();
-        } else {
-            // Avoid UBSan warning:
-            //   test/fuzz/FuzzedDataProvider.h:212:17: runtime error: null pointer passed as argument 1, which is declared to never be null
-            //   /usr/include/string.h:43:28: note: nonnull attribute specified here
-            return std::vector<uint8_t>();
-        }
-    }();
+    const std::vector<uint8_t> script_bytes = fuzzed_data_provider.ConsumeRemainingBytes<uint8_t>();
     const CScript script(script_bytes.begin(), script_bytes.end());
     for (const auto sig_version : {SigVersion::BASE, SigVersion::WITNESS_V0}) {
         std::vector<std::vector<unsigned char>> stack;


### PR DESCRIPTION
**Problem:** `CHMAC_SHA256` and `CHMAC_SHA512` copied the key with `memcpy(rkey, key, keylen)` before zero-padding it.
Empty-vector callers can pass a null key pointer because C++ [`vector.data`](https://eel.is/c++draft/vector.data#1) only guarantees `data() == addressof(front())` for non-empty vectors.
On glibc, [`memcpy` arguments are `__nonnull`](https://codebrowser.dev/glibc/glibc/string/string.h.html#43), so a UBSan build aborts on the empty-key path:

```
crypto/hmac_sha256.cpp:16:15: runtime error: null pointer passed as argument 2, which is declared to never be null
```

That matches [C++ library preconditions](https://eel.is/c++draft/library.c#2) inheriting C library semantics, and C11 Annex J.2 listing invalid string utility pointers as undefined behavior ["even if the length is zero"](https://port70.net/~nsz/c/c11/n1570.html#J.2p1).

**Fix:** Skip the copy when `keylen == 0`; the following `memset` still zero-fills the whole HMAC key block, so the derived pads and digests are unchanged.
The new empty-key HMAC vectors pin the boundary.
The crypto fuzzer can now stop rewriting empty inputs to non-empty ones, and the stale `eval_script` guard can use `ConsumeRemainingBytes()` directly because `ConsumeBytes()` already returns before copying for empty results.
