### PR TITLE
univalue: clear failed reads

### DIFF
--- a/src/test/fuzz/parse_univalue.cpp
+++ b/src/test/fuzz/parse_univalue.cpp
@@ -8,6 +8,7 @@
 #include <test/fuzz/fuzz.h>
 #include <util/chaintype.h>
 
+#include <cassert>
 #include <limits>
 #include <string>
 
@@ -19,13 +20,9 @@ void initialize_parse_univalue()
 FUZZ_TARGET(parse_univalue, .init = initialize_parse_univalue)
 {
     const std::string random_string(buffer.begin(), buffer.end());
-    bool valid = true;
-    const UniValue univalue = [&] {
-        UniValue uv;
-        if (!uv.read(random_string)) valid = false;
-        return valid ? uv : UniValue{};
-    }();
-    if (!valid) {
+    UniValue univalue;
+    if (!univalue.read(random_string)) {
+        assert(univalue.isNull());
         return;
     }
     try {

--- a/src/univalue/lib/univalue_read.cpp
+++ b/src/univalue/lib/univalue_read.cpp
@@ -9,6 +9,7 @@
 #include <cstring>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 /*
@@ -262,6 +263,7 @@ enum expect_bits : unsigned {
 bool UniValue::read(std::string_view str_in)
 {
     clear();
+    UniValue parsed;
 
     uint32_t expectMask = 0;
     std::vector<UniValue*> stack;
@@ -322,10 +324,10 @@ bool UniValue::read(std::string_view str_in)
             VType utyp = (tok == JTOK_OBJ_OPEN ? VOBJ : VARR);
             if (!stack.size()) {
                 if (utyp == VOBJ)
-                    setObject();
+                    parsed.setObject();
                 else
-                    setArray();
-                stack.push_back(this);
+                    parsed.setArray();
+                stack.push_back(&parsed);
             } else {
                 UniValue tmpVal(utyp);
                 UniValue *top = stack.back();
@@ -404,7 +406,7 @@ bool UniValue::read(std::string_view str_in)
             }
 
             if (!stack.size()) {
-                *this = tmpVal;
+                parsed = std::move(tmpVal);
                 break;
             }
 
@@ -418,7 +420,7 @@ bool UniValue::read(std::string_view str_in)
         case JTOK_NUMBER: {
             UniValue tmpVal(VNUM, tokenVal);
             if (!stack.size()) {
-                *this = tmpVal;
+                parsed = std::move(tmpVal);
                 break;
             }
 
@@ -438,7 +440,7 @@ bool UniValue::read(std::string_view str_in)
             } else {
                 UniValue tmpVal(VSTR, tokenVal);
                 if (!stack.size()) {
-                    *this = tmpVal;
+                    parsed = std::move(tmpVal);
                     break;
                 }
                 UniValue *top = stack.back();
@@ -459,6 +461,6 @@ bool UniValue::read(std::string_view str_in)
     if (tok != JTOK_NONE)
         return false;
 
+    *this = std::move(parsed);
     return true;
 }
-

--- a/src/univalue/test/object.cpp
+++ b/src/univalue/test/object.cpp
@@ -449,15 +449,15 @@ void univalue_readwrite()
 
     BOOST_CHECK(!v.read("@{}"));
     BOOST_CHECK(!v.read("{} garbage"));
-    BOOST_CHECK(v.isObject()); // TODO: Failed reads should clear parsed prefixes.
+    BOOST_CHECK(v.isNull());
     BOOST_CHECK(!v.read("[]{}"));
-    BOOST_CHECK(v.isArray()); // TODO: Failed reads should clear parsed prefixes.
+    BOOST_CHECK(v.isNull());
     BOOST_CHECK(!v.read("{}[]"));
-    BOOST_CHECK(v.isObject()); // TODO: Failed reads should clear parsed prefixes.
+    BOOST_CHECK(v.isNull());
     BOOST_CHECK(!v.read("{} 42"));
-    BOOST_CHECK(v.isObject()); // TODO: Failed reads should clear parsed prefixes.
+    BOOST_CHECK(v.isNull());
     BOOST_CHECK(!v.read("42 garbage"));
-    BOOST_CHECK(v.isNum()); // TODO: Failed reads should clear parsed prefixes.
+    BOOST_CHECK(v.isNull());
 }
 
 int main(int argc, char* argv[])

--- a/src/univalue/test/object.cpp
+++ b/src/univalue/test/object.cpp
@@ -449,9 +449,15 @@ void univalue_readwrite()
 
     BOOST_CHECK(!v.read("@{}"));
     BOOST_CHECK(!v.read("{} garbage"));
+    BOOST_CHECK(v.isObject()); // TODO: Failed reads should clear parsed prefixes.
     BOOST_CHECK(!v.read("[]{}"));
+    BOOST_CHECK(v.isArray()); // TODO: Failed reads should clear parsed prefixes.
     BOOST_CHECK(!v.read("{}[]"));
+    BOOST_CHECK(v.isObject()); // TODO: Failed reads should clear parsed prefixes.
     BOOST_CHECK(!v.read("{} 42"));
+    BOOST_CHECK(v.isObject()); // TODO: Failed reads should clear parsed prefixes.
+    BOOST_CHECK(!v.read("42 garbage"));
+    BOOST_CHECK(v.isNum()); // TODO: Failed reads should clear parsed prefixes.
 }
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
**Problem:** `UniValue::read()` [clears the receiver](https://github.com/bitcoin/bitcoin/blob/32941e131479b4aec1eb606d68a9bcc3f5d7cf3d/src/univalue/lib/univalue_read.cpp#L262-L264), then parses root values into that same receiver before the full input is accepted.
For `{} garbage`, the `{}` prefix is stored first, and only then does the [trailing-token check](https://github.com/bitcoin/bitcoin/blob/32941e131479b4aec1eb606d68a9bcc3f5d7cf3d/src/univalue/lib/univalue_read.cpp#L457-L460) return false.
A failed read can therefore leave the receiver holding the parsed prefix.
Current RPC/REST paths reject malformed JSON from the false return before using the receiver; I did not find a current node-facing path where this changes behavior.

**Fix:** Parse into a local root and move it into the receiver only after the complete input has been consumed.
All failed reads leave the receiver null.
The existing UniValue object test covers object, array, and scalar prefixes followed by a trailing token, and `FUZZ=parse_univalue` asserts failed reads leave null output.
