### PR TITLE
index: rewind stale child after disconnect

### DIFF
--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -148,28 +148,29 @@ bool BaseIndex::Init()
     return true;
 }
 
-static const CBlockIndex* NextSyncBlock(const CBlockIndex* const pindex_prev, CChain& chain) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+// Returns the next block to sync and the block to rewind to first.
+static std::pair<const CBlockIndex*, const CBlockIndex*> NextSyncBlock(const CBlockIndex* const pindex_prev, CChain& chain) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
 
     if (!pindex_prev) {
-        return chain.Genesis();
+        return {chain.Genesis(), nullptr};
     }
 
     if (const auto* pindex{chain.Next(*pindex_prev)}) {
-        return pindex;
+        return {pindex, pindex_prev};
     }
 
     // If there is no next block, we might be synced
     if (pindex_prev == chain.Tip()) {
-        return nullptr;
+        return {nullptr, pindex_prev};
     }
 
     // Since block is not in the chain, return the next block in the chain AFTER the last common ancestor.
     // Caller will be responsible for rewinding back to the common ancestor.
     const auto* fork{chain.FindFork(*pindex_prev)};
     // Common ancestor must exist (genesis).
-    return chain.Next(*Assert(fork));
+    return {chain.Next(*Assert(fork)), fork};
 }
 
 bool BaseIndex::ProcessBlock(const CBlockIndex* pindex, const CBlock* block_data)
@@ -223,9 +224,9 @@ void BaseIndex::Sync()
                 return;
             }
 
-            const CBlockIndex* pindex_next = WITH_LOCK(cs_main, return NextSyncBlock(pindex, m_chainstate->m_chain));
-            // If pindex_next is null, it means pindex is the chain tip, so
-            // commit data indexed so far.
+            auto next_sync{WITH_LOCK(::cs_main, return NextSyncBlock(pindex, m_chainstate->m_chain))};
+            auto& [pindex_next, rewind_to]{next_sync};
+            // If next is null, commit data indexed so far.
             if (!pindex_next) {
                 SetBestBlockIndex(pindex);
                 // No need to handle errors in Commit. See rationale above.
@@ -237,13 +238,13 @@ void BaseIndex::Sync()
                 // attached while m_synced is still false, and it would not be
                 // indexed.
                 LOCK(::cs_main);
-                pindex_next = NextSyncBlock(pindex, m_chainstate->m_chain);
+                next_sync = NextSyncBlock(pindex, m_chainstate->m_chain);
                 if (!pindex_next) {
                     m_synced = true;
                     break;
                 }
             }
-            if (pindex_next->pprev != pindex && !Rewind(pindex, pindex_next->pprev)) {
+            if (rewind_to != pindex && !Rewind(pindex, rewind_to)) {
                 FatalErrorf("Failed to rewind %s to a previous chain tip", GetName());
                 return;
             }

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -226,6 +226,16 @@ void BaseIndex::Sync()
 
             auto next_sync{WITH_LOCK(::cs_main, return NextSyncBlock(pindex, m_chainstate->m_chain))};
             auto& [pindex_next, rewind_to]{next_sync};
+            // A pure disconnect has no next block but still needs a rewind to the chain tip.
+            if (!pindex_next && pindex != rewind_to) {
+                if (!Rewind(pindex, rewind_to)) {
+                    FatalErrorf("Failed to rewind %s to the current chain tip", GetName());
+                    return;
+                }
+                pindex = rewind_to;
+                continue;
+            }
+
             // If next is null, commit data indexed so far.
             if (!pindex_next) {
                 SetBestBlockIndex(pindex);
@@ -240,6 +250,7 @@ void BaseIndex::Sync()
                 LOCK(::cs_main);
                 next_sync = NextSyncBlock(pindex, m_chainstate->m_chain);
                 if (!pindex_next) {
+                    if (pindex != rewind_to) continue;
                     m_synced = true;
                     break;
                 }

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -32,6 +32,8 @@ struct IndexSummary {
     bool synced{false};
     int best_block_height{0};
     uint256 best_block_hash;
+
+    bool operator==(const IndexSummary&) const = default;
 };
 namespace interfaces {
 struct BlockRef;

--- a/src/test/baseindex_tests.cpp
+++ b/src/test/baseindex_tests.cpp
@@ -59,4 +59,39 @@ BOOST_FIXTURE_TEST_CASE(baseindex_no_commit_ahead_of_flush, TestChain100Setup)
     sync_index(false, 101, 100);
 }
 
+BOOST_FIXTURE_TEST_CASE(baseindex_restart_after_pure_disconnect, TestChain100Setup)
+{
+    auto& chainstate{Assert(m_node.chainman)->ActiveChainstate()};
+    auto current_tip{[&] { return Assert(WITH_LOCK(::cs_main, return chainstate.m_chain.Tip())); }};
+    auto persist_chainstate{[&] {
+        chainstate.ForceFlushStateToDisk();
+        m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    }};
+    auto restart_index{[&](bool do_sync = true) {
+        CoinStatsIndex index{interfaces::MakeChain(m_node), /*n_cache_size=*/1_MiB};
+        BOOST_REQUIRE(index.Init());
+        if (do_sync) index.Sync();
+        auto summary{index.GetSummary()};
+        index.Stop();
+        return summary;
+    }};
+    auto synced_at{[](const CBlockIndex& tip, bool synced = true) { return IndexSummary{"coinstatsindex", synced, tip.nHeight, tip.GetBlockHash()}; }};
+    auto* old_tip{current_tip()};
+
+    // Persist the chainstate and index at the old child.
+    persist_chainstate();
+    BOOST_CHECK(restart_index() == synced_at(*old_tip));
+
+    // Persist a pure disconnect to the parent while leaving the index locator
+    // at the old child, modeling a crash before the index sees the notification.
+    BlockValidationState state{};
+    BOOST_REQUIRE(chainstate.InvalidateBlock(state, old_tip) && state.IsValid());
+    auto* new_tip{current_tip()};
+    BOOST_REQUIRE_EQUAL(new_tip, old_tip->pprev);
+    persist_chainstate();
+
+    BOOST_CHECK(restart_index() == synced_at(*old_tip)); // TODO: Rewind to new_tip.
+    BOOST_CHECK(restart_index(/*do_sync=*/false) == synced_at(*old_tip, /*synced=*/false)); // TODO: Persist new_tip and mark it synced.
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/baseindex_tests.cpp
+++ b/src/test/baseindex_tests.cpp
@@ -75,7 +75,7 @@ BOOST_FIXTURE_TEST_CASE(baseindex_restart_after_pure_disconnect, TestChain100Set
         index.Stop();
         return summary;
     }};
-    auto synced_at{[](const CBlockIndex& tip, bool synced = true) { return IndexSummary{"coinstatsindex", synced, tip.nHeight, tip.GetBlockHash()}; }};
+    auto synced_at{[](const CBlockIndex& tip) { return IndexSummary{"coinstatsindex", /*synced=*/true, tip.nHeight, tip.GetBlockHash()}; }};
     auto* old_tip{current_tip()};
 
     // Persist the chainstate and index at the old child.
@@ -90,8 +90,8 @@ BOOST_FIXTURE_TEST_CASE(baseindex_restart_after_pure_disconnect, TestChain100Set
     BOOST_REQUIRE_EQUAL(new_tip, old_tip->pprev);
     persist_chainstate();
 
-    BOOST_CHECK(restart_index() == synced_at(*old_tip)); // TODO: Rewind to new_tip.
-    BOOST_CHECK(restart_index(/*do_sync=*/false) == synced_at(*old_tip, /*synced=*/false)); // TODO: Persist new_tip and mark it synced.
+    BOOST_CHECK(restart_index() == synced_at(*new_tip));
+    BOOST_CHECK(restart_index(/*do_sync=*/false) == synced_at(*new_tip));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
**Problem:** [#34897](https://github.com/bitcoin/bitcoin/pull/34897) prevents index locators from advancing past flushed chainstate, but a pure disconnect can leave the persisted index locator at the disconnected tip while the active chain ends at its parent.
`NextSyncBlock()` returns null in this state, so `BaseIndex::Sync()` incorrectly marks that locator as synced.

**Fix:** Have `NextSyncBlock()` return its rewind target with the next block, then rewind a persisted descendant to the active tip before marking it synced and committing the corrected locator.
A characterization test records the incorrect restart state before the fix.

**Reproducer:** Persist the index at height 2, disconnect the tip while the index is disabled, then restart it and compare the chain and index heights.
<details><summary>Pure-disconnect restart</summary>

```bash
D="$(mktemp -d)"
cli() { build/bin/bitcoin-cli -regtest "-datadir=$D" "$@"; }
start() { build/bin/bitcoind -regtest "-datadir=$D" -daemonwait "$@" >/dev/null 2>&1; }
mine() { cli generatetodescriptor "$1" 'raw(51)' >/dev/null; }
synced() { until cli getindexinfo coinstatsindex | grep -q '"synced": true'; do sleep .1; done; }
stop() { cli stop >/dev/null 2>&1; while test -e "$D/regtest/bitcoind.pid"; do sleep .1; done; }
# Persist chainstate and index at height 2
    cmake -B build -GNinja >/dev/null 2>&1 && ninja -C build >/dev/null
    start -coinstatsindex=1 && mine 2 && synced && stop
# Persist a disconnect while the index is disabled
    start && cli invalidateblock "$(cli getbestblockhash)" >/dev/null && stop
# Restart the index and print both heights
    start -coinstatsindex=1 && synced
    echo -n 'chain: '; cli getblockcount
    echo -n 'index: '; cli getindexinfo coinstatsindex | sed -n 's/.*best_block_height": \([0-9]*\).*/\1/p'
    stop
```

**Before:**

```text
chain: 1
index: 2
```

**After:**

```text
chain: 1
index: 1
```
</details>