### PR TITLE
index: make txospender reorg recovery crash-safe

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -108,9 +108,9 @@ void CCoinsViewCache::AddCoin(const COutPoint &outpoint, Coin&& coin, bool possi
            (bool)it->second.coin.IsCoinBase());
 }
 
-void CCoinsViewCache::EmplaceCoinInternalDANGER(COutPoint&& outpoint, Coin&& coin) {
+void CCoinsViewCache::EmplaceCoinInternalDANGER(const COutPoint& outpoint, Coin&& coin) {
     const auto mem_usage{coin.DynamicMemoryUsage()};
-    auto [it, inserted] = cacheCoins.try_emplace(std::move(outpoint), std::move(coin));
+    auto [it, inserted] = cacheCoins.try_emplace(outpoint, std::move(coin));
     if (inserted) {
         CCoinsCacheEntry::SetDirty(*it, m_sentinel);
         ++m_dirty_count;

--- a/src/coins.h
+++ b/src/coins.h
@@ -471,7 +471,7 @@ public:
      * NOT FOR GENERAL USE. Used only when loading coins from a UTXO snapshot.
      * @sa ChainstateManager::PopulateAndValidateSnapshot()
      */
-    void EmplaceCoinInternalDANGER(COutPoint&& outpoint, Coin&& coin);
+    void EmplaceCoinInternalDANGER(const COutPoint& outpoint, Coin&& coin);
 
     /**
      * Spend a coin. Pass moveto in order to get the deleted data.

--- a/src/index/txospenderindex.cpp
+++ b/src/index/txospenderindex.cpp
@@ -35,12 +35,14 @@
 
 /* The database is used to find the spending transaction of a given utxo.
  * For every input of every transaction it stores a key that is a pair(siphash(input outpoint), transaction location on disk) and a zero-byte value.
+ * For every block with spender records it also stores one (block location on disk, block hash) entry, so lookups can reject records of inactive blocks without reading their transactions.
  * To find the spending transaction of an outpoint, we perform a range query on siphash(outpoint), and for each returned key load the transaction
  * and return it if it does spend the provided outpoint.
  */
 
 // LevelDB key prefix. We only have one key for now but it will make it easier to add others if needed.
 constexpr uint8_t DB_TXOSPENDERINDEX{'s'};
+constexpr uint8_t DB_TXOSPENDER_BLOCK{'b'};
 
 std::unique_ptr<TxoSpenderIndex> g_txospenderindex;
 
@@ -82,6 +84,12 @@ static DBKey CreateKey(std::pair<uint64_t, uint64_t> siphash_key, const COutPoin
     return DBKey(CreateKeyPrefix(siphash_key, vout), pos);
 }
 
+// Copy only the FlatFilePos base so every spender in a block uses the same mapping key.
+static auto CreateBlockKey(const FlatFilePos& pos)
+{
+    return std::pair{DB_TXOSPENDER_BLOCK, pos};
+}
+
 static std::vector<std::pair<COutPoint, CDiskTxPos>> BuildSpenderPositions(const interfaces::BlockInfo& block)
 {
     std::vector<std::pair<COutPoint, CDiskTxPos>> items;
@@ -103,9 +111,13 @@ static std::vector<std::pair<COutPoint, CDiskTxPos>> BuildSpenderPositions(const
 
 bool TxoSpenderIndex::CustomAppend(const interfaces::BlockInfo& block)
 {
+    auto items{BuildSpenderPositions(block)};
+    if (items.empty()) return true;
+
     CDBBatch batch(*m_db);
+    batch.Write(CreateBlockKey({block.file_number, block.data_pos}), block.hash);
     // The values are only markers; older entries may contain serialized empty strings, so FindSpender() reads only keys.
-    for (const auto& [outpoint, pos] : BuildSpenderPositions(block)) {
+    for (const auto& [outpoint, pos] : items) {
         batch.Write(CreateKey(m_siphash_key, outpoint, pos), std::span<const std::byte>{});
     }
     m_db->WriteBatch(batch);
@@ -136,24 +148,45 @@ util::Expected<std::optional<TxoSpender>, std::string> TxoSpenderIndex::FindSpen
     const uint64_t prefix{CreateKeyPrefix(m_siphash_key, txo)};
     std::unique_ptr<CDBIterator> it(m_db->NewIterator());
     DBKey key(prefix, CDiskTxPos());
+    std::optional<std::string> legacy_read_error;
     auto in_active_chain{[&](const uint256& block_hash) {
         bool active{false};
         return m_chain->findBlock(block_hash, interfaces::FoundBlock().inActiveChain(active)) && active;
+    }};
+    auto io_error{[&](const std::string& err) {
+        LogError("Deserialize or I/O error - %s", err);
+        return util::Unexpected{strprintf("IO error finding spending tx for outpoint %s:%d.", txo.hash.GetHex(), txo.n)};
     }};
 
     // find all keys that start with the outpoint hash, load the transaction at the location specified in the key
     // and return it if it does spend the provided outpoint
     for (it->Seek(std::pair{DB_TXOSPENDERINDEX, prefix}); it->Valid() && it->GetKey(key) && key.hash == prefix; it->Next()) {
-        if (const auto spender{ReadTransaction(key.pos)}) {
-            if (!std::ranges::any_of(spender->tx->vin, [&](const auto& input) { return input.prevout == txo; })) continue;
-            if (!in_active_chain(spender->block_hash)) continue;
+        uint256 stored_block_hash;
+        const bool has_stored_block_hash{m_db->Read(CreateBlockKey(key.pos), stored_block_hash)};
+        if (has_stored_block_hash && !in_active_chain(stored_block_hash)) continue;
 
-            return std::optional{*spender};
-        } else {
-            LogError("Deserialize or I/O error - %s", spender.error());
-            return util::Unexpected{strprintf("IO error finding spending tx for outpoint %s:%d.", txo.hash.GetHex(), txo.n)};
+        const auto spender{ReadTransaction(key.pos)};
+        if (!spender) {
+            if (has_stored_block_hash) return io_error(spender.error());
+            if (!legacy_read_error) legacy_read_error = spender.error();
+            continue;
         }
+
+        if (has_stored_block_hash && spender->block_hash != stored_block_hash) {
+            return util::Unexpected{strprintf("Block hash mismatch finding spending tx for outpoint %s:%d.", txo.hash.GetHex(), txo.n)};
+        }
+
+        if (!std::ranges::any_of(spender->tx->vin, [&](const auto& input) { return input.prevout == txo; })) continue;
+
+        if (!has_stored_block_hash) {
+            // Entries written by older versions have no block mapping, so
+            // their block identity is only available after reading them.
+            if (!in_active_chain(spender->block_hash)) continue;
+        }
+
+        return std::optional{*spender};
     }
+    if (legacy_read_error) return io_error(*legacy_read_error);
     return util::Expected<std::optional<TxoSpender>, std::string>(std::nullopt);
 }
 

--- a/src/index/txospenderindex.cpp
+++ b/src/index/txospenderindex.cpp
@@ -23,6 +23,7 @@
 #include <util/fs.h>
 #include <validation.h>
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdio>
 #include <exception>
@@ -71,13 +72,6 @@ TxoSpenderIndex::TxoSpenderIndex(std::unique_ptr<interfaces::Chain> chain, size_
     }
 }
 
-interfaces::Chain::NotifyOptions TxoSpenderIndex::CustomOptions()
-{
-    interfaces::Chain::NotifyOptions options;
-    options.disconnect_data = true;
-    return options;
-}
-
 static uint64_t CreateKeyPrefix(std::pair<uint64_t, uint64_t> siphash_key, const COutPoint& vout)
 {
     return PresaltedSipHasher(siphash_key.first, siphash_key.second)(vout.hash.ToUint256(), vout.n);
@@ -101,15 +95,6 @@ void TxoSpenderIndex::WriteSpenderInfos(const std::vector<std::pair<COutPoint, C
 }
 
 
-void TxoSpenderIndex::EraseSpenderInfos(const std::vector<std::pair<COutPoint, CDiskTxPos>>& items)
-{
-    CDBBatch batch(*m_db);
-    for (const auto& [outpoint, pos] : items) {
-        batch.Erase(CreateKey(m_siphash_key, outpoint, pos));
-    }
-    m_db->WriteBatch(batch);
-}
-
 static std::vector<std::pair<COutPoint, CDiskTxPos>> BuildSpenderPositions(const interfaces::BlockInfo& block)
 {
     std::vector<std::pair<COutPoint, CDiskTxPos>> items;
@@ -132,12 +117,6 @@ static std::vector<std::pair<COutPoint, CDiskTxPos>> BuildSpenderPositions(const
 bool TxoSpenderIndex::CustomAppend(const interfaces::BlockInfo& block)
 {
     WriteSpenderInfos(BuildSpenderPositions(block));
-    return true;
-}
-
-bool TxoSpenderIndex::CustomRemove(const interfaces::BlockInfo& block)
-{
-    EraseSpenderInfos(BuildSpenderPositions(block));
     return true;
 }
 
@@ -165,16 +144,19 @@ util::Expected<std::optional<TxoSpender>, std::string> TxoSpenderIndex::FindSpen
     const uint64_t prefix{CreateKeyPrefix(m_siphash_key, txo)};
     std::unique_ptr<CDBIterator> it(m_db->NewIterator());
     DBKey key(prefix, CDiskTxPos());
+    auto in_active_chain{[&](const uint256& block_hash) {
+        bool active{false};
+        return m_chain->findBlock(block_hash, interfaces::FoundBlock().inActiveChain(active)) && active;
+    }};
 
     // find all keys that start with the outpoint hash, load the transaction at the location specified in the key
     // and return it if it does spend the provided outpoint
     for (it->Seek(std::pair{DB_TXOSPENDERINDEX, prefix}); it->Valid() && it->GetKey(key) && key.hash == prefix; it->Next()) {
         if (const auto spender{ReadTransaction(key.pos)}) {
-            for (const auto& input : spender->tx->vin) {
-                if (input.prevout == txo) {
-                    return std::optional{*spender};
-                }
-            }
+            if (!std::ranges::any_of(spender->tx->vin, [&](const auto& input) { return input.prevout == txo; })) continue;
+            if (!in_active_chain(spender->block_hash)) continue;
+
+            return std::optional{*spender};
         } else {
             LogError("Deserialize or I/O error - %s", spender.error());
             return util::Unexpected{strprintf("IO error finding spending tx for outpoint %s:%d.", txo.hash.GetHex(), txo.n)};

--- a/src/index/txospenderindex.cpp
+++ b/src/index/txospenderindex.cpp
@@ -82,19 +82,6 @@ static DBKey CreateKey(std::pair<uint64_t, uint64_t> siphash_key, const COutPoin
     return DBKey(CreateKeyPrefix(siphash_key, vout), pos);
 }
 
-void TxoSpenderIndex::WriteSpenderInfos(const std::vector<std::pair<COutPoint, CDiskTxPos>>& items)
-{
-    CDBBatch batch(*m_db);
-    for (const auto& [outpoint, pos] : items) {
-        DBKey key(CreateKey(m_siphash_key, outpoint, pos));
-        // The key encodes the spent outpoint hash and disk position. The value is only a marker.
-        // Older entries may contain serialized empty strings; FindSpender() reads only keys.
-        batch.Write(key, std::span<const std::byte>{});
-    }
-    m_db->WriteBatch(batch);
-}
-
-
 static std::vector<std::pair<COutPoint, CDiskTxPos>> BuildSpenderPositions(const interfaces::BlockInfo& block)
 {
     std::vector<std::pair<COutPoint, CDiskTxPos>> items;
@@ -116,7 +103,12 @@ static std::vector<std::pair<COutPoint, CDiskTxPos>> BuildSpenderPositions(const
 
 bool TxoSpenderIndex::CustomAppend(const interfaces::BlockInfo& block)
 {
-    WriteSpenderInfos(BuildSpenderPositions(block));
+    CDBBatch batch(*m_db);
+    // The values are only markers; older entries may contain serialized empty strings, so FindSpender() reads only keys.
+    for (const auto& [outpoint, pos] : BuildSpenderPositions(block)) {
+        batch.Write(CreateKey(m_siphash_key, outpoint, pos), std::span<const std::byte>{});
+    }
+    m_db->WriteBatch(batch);
     return true;
 }
 

--- a/src/index/txospenderindex.h
+++ b/src/index/txospenderindex.h
@@ -16,7 +16,6 @@
 #include <optional>
 #include <string>
 #include <utility>
-#include <vector>
 
 struct CDiskTxPos;
 namespace interfaces {
@@ -41,7 +40,6 @@ private:
     std::unique_ptr<BaseIndex::DB> m_db;
     std::pair<uint64_t, uint64_t> m_siphash_key;
     bool AllowPrune() const override { return false; }
-    void WriteSpenderInfos(const std::vector<std::pair<COutPoint, CDiskTxPos>>& items);
     util::Expected<TxoSpender, std::string> ReadTransaction(const CDiskTxPos& pos) const;
 
 protected:

--- a/src/index/txospenderindex.h
+++ b/src/index/txospenderindex.h
@@ -6,7 +6,6 @@
 #define BITCOIN_INDEX_TXOSPENDERINDEX_H
 
 #include <index/base.h>
-#include <interfaces/chain.h>
 #include <primitives/transaction.h>
 #include <uint256.h>
 #include <util/expected.h>
@@ -20,6 +19,9 @@
 #include <vector>
 
 struct CDiskTxPos;
+namespace interfaces {
+class Chain;
+} // namespace interfaces
 
 static constexpr bool DEFAULT_TXOSPENDERINDEX{false};
 
@@ -40,15 +42,10 @@ private:
     std::pair<uint64_t, uint64_t> m_siphash_key;
     bool AllowPrune() const override { return false; }
     void WriteSpenderInfos(const std::vector<std::pair<COutPoint, CDiskTxPos>>& items);
-    void EraseSpenderInfos(const std::vector<std::pair<COutPoint, CDiskTxPos>>& items);
     util::Expected<TxoSpender, std::string> ReadTransaction(const CDiskTxPos& pos) const;
 
 protected:
-    interfaces::Chain::NotifyOptions CustomOptions() override;
-
     bool CustomAppend(const interfaces::BlockInfo& block) override;
-
-    bool CustomRemove(const interfaces::BlockInfo& block) override;
 
     BaseIndex::DB& GetDB() const override;
 

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -236,7 +236,7 @@ struct RPCArg {
         std::string description,
         RPCArgOptions opts = {})
         : m_names{std::move(name)},
-          m_type{std::move(type)},
+          m_type{type},
           m_fallback{std::move(fallback)},
           m_description{std::move(description)},
           m_opts{std::move(opts)}
@@ -252,7 +252,7 @@ struct RPCArg {
         std::vector<RPCArg> inner,
         RPCArgOptions opts = {})
         : m_names{std::move(name)},
-          m_type{std::move(type)},
+          m_type{type},
           m_inner{std::move(inner)},
           m_fallback{std::move(fallback)},
           m_description{std::move(description)},
@@ -338,7 +338,7 @@ struct RPCResult {
         std::string description,
         std::vector<RPCResult> inner = {},
         RPCResultOptions opts = {})
-        : m_type{std::move(type)},
+        : m_type{type},
           m_key_name{std::move(m_key_name)},
           m_inner{std::move(inner)},
           m_optional{optional},
@@ -366,7 +366,7 @@ struct RPCResult {
         std::string description,
         std::vector<RPCResult> inner = {},
         RPCResultOptions opts = {})
-        : m_type{std::move(type)},
+        : m_type{type},
           m_key_name{std::move(m_key_name)},
           m_inner{std::move(inner)},
           m_optional{optional},

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -5,15 +5,12 @@
 #include <addresstype.h>
 #include <blockfilter.h>
 #include <chain.h>
-#include <consensus/merkle.h>
 #include <consensus/validation.h>
 #include <index/base.h>
 #include <index/blockfilterindex.h>
 #include <interfaces/chain.h>
-#include <interfaces/mining.h>
 #include <key.h>
 #include <node/blockstorage.h>
-#include <pow.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
@@ -47,7 +44,6 @@ using node::BlockManager;
 BOOST_AUTO_TEST_SUITE(blockfilter_index_tests)
 
 struct BuildChainTestingSetup : public TestChain100Setup {
-    CBlock CreateBlock(const CBlockIndex* prev, const std::vector<CMutableTransaction>& txns, const CScript& scriptPubKey);
     bool BuildChain(const CBlockIndex* pindex, const CScript& coinbase_script_pub_key, size_t length, std::vector<std::shared_ptr<CBlock>>& chain);
 };
 
@@ -83,37 +79,6 @@ static bool CheckFilterLookups(BlockFilterIndex& filter_index, const CBlockIndex
     filter_hashes.clear();
     last_header = filter_header;
     return true;
-}
-
-CBlock BuildChainTestingSetup::CreateBlock(const CBlockIndex* prev,
-    const std::vector<CMutableTransaction>& txns,
-    const CScript& scriptPubKey)
-{
-    auto mining{interfaces::MakeMining(m_node)};
-    auto block_template{mining->createNewBlock({
-        .coinbase_output_script = scriptPubKey,
-    }, /*cooldown=*/false)};
-    BOOST_REQUIRE(block_template);
-    CBlock block{block_template->getBlock()};
-    block.hashPrevBlock = prev->GetBlockHash();
-    block.nTime = prev->nTime + 1;
-
-    // Replace mempool-selected txns with just coinbase plus passed-in txns:
-    block.vtx.resize(1);
-    for (const CMutableTransaction& tx : txns) {
-        block.vtx.push_back(MakeTransactionRef(tx));
-    }
-    {
-        CMutableTransaction tx_coinbase{*block.vtx.at(0)};
-        tx_coinbase.nLockTime = static_cast<uint32_t>(prev->nHeight);
-        tx_coinbase.vin.at(0).scriptSig = CScript{} << prev->nHeight + 1;
-        block.vtx.at(0) = MakeTransactionRef(std::move(tx_coinbase));
-        block.hashMerkleRoot = BlockMerkleRoot(block);
-    }
-
-    while (!CheckProofOfWork(block.GetHash(), block.nBits, m_node.chainman->GetConsensus())) ++block.nNonce;
-
-    return block;
 }
 
 bool BuildChainTestingSetup::BuildChain(const CBlockIndex* pindex,

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -193,7 +193,7 @@ void SimulationTest(CCoinsView* base, bool fake_best_block)
                     coin = newcoin;
                 }
                 if (COutPoint op(txid, 0); !stack.back()->map().contains(op) && !newcoin.out.scriptPubKey.IsUnspendable() && m_rng.randbool()) {
-                    stack.back()->EmplaceCoinInternalDANGER(std::move(op), std::move(newcoin));
+                    stack.back()->EmplaceCoinInternalDANGER(op, std::move(newcoin));
                 } else {
                     stack.back()->AddCoin(op, std::move(newcoin), /*possible_overwrite=*/!coin.IsSpent() || m_rng.randbool());
                 }
@@ -1109,11 +1109,11 @@ BOOST_AUTO_TEST_CASE(ccoins_emplace_duplicate_keeps_usage_balanced)
     const COutPoint outpoint{Txid::FromUint256(m_rng.rand256()), m_rng.rand32()};
 
     const Coin coin1{CTxOut{m_rng.randrange(10), CScript{} << m_rng.randbytes(CScriptBase::STATIC_SIZE + 1)}, 1, false};
-    cache.EmplaceCoinInternalDANGER(COutPoint{outpoint}, Coin{coin1});
+    cache.EmplaceCoinInternalDANGER(outpoint, Coin{coin1});
     cache.SelfTest();
 
     const Coin coin2{CTxOut{m_rng.randrange(20), CScript{} << m_rng.randbytes(CScriptBase::STATIC_SIZE + 2)}, 2, false};
-    cache.EmplaceCoinInternalDANGER(COutPoint{outpoint}, Coin{coin2});
+    cache.EmplaceCoinInternalDANGER(outpoint, Coin{coin2});
     cache.SelfTest();
 
     BOOST_CHECK(cache.AccessCoin(outpoint) == coin1);
@@ -1132,7 +1132,7 @@ BOOST_AUTO_TEST_CASE(ccoins_reset_guard)
     const COutPoint outpoint{Txid::FromUint256(m_rng.rand256()), m_rng.rand32()};
 
     const Coin coin{CTxOut{m_rng.randrange(10), CScript{} << m_rng.randbytes(CScriptBase::STATIC_SIZE + 1)}, 1, false};
-    cache.EmplaceCoinInternalDANGER(COutPoint{outpoint}, Coin{coin});
+    cache.EmplaceCoinInternalDANGER(outpoint, Coin{coin});
     BOOST_CHECK_EQUAL(cache.GetDirtyCount(), 1U);
 
     uint256 cache_best_block{m_rng.rand256()};

--- a/src/test/coinsviewoverlay_tests.cpp
+++ b/src/test/coinsviewoverlay_tests.cpp
@@ -48,7 +48,7 @@ void PopulateView(const CBlock& block, CCoinsView& view, bool spent = false)
         for (const auto& in : tx->vin) {
             Coin coin{};
             if (!spent) coin.out.nValue = 1;
-            cache.EmplaceCoinInternalDANGER(COutPoint{in.prevout}, std::move(coin));
+            cache.EmplaceCoinInternalDANGER(in.prevout, std::move(coin));
         }
     }
 

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -115,7 +115,7 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& co
                     const bool possible_overwrite{coins_view_cache.PeekCoin(outpoint) || fuzzed_data_provider.ConsumeBool()};
                     coins_view_cache.AddCoin(outpoint, std::move(coin), possible_overwrite);
                 } else {
-                    coins_view_cache.EmplaceCoinInternalDANGER(std::move(outpoint), std::move(coin));
+                    coins_view_cache.EmplaceCoinInternalDANGER(outpoint, std::move(coin));
                 }
             },
             [&] {

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -73,17 +73,6 @@ T Deserialize(DataStream&& ds, const P& params)
     return obj;
 }
 
-template <typename T, typename P>
-void DeserializeFromFuzzingInput(FuzzBufferType buffer, T&& obj, const P& params)
-{
-    try {
-        SpanReader{buffer} >> params(obj);
-    } catch (const std::ios_base::failure&) {
-        throw invalid_fuzzing_input_exception();
-    }
-    assert(buffer.empty() || !Serialize(obj, params).empty());
-}
-
 template <typename T>
 DataStream Serialize(const T& obj)
 {

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -58,14 +58,6 @@ struct invalid_fuzzing_input_exception : public std::exception {
 };
 
 template <typename T, typename P>
-DataStream Serialize(const T& obj, const P& params)
-{
-    DataStream ds{};
-    ds << params(obj);
-    return ds;
-}
-
-template <typename T, typename P>
 T Deserialize(DataStream&& ds, const P& params)
 {
     T obj;
@@ -116,7 +108,7 @@ T DeserializeConstructFromFuzzingInput(FuzzBufferType buffer)
 template <typename T, typename P>
 void AssertEqualAfterSerializeDeserialize(const T& obj, const P& params)
 {
-    assert(Deserialize<T>(Serialize(obj, params), params) == obj);
+    assert(Deserialize<T>(Serialize(params(obj)), params) == obj);
 }
 template <typename T>
 void AssertEqualAfterSerializeDeserialize(const T& obj)

--- a/src/test/txospenderindex_tests.cpp
+++ b/src/test/txospenderindex_tests.cpp
@@ -3,11 +3,15 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <index/txospenderindex.h>
+#include <script/interpreter.h>
 #include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <validation.h>
 
 #include <boost/test/unit_test.hpp>
+
+#include <cstdint>
+#include <utility>
 
 BOOST_AUTO_TEST_SUITE(txospenderindex_tests)
 
@@ -72,6 +76,91 @@ BOOST_FIXTURE_TEST_CASE(txospenderindex_initial_sync, TestChain100Setup)
 
     // Shutdown sequence (c.f. Shutdown() in init.cpp)
     txospenderindex.Stop();
+}
+
+BOOST_FIXTURE_TEST_CASE(txospenderindex_reorg_recovery, TestChain100Setup)
+{
+    auto& chainman{*Assert(m_node.chainman)};
+    auto& chainstate{chainman.ActiveChainstate()};
+    const CScript& coinbase_script{m_coinbase_txns.front()->vout.front().scriptPubKey};
+    const CTransactionRef& coinbase_tx{m_coinbase_txns.front()};
+    const COutPoint spent{coinbase_tx->GetHash(), 0};
+
+    auto current_tip{[&] { return Assert(WITH_LOCK(::cs_main, return chainstate.m_chain.Tip())); }};
+    auto make_index{[&](bool wipe) { return TxoSpenderIndex{interfaces::MakeChain(m_node), 1_MiB, false, wipe}; }};
+    auto sync_callbacks{[&] { m_node.validation_signals->SyncWithValidationInterfaceQueue(); }};
+    auto find_spender{[&](TxoSpenderIndex& index) {
+        auto result{index.FindSpender(spent)};
+        BOOST_REQUIRE(result.has_value());
+        BOOST_REQUIRE(result->has_value());
+        return (*result)->tx->GetHash();
+    }};
+    auto invalidate{[&](CBlockIndex* block) {
+        BlockValidationState state{};
+        BOOST_REQUIRE(chainstate.InvalidateBlock(state, block) && state.IsValid());
+    }};
+    auto make_spender{[&](int32_t version) {
+        CMutableTransaction tx;
+        tx.version = version;
+        tx.vin.resize(1);
+        tx.vin.front().prevout = spent;
+        tx.vout.resize(1);
+        tx.vout.front().nValue = coinbase_tx->GetValueOut();
+        tx.vout.front().scriptPubKey = coinbase_script;
+
+        std::vector<unsigned char> signature;
+        BOOST_REQUIRE(coinbaseKey.Sign(SignatureHash(coinbase_script, tx, 0, SIGHASH_ALL, 0, SigVersion::BASE), signature));
+        signature.push_back(static_cast<unsigned char>(SIGHASH_ALL));
+        tx.vin.front().scriptSig << signature;
+        return tx;
+    }};
+
+    auto spender_a{make_spender(/*version=*/1)};
+    auto spender_b{make_spender(/*version=*/2)};
+    auto* fork_parent{current_tip()};
+
+    // Store B before A so its key sorts first; keep B invalid until A is durable.
+    auto block_b{std::make_shared<const CBlock>(CreateBlock(fork_parent, {spender_b}, coinbase_script))};
+    BOOST_REQUIRE(chainman.ProcessNewBlock(block_b, /*force_processing=*/true, /*min_pow_checked=*/true, nullptr));
+    auto* block_b_index{Assert(WITH_LOCK(::cs_main, return chainstate.m_blockman.LookupBlockIndex(block_b->GetHash())))};
+    invalidate(block_b_index);
+
+    CreateAndProcessBlock({spender_a}, coinbase_script);
+    sync_callbacks();
+    auto* old_tip{current_tip()};
+
+    // Commit A, reorg the live index to B without flushing, then restore A.
+    {
+        auto index{make_index(/*wipe=*/true)};
+        BOOST_REQUIRE(index.Init());
+        index.Sync();
+        chainstate.ForceFlushStateToDisk();
+        sync_callbacks();
+        BOOST_CHECK_EQUAL(find_spender(index), spender_a.GetHash());
+
+        {
+            LOCK(::cs_main);
+            chainstate.ResetBlockFailureFlags(block_b_index);
+            chainman.RecalculateBestHeader();
+        }
+        auto block_c{std::make_shared<const CBlock>(CreateBlock(block_b_index, {}, coinbase_script))};
+        BOOST_REQUIRE(chainman.ProcessNewBlock(block_c, /*force_processing=*/true, /*min_pow_checked=*/true, nullptr));
+        sync_callbacks();
+        BOOST_CHECK_EQUAL(WITH_LOCK(::cs_main, return chainstate.GetLastFlushedBlock()), old_tip);
+        BOOST_CHECK_EQUAL(find_spender(index), spender_b.GetHash());
+        index.Stop();
+
+        invalidate(block_b_index);
+        BlockValidationState state{};
+        BOOST_REQUIRE(chainstate.ActivateBestChain(state, nullptr) && state.IsValid());
+        sync_callbacks();
+        BOOST_REQUIRE_EQUAL(current_tip(), old_tip);
+    }
+
+    auto index{make_index(/*wipe=*/false)};
+    BOOST_REQUIRE(index.Init());
+    BOOST_CHECK_EQUAL(find_spender(index), spender_b.GetHash()); // TODO: Preserve the restored active-chain spender record.
+    index.Stop();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/txospenderindex_tests.cpp
+++ b/src/test/txospenderindex_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <dbwrapper.h>
 #include <index/txospenderindex.h>
 #include <script/interpreter.h>
 #include <test/util/common.h>
@@ -160,6 +161,16 @@ BOOST_FIXTURE_TEST_CASE(txospenderindex_reorg_recovery, TestChain100Setup)
     }
 
     auto block_b_pos{WITH_LOCK(::cs_main, return block_b_index->GetBlockPos())};
+    auto erase_block_mapping{[&] {
+        auto block_b_key{std::pair{uint8_t{'b'}, block_b_pos}}; // Matches DB_TXOSPENDER_BLOCK
+        CDBWrapper db{{
+            .path = gArgs.GetDataDirNet() / "indexes" / "txospenderindex" / "db",
+            .cache_bytes = 1_MiB,
+        }};
+        BOOST_REQUIRE(db.Exists(block_b_key));
+        db.Erase(block_b_key);
+        BOOST_CHECK(!db.Exists(block_b_key));
+    }};
     auto corrupt_spender_b{[&] {
         auto corrupt_pos{block_b_pos};
         corrupt_pos.nPos += static_cast<unsigned>(::GetSerializeSize(static_cast<const CBlockHeader&>(*block_b))) + GetSizeOfCompactSize(block_b->vtx.size()) +
@@ -170,12 +181,21 @@ BOOST_FIXTURE_TEST_CASE(txospenderindex_reorg_recovery, TestChain100Setup)
         file.write(invalid_compact_size);
         BOOST_REQUIRE_EQUAL(file.fclose(), 0);
     }};
+    auto restart_index{[&] {
+        auto index{make_index(/*wipe=*/false)};
+        BOOST_REQUIRE(index.Init());
+        auto spender_hash{find_spender(index)};
+        index.Stop();
+        return spender_hash;
+    }};
     corrupt_spender_b();
 
-    auto index{make_index(/*wipe=*/false)};
-    BOOST_REQUIRE(index.Init());
-    BOOST_CHECK(!index.FindSpender(spent).has_value()); // TODO: Skip inactive records before reading their block data.
-    index.Stop();
+    // The block mapping rejects inactive B before reading its corrupt transaction.
+    BOOST_CHECK_EQUAL(restart_index(), spender_a.GetHash());
+
+    // Without the mapping, model legacy data and continue from unreadable B to active A.
+    erase_block_mapping();
+    BOOST_CHECK_EQUAL(restart_index(), spender_a.GetHash());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/txospenderindex_tests.cpp
+++ b/src/test/txospenderindex_tests.cpp
@@ -10,6 +10,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <array>
+#include <cstddef>
 #include <cstdint>
 #include <utility>
 
@@ -157,9 +159,22 @@ BOOST_FIXTURE_TEST_CASE(txospenderindex_reorg_recovery, TestChain100Setup)
         BOOST_REQUIRE_EQUAL(current_tip(), old_tip);
     }
 
+    auto block_b_pos{WITH_LOCK(::cs_main, return block_b_index->GetBlockPos())};
+    auto corrupt_spender_b{[&] {
+        auto corrupt_pos{block_b_pos};
+        corrupt_pos.nPos += static_cast<unsigned>(::GetSerializeSize(static_cast<const CBlockHeader&>(*block_b))) + GetSizeOfCompactSize(block_b->vtx.size()) +
+                            static_cast<unsigned>(::GetSerializeSize(TX_WITH_WITNESS(*block_b->vtx.front()))) + sizeof(spender_b.version);
+        AutoFile file{chainstate.m_blockman.OpenBlockFile(corrupt_pos, /*fReadOnly=*/false)};
+        BOOST_REQUIRE(!file.IsNull());
+        std::array<std::byte, 9> invalid_compact_size{std::byte{0xff}};
+        file.write(invalid_compact_size);
+        BOOST_REQUIRE_EQUAL(file.fclose(), 0);
+    }};
+    corrupt_spender_b();
+
     auto index{make_index(/*wipe=*/false)};
     BOOST_REQUIRE(index.Init());
-    BOOST_CHECK_EQUAL(find_spender(index), spender_a.GetHash());
+    BOOST_CHECK(!index.FindSpender(spent).has_value()); // TODO: Skip inactive records before reading their block data.
     index.Stop();
 }
 

--- a/src/test/txospenderindex_tests.cpp
+++ b/src/test/txospenderindex_tests.cpp
@@ -159,7 +159,7 @@ BOOST_FIXTURE_TEST_CASE(txospenderindex_reorg_recovery, TestChain100Setup)
 
     auto index{make_index(/*wipe=*/false)};
     BOOST_REQUIRE(index.Init());
-    BOOST_CHECK_EQUAL(find_spender(index), spender_b.GetHash()); // TODO: Preserve the restored active-chain spender record.
+    BOOST_CHECK_EQUAL(find_spender(index), spender_a.GetHash());
     index.Stop();
 }
 

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -464,6 +464,36 @@ CBlock TestChain100Setup::CreateBlock(
     return block;
 }
 
+CBlock TestChain100Setup::CreateBlock(
+    const CBlockIndex* prev,
+    const std::vector<CMutableTransaction>& txns,
+    const CScript& scriptPubKey)
+{
+    auto mining{interfaces::MakeMining(m_node)};
+    auto block_template{mining->createNewBlock({
+        .use_mempool = false,
+        .coinbase_output_script = scriptPubKey,
+    }, /*cooldown=*/false)};
+    Assert(block_template);
+    CBlock block{block_template->getBlock()};
+    block.hashPrevBlock = prev->GetBlockHash();
+    block.nTime = prev->nTime + 1;
+
+    Assert(block.vtx.size() == 1);
+    for (const CMutableTransaction& tx : txns) {
+        block.vtx.push_back(MakeTransactionRef(tx));
+    }
+    CMutableTransaction tx_coinbase{*block.vtx.at(0)};
+    tx_coinbase.nLockTime = static_cast<uint32_t>(prev->nHeight);
+    tx_coinbase.vin.at(0).scriptSig = CScript{} << prev->nHeight + 1;
+    block.vtx.at(0) = MakeTransactionRef(std::move(tx_coinbase));
+    RegenerateCommitments(block, *Assert(m_node.chainman));
+
+    while (!CheckProofOfWork(block.GetHash(), block.nBits, m_node.chainman->GetConsensus())) ++block.nNonce;
+
+    return block;
+}
+
 CBlock TestChain100Setup::CreateAndProcessBlock(
     const std::vector<CMutableTransaction>& txns,
     const CScript& scriptPubKey)

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -131,6 +131,7 @@ struct Testnet4Setup : public TestingSetup {
 };
 
 class CBlock;
+class CBlockIndex;
 class CScript;
 
 /**
@@ -153,6 +154,15 @@ struct TestChain100Setup : public TestingSetup {
      * scriptPubKey.
      */
     CBlock CreateBlock(
+        const std::vector<CMutableTransaction>& txns,
+        const CScript& scriptPubKey);
+
+    /**
+     * Create a new block on top of prev with just given transactions,
+     * coinbase paying to scriptPubKey. The block is not processed.
+     */
+    CBlock CreateBlock(
+        const CBlockIndex* prev,
         const std::vector<CMutableTransaction>& txns,
         const CScript& scriptPubKey);
 

--- a/src/txgraph.cpp
+++ b/src/txgraph.cpp
@@ -2710,9 +2710,9 @@ void TxGraphImpl::CommitStaging() noexcept
     m_main_clusterset.m_deps_to_add = std::move(m_staging_clusterset->m_deps_to_add);
     m_main_clusterset.m_to_remove = std::move(m_staging_clusterset->m_to_remove);
     m_main_clusterset.m_group_data = std::move(m_staging_clusterset->m_group_data);
-    m_main_clusterset.m_oversized = std::move(m_staging_clusterset->m_oversized);
-    m_main_clusterset.m_txcount = std::move(m_staging_clusterset->m_txcount);
-    m_main_clusterset.m_txcount_oversized = std::move(m_staging_clusterset->m_txcount_oversized);
+    m_main_clusterset.m_oversized = m_staging_clusterset->m_oversized;
+    m_main_clusterset.m_txcount = m_staging_clusterset->m_txcount;
+    m_main_clusterset.m_txcount_oversized = m_staging_clusterset->m_txcount_oversized;
     // Delete the old staging graph, after all its information was moved to main.
     m_staging_clusterset.reset();
     Compact();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5812,7 +5812,7 @@ util::Result<void> ChainstateManager::PopulateAndValidateSnapshot(
                     return util::Error{Untranslated(strprintf("Bad snapshot data after deserializing %d coins - bad tx out value",
                               coins_count - coins_left))};
                 }
-                coins_cache.EmplaceCoinInternalDANGER(std::move(outpoint), std::move(coin));
+                coins_cache.EmplaceCoinInternalDANGER(outpoint, std::move(coin));
 
                 --coins_left;
                 ++coins_processed;

--- a/test/functional/rpc_gettxspendingprevout.py
+++ b/test/functional/rpc_gettxspendingprevout.py
@@ -195,10 +195,9 @@ class GetTxSpendingPrevoutTest(BitcoinTestFramework):
         assert tx1["txid"] not in node0_mempool
         assert tx2["txid"] not in node0_mempool
 
-        # TODO: Do not return spends from inactive blocks.
-        # tx2 is not in the mempool anymore, but still in txospender index which has not been rewound yet
+        # tx2's block is inactive, so its stale index record must not be returned.
         result = node0.gettxspendingprevout([prevout(tx1['txid'], vout=0)], return_spending_tx=True)
-        assert_equal(result, [spent_out_in_block(tx1['txid'], vout=0, spending_tx_id=tx2["txid"], blockhash=blockhash, spending_tx=tx2['hex'])])
+        assert_equal(result, [unspent_out(tx1['txid'], vout=0)])
 
         txinfo = node0.getrawtransaction(tx2["txid"], verbose = True, blockhash = blockhash)
         assert_equal(txinfo["confirmations"], 0)

--- a/test/functional/rpc_gettxspendingprevout.py
+++ b/test/functional/rpc_gettxspendingprevout.py
@@ -195,6 +195,7 @@ class GetTxSpendingPrevoutTest(BitcoinTestFramework):
         assert tx1["txid"] not in node0_mempool
         assert tx2["txid"] not in node0_mempool
 
+        # TODO: Do not return spends from inactive blocks.
         # tx2 is not in the mempool anymore, but still in txospender index which has not been rewound yet
         result = node0.gettxspendingprevout([prevout(tx1['txid'], vout=0)], return_spending_tx=True)
         assert_equal(result, [spent_out_in_block(tx1['txid'], vout=0, spending_tx_id=tx2["txid"], blockhash=blockhash, spending_tx=tx2['hex'])])


### PR DESCRIPTION
**Problem:** `TxoSpenderIndex` writes spender records before its best-block locator is durable.
After an interrupted reorg, disconnect cleanup can remove the restored active spend while a competing record remains, so restart returns a spend from an inactive block.
Because records identify only disk positions, unreadable data for that stale block can also prevent a later active spend from being found.

**Fix:** Keep spender records append-only and filter them by active-chain membership during lookup.
Store one block-position-to-hash mapping per block in the same batch as its spender records, allowing inactive blocks to be rejected before transaction I/O.
For legacy records without mappings, continue past unreadable candidates and report the saved I/O error only if no active spend is found.

**Reproducer:** This matures a coinbase, kills the node after its spend is indexed but before the index locator becomes durable, then restarts and queries the original output.
This exercises immediate process-crash recovery, not power-loss durability.

<details><summary>Stale spend after an interrupted block connection</summary>

```bash
D="$(mktemp -d)"
cli() { build/bin/bitcoin-cli -regtest "-datadir=$D" "$@"; }
start() { build/bin/bitcoind -regtest "-datadir=$D" -txospenderindex=1 >/dev/null 2>&1 & p=$!; until cli getblockcount >/dev/null 2>&1; do sleep .1; done; }
stop() { cli stop >/dev/null; wait "$p"; }
synced() { until cli getindexinfo | grep -q '"synced": true'; do sleep .1; done; }
# Persist a spendable coinbase and its index state
    ninja -C build >/dev/null && start && \
    cli generatetodescriptor 101 'raw(51)' >/dev/null && \
    coin="$(cli getblock "$(cli getblockhash 1)" 2 | awk -F '"' '/"txid":/ { print $4; exit }')" && \
    synced && stop
# Crash after the spender record is written, before its locator is durable
    start && synced && \
    tx="$(cli createrawtransaction "[{\"txid\":\"$coin\",\"vout\":0}]" '[{"data":"00"}]')" && \
    cli generateblock 'raw(51)' "[\"$tx\"]" >/dev/null && \
    cli syncwithvalidationinterfacequeue && kill -9 "$p"; wait "$p" || true
# Query the stale record after restart
    start && synced && \
    cli gettxspendingprevout "[{\"txid\":\"$coin\",\"vout\":0}]" '{"mempool_only":false}' && stop
```

The spend never enters the mempool, so the pre-fix result comes from the stale index record.

**Before:** The result includes a `spendingtxid` and `blockhash` from the crashed block.

**After:** The result contains only the queried `txid` and `vout`.
</details>

<details><summary>History</summary>

* [#24539](https://github.com/bitcoin/bitcoin/pull/24539#discussion_r1028544839) added disconnect-time record removal to avoid returning stale reorg spends. Crash rollback exposes the inverse failure: removal can lose a restored active spend, so this PR preserves records and checks active-chain membership during lookup.
* [#34897](https://github.com/bitcoin/bitcoin/pull/34897#discussion_r3477474285) identified that eager `TxoSpenderIndex` writes can outlive the durable index locator and that rejecting unreadable stale records requires block identity. This PR adds one block-position mapping per block.
</details>
