### PR TITLE
blockstorage: flush every dirty undo file

### DIFF
--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -797,15 +797,26 @@ BlockfileType BlockManager::BlockfileTypeForHeight(int height)
 bool BlockManager::FlushChainstateBlockFile(int tip_height)
 {
     AssertLockHeld(::cs_main);
-    auto& cursor = m_blockfile_cursors[BlockfileTypeForHeight(tip_height)];
+    bool success{true};
+
+    auto& cursor{m_blockfile_cursors[BlockfileTypeForHeight(tip_height)]};
     // If the cursor does not exist, it means an assumeutxo snapshot is loaded,
-    // but no blocks past the snapshot height have been written yet, so there
-    // is no data associated with the chainstate, and it is safe not to flush.
+    // but no blocks past the snapshot height have been written yet.
     if (cursor) {
-        return FlushBlockFile(cursor->file_num, /*fFinalize=*/false, /*finalize_undo=*/false);
+        success = FlushBlockFile(cursor->file_num, /*fFinalize=*/false, /*finalize_undo=*/false);
     }
-    // No need to log warnings in this case.
-    return true;
+
+    // Blocks are written in download order, while undo data is written in validation order. An older rev file can
+    // therefore receive new undo data after the block cursor has advanced. Flush every dirty undo file before its
+    // BLOCK_HAVE_UNDO entries are persisted by WriteBlockIndexDB().
+    for (const int file_num : m_dirty_fileinfo) {
+        if (cursor && file_num == cursor->file_num) continue;
+        if (file_num < 0 || static_cast<size_t>(file_num) >= m_blockfile_info.size()) continue;
+        if (m_blockfile_info[file_num].nUndoSize == 0) continue;
+        if (!FlushUndoFile(file_num)) success = false;
+    }
+
+    return success;
 }
 
 uint64_t BlockManager::CalculateCurrentUsage()

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -196,6 +196,7 @@ class BlockManager
 {
     friend Chainstate;
     friend ChainstateManager;
+    friend struct BlockManagerTestAccess;
 
 private:
     const CChainParams& GetParams() const { return m_opts.chainparams; }

--- a/src/test/blockmanager_tests.cpp
+++ b/src/test/blockmanager_tests.cpp
@@ -8,21 +8,32 @@
 #include <node/blockstorage.h>
 #include <node/context.h>
 #include <node/kernel_notifications.h>
-#include <script/solver.h>
 #include <primitives/block.h>
-#include <util/chaintype.h>
-#include <validation.h>
-
-#include <boost/test/unit_test.hpp>
+#include <script/solver.h>
 #include <test/util/common.h>
 #include <test/util/logging.h>
 #include <test/util/setup_common.h>
+#include <undo.h>
+#include <util/chaintype.h>
+#include <util/translation.h>
+#include <validation.h>
+
+#include <boost/test/unit_test.hpp>
 
 using kernel::CBlockFileInfo;
 using node::STORAGE_HEADER_BYTES;
 using node::BlockManager;
 using node::KernelNotifications;
 using node::MAX_BLOCKFILE_SIZE;
+
+namespace node {
+struct BlockManagerTestAccess {
+    static bool FlushChainstateBlockFile(BlockManager& blockman, int tip_height) EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
+    {
+        return blockman.FlushChainstateBlockFile(tip_height);
+    }
+};
+} // namespace node
 
 // use BasicTestingSetup here for the data directory configuration, setup, and cleanup
 BOOST_FIXTURE_TEST_SUITE(blockmanager_tests, BasicTestingSetup)
@@ -300,6 +311,79 @@ BOOST_AUTO_TEST_CASE(blockmanager_flush_block_file)
     // Block 2 was not overwritten:
     BOOST_CHECK(!blockman.ReadBlock(read_block, pos2, {}));
     BOOST_CHECK_EQUAL(read_block.nVersion, 2);
+}
+
+BOOST_AUTO_TEST_CASE(blockmanager_flush_chainstate_block_file_dirty_undo_file)
+{
+    const auto params{CreateChainParams(ArgsManager{}, ChainType::MAIN)};
+
+    struct TestNotifications final : kernel::Notifications {
+        int flush_errors{0};
+        void flushError(const bilingual_str&) override { ++flush_errors; }
+    } notifications;
+
+    const BlockManager::Options blockman_opts{
+        .chainparams = *params,
+        .fast_prune = true,
+        .blocks_dir = m_args.GetBlocksDirPath(),
+        .notifications = notifications,
+        .block_tree_db_params = DBParams{
+            .path = m_args.GetDataDirNet() / "blocks" / "index",
+            .cache_bytes = 0,
+        },
+    };
+    BlockManager blockman{*Assert(m_node.shutdown_signal), blockman_opts};
+
+    const auto make_big_block{[](int version) {
+        CBlock block;
+        block.nVersion = version;
+
+        CMutableTransaction tx;
+        tx.vin.resize(1);
+        tx.vout.resize(1);
+        tx.vin[0].scriptSig.resize(40'000);
+        block.vtx.push_back(MakeTransactionRef(std::move(tx)));
+
+        return block;
+    }};
+
+    const FlatFilePos pos1{WITH_LOCK(::cs_main, return blockman.WriteBlock(make_big_block(1), /*nHeight=*/1))};
+    const FlatFilePos pos2{WITH_LOCK(::cs_main, return blockman.WriteBlock(make_big_block(2), /*nHeight=*/2))};
+    BOOST_CHECK_EQUAL(pos1.nFile, 0);
+    BOOST_CHECK_EQUAL(pos2.nFile, 1);
+
+    // Write undo for a block stored in file 0 after file 1 is already in use.
+    const uint256 prev_hash{uint8_t{1}};
+    CBlockIndex prev_index{CBlockHeader{}};
+    prev_index.phashBlock = &prev_hash;
+
+    const uint256 block_hash{uint8_t{2}};
+    CBlockIndex index{CBlockHeader{}};
+    index.phashBlock = &block_hash;
+    index.pprev = &prev_index;
+    index.nHeight = 1;
+
+    BlockValidationState state{};
+    {
+        LOCK(::cs_main);
+        index.nFile = pos1.nFile;
+        BOOST_REQUIRE(blockman.WriteBlockUndo(CBlockUndo{}, state, index));
+    }
+
+    // Replacing the older rev file with a directory makes an attempted flush fail.
+    const fs::path undo_path{blockman_opts.blocks_dir / "rev00000.dat"};
+    BOOST_REQUIRE(fs::exists(undo_path));
+    BOOST_REQUIRE(fs::remove(undo_path));
+    BOOST_REQUIRE(fs::create_directory(undo_path));
+
+    // Current behavior only flushes the cursor file, leaving older dirty undo files unflushed.
+    {
+        LOCK(::cs_main);
+        // TODO: Flush every dirty undo file during the chainstate flush.
+        BOOST_CHECK(node::BlockManagerTestAccess::FlushChainstateBlockFile(blockman, /*tip_height=*/2));
+    }
+    // TODO: Flushing the replaced old undo file should report an I/O error.
+    BOOST_CHECK_EQUAL(notifications.flush_errors, 0);
 }
 
 BOOST_FIXTURE_TEST_CASE(prune_lock_update_and_delete, TestingSetup)

--- a/src/test/blockmanager_tests.cpp
+++ b/src/test/blockmanager_tests.cpp
@@ -376,14 +376,12 @@ BOOST_AUTO_TEST_CASE(blockmanager_flush_chainstate_block_file_dirty_undo_file)
     BOOST_REQUIRE(fs::remove(undo_path));
     BOOST_REQUIRE(fs::create_directory(undo_path));
 
-    // Current behavior only flushes the cursor file, leaving older dirty undo files unflushed.
+    // The chainstate flush must also attempt to flush the older dirty undo file.
     {
         LOCK(::cs_main);
-        // TODO: Flush every dirty undo file during the chainstate flush.
-        BOOST_CHECK(node::BlockManagerTestAccess::FlushChainstateBlockFile(blockman, /*tip_height=*/2));
+        BOOST_CHECK(!node::BlockManagerTestAccess::FlushChainstateBlockFile(blockman, /*tip_height=*/2));
     }
-    // TODO: Flushing the replaced old undo file should report an I/O error.
-    BOOST_CHECK_EQUAL(notifications.flush_errors, 0);
+    BOOST_CHECK_EQUAL(notifications.flush_errors, 1);
 }
 
 BOOST_FIXTURE_TEST_CASE(prune_lock_update_and_delete, TestingSetup)

--- a/test/functional/feature_undo_flush.py
+++ b/test/functional/feature_undo_flush.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the undo-file flush ordering described in issue #25539.
+
+Blocks are written in download order, while undo data is written in validation
+order. Undo data can therefore be added to an older rev file after the block
+cursor has advanced to a newer blk file.
+
+Replace the older rev file with a directory and force a chainstate flush. The
+current behavior succeeds because it does not try to flush that older file.
+"""
+
+from test_framework.blocktools import (
+    create_block,
+    create_coinbase,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than,
+)
+
+
+class UndoFlushTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.extra_args = [["-fastprune=1"]]
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        # -fastprune uses 64 KiB blockfiles. Keep file 0 below the limit until
+        # explicitly rotating to file 1.
+        payload_bytes = 18_000
+        nulldata = "ff" * payload_bytes
+
+        def mine_large_block():
+            self.generateblock(node, output=f"raw(6a{nulldata})", transactions=[])
+
+        self.log.info("Mine three large blocks on the active chain")
+        for _ in range(3):
+            mine_large_block()
+        assert_equal(node.getblockcount(), 3)
+
+        fork_base_hash = node.getblockhash(1)
+        fork_base_time = node.getblock(fork_base_hash)["time"]
+
+        self.log.info("Submit a side-chain block that remains inactive")
+        block2 = create_block(int(fork_base_hash, 16), create_coinbase(2), ntime=fork_base_time + 1)
+        block2.solve()
+        assert_equal(node.submitblock(block2.serialize().hex()), "inconclusive")
+
+        self.log.info("Rotate to blk00001.dat")
+        mine_large_block()
+        assert_equal(node.getblockcount(), 4)
+        block_files = list(node.blocks_path.glob("blk[0-9][0-9][0-9][0-9][0-9].dat"))
+        assert_greater_than(len(block_files), 1)
+
+        self.log.info("Extend the side chain to trigger a reorg")
+        tip = block2.hash_int
+        height = 2
+        block_time = block2.nTime + 1
+        side_tip_hash = None
+        for _ in range(3):
+            height += 1
+            block = create_block(tip, create_coinbase(height), ntime=block_time)
+            block.solve()
+            assert node.submitblock(block.serialize().hex()) in ("inconclusive", None)
+            tip = block.hash_int
+            block_time += 1
+            side_tip_hash = block.hash_hex
+
+        assert side_tip_hash is not None
+        self.wait_until(lambda: node.getbestblockhash() == side_tip_hash, timeout=10)
+        assert_equal(node.getblockcount(), 5)
+
+        rev0 = node.blocks_path / "rev00000.dat"
+        assert rev0.exists()
+        self.log.info("Replace rev00000.dat with a directory and force a flush")
+        rev0.unlink()
+        rev0.mkdir()
+
+        # TODO: The old dirty undo file must be flushed and abort this node.
+        node.gettxoutsetinfo("none")
+        assert_equal(node.getblockcount(), 5)
+
+
+if __name__ == "__main__":
+    UndoFlushTest(__file__).main()

--- a/test/functional/feature_undo_flush.py
+++ b/test/functional/feature_undo_flush.py
@@ -9,7 +9,7 @@ order. Undo data can therefore be added to an older rev file after the block
 cursor has advanced to a newer blk file.
 
 Replace the older rev file with a directory and force a chainstate flush. The
-current behavior succeeds because it does not try to flush that older file.
+node must try to flush the older file and abort when that operation fails.
 """
 
 from test_framework.blocktools import (
@@ -83,9 +83,15 @@ class UndoFlushTest(BitcoinTestFramework):
         rev0.unlink()
         rev0.mkdir()
 
-        # TODO: The old dirty undo file must be flushed and abort this node.
-        node.gettxoutsetinfo("none")
-        assert_equal(node.getblockcount(), 5)
+        expected_stderr = (
+            "Error: A fatal internal error occurred, see debug.log for details: "
+            "Flushing undo file to disk failed. This is likely the result of an I/O error."
+        )
+        try:
+            node.gettxoutsetinfo("none")
+        except Exception:
+            pass
+        node.wait_until_stopped(timeout=5, expect_error=True, expected_stderr=expected_stderr)
 
 
 if __name__ == "__main__":

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -372,6 +372,7 @@ BASE_SCRIPTS = [
     'wallet_timelock.py',
     'p2p_permissions.py',
     'feature_blocksdir.py',
+    'feature_undo_flush.py',
     'wallet_startup.py',
     'p2p_private_broadcast_retry_v1.py',
     'feature_remove_pruned_files_on_startup.py',


### PR DESCRIPTION
**Problem:** Blocks are written in download order while undo data is written in validation order.
After the block cursor advances, a reorg can append undo data to an older `rev` file.
`FlushChainstateBlockFile()` currently flushes only the cursor file, allowing `WriteBlockIndexDB()` to record `BLOCK_HAVE_UNDO` without first attempting to commit the referenced older undo bytes.

**Fix:** Flush every dirty undo file during the chainstate file flush.

Refs #25539
