### PR TITLE
validation: stop writes after flush failure

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -40,10 +40,10 @@ code.
     - Class member variables have a `m_` prefix.
     - Global variables have a `g_` prefix.
   - Constant names are all uppercase, and use `_` to separate words.
-  - Enumerator constants may be `snake_case`, `PascalCase` or `ALL_CAPS`.
-    This is a more tolerant policy than the [C++ Core
+  - Enumerator constants may be `snake_case`, or `PascalCase`. They should not
+    be `ALL_CAPS`, according to the [C++ Core
     Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#renum-caps),
-    which recommend using `snake_case`.  Please use what seems appropriate.
+    to avoid clashing with macros.
   - Class names, function names, and method names are UpperCamelCase
     (PascalCase). Do not prefix class names with `C`. See [Internal interface
     naming style](#internal-interface-naming-style) for an exception to this

--- a/src/test/chainstate_write_tests.cpp
+++ b/src/test/chainstate_write_tests.cpp
@@ -2,12 +2,16 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <node/blockstorage.h>
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
+#include <util/fs.h>
 #include <validation.h>
 #include <validationinterface.h>
 
 #include <boost/test/unit_test.hpp>
+
+#include <cstdlib>
 
 using kernel::ChainstateRole;
 
@@ -103,6 +107,26 @@ BOOST_FIXTURE_TEST_CASE(write_during_multiblock_activation, TestChain100Setup)
     m_node.validation_signals->SyncWithValidationInterfaceQueue();
     BOOST_CHECK_EQUAL(sub->m_flushed_at_block, second_from_tip);
     BOOST_CHECK_EQUAL(WITH_LOCK(::cs_main, return chainstate.GetLastFlushedBlock()), second_from_tip);
+}
+
+BOOST_FIXTURE_TEST_CASE(chainstate_flush_failure_boundary, TestChain100Setup)
+{
+    const auto inject_file_open_failure{[](const fs::path& file) { Assert(fs::remove(file)); Assert(fs::create_directory(file)); }};
+    auto& chainstate{Assert(m_node.chainman)->ActiveChainstate()};
+    BlockValidationState state{};
+
+    BOOST_REQUIRE(chainstate.FlushStateToDisk(state, FlushStateMode::FORCE_FLUSH) && state.IsValid());
+    const auto* old_flushed{WITH_LOCK(::cs_main, return chainstate.GetLastFlushedBlock())};
+
+    mineBlocks(1);
+    const auto* new_tip{WITH_LOCK(::cs_main, return chainstate.m_chain.Tip())};
+    BOOST_REQUIRE_NE(old_flushed, new_tip);
+    inject_file_open_failure(WITH_LOCK(::cs_main, return chainstate.m_blockman.GetBlockPosFilename(new_tip->GetBlockPos())));
+
+    const bool flushed{chainstate.FlushStateToDisk(state, FlushStateMode::FORCE_FLUSH)};
+    BOOST_CHECK_EQUAL(m_node.exit_status.load(), EXIT_FAILURE);
+    BOOST_CHECK(flushed && state.IsValid()); // TODO: Return the flush error
+    BOOST_CHECK_EQUAL(WITH_LOCK(::cs_main, return chainstate.GetLastFlushedBlock()), new_tip); // TODO: Keep the previous flushed block
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/chainstate_write_tests.cpp
+++ b/src/test/chainstate_write_tests.cpp
@@ -125,8 +125,8 @@ BOOST_FIXTURE_TEST_CASE(chainstate_flush_failure_boundary, TestChain100Setup)
 
     const bool flushed{chainstate.FlushStateToDisk(state, FlushStateMode::FORCE_FLUSH)};
     BOOST_CHECK_EQUAL(m_node.exit_status.load(), EXIT_FAILURE);
-    BOOST_CHECK(flushed && state.IsValid()); // TODO: Return the flush error
-    BOOST_CHECK_EQUAL(WITH_LOCK(::cs_main, return chainstate.GetLastFlushedBlock()), new_tip); // TODO: Keep the previous flushed block
+    BOOST_CHECK(!flushed && state.IsError());
+    BOOST_CHECK_EQUAL(WITH_LOCK(::cs_main, return chainstate.GetLastFlushedBlock()), old_flushed);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2792,10 +2792,9 @@ bool Chainstate::FlushStateToDisk(
                 LOG_TIME_MILLIS_WITH_CATEGORY("write block and undo data to disk", BCLog::BENCH);
 
                 // First make sure all block and undo data is flushed to disk.
-                // TODO: Handle return error, or add detailed comment why it is
-                // safe to not return an error upon failure.
                 if (!m_blockman.FlushChainstateBlockFile(m_chain.Height())) {
-                    LogWarning("%s: Failed to flush block file.\n", __func__);
+                    // FlushChainstateBlockFile() already emitted the flush-error notification.
+                    return state.Error("Failed to flush block or undo file");
                 }
             }
 


### PR DESCRIPTION
**Problem:** When `FlushChainstateBlockFile()` fails, shutdown is requested, but `FlushStateToDisk()` still writes block-index metadata and coins data, then advances `m_last_flushed_block`.
Those writes can record a block even though its block or undo data may not be durable.

**Fix:** Return the flush error before those writes, leaving `m_last_flushed_block` at the last successfully flushed block.

<details><summary>History</summary>

* [#27866](https://github.com/bitcoin/bitcoin/pull/27866#discussion_r1256378064) proposed returning here to avoid writing metadata for block data that failed to flush, but review requested a test and caller audit before changing behavior, so it was [deferred](https://github.com/bitcoin/bitcoin/pull/27866#discussion_r1297313148) as the current [TODO](https://github.com/bitcoin/bitcoin/pull/27866#issuecomment-1702186979); this PR now resolves it.
* [#34897](https://github.com/bitcoin/bitcoin/pull/34897) later introduced `m_last_flushed_block` to prevent persistent indexes from advancing past flushed chainstate; this fix keeps it at the last successful flush.
</details>
