### PR TITLE
index: recover blockfilter header after crash

### DIFF
--- a/src/index/base.h
+++ b/src/index/base.h
@@ -32,6 +32,8 @@ struct IndexSummary {
     bool synced{false};
     int best_block_height{0};
     uint256 best_block_hash;
+
+    bool operator==(const IndexSummary&) const = default;
 };
 namespace interfaces {
 struct BlockRef;

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -122,7 +122,7 @@ bool BlockFilterIndex::CustomInit(const std::optional<interfaces::BlockRef>& blo
     }
 
     if (block) {
-        auto op_last_header = ReadFilterHeader(block->height, block->hash);
+        auto op_last_header = ReadFilterHeader(*block);
         if (!op_last_header) {
             LogError("Cannot read last block filter header; index may be corrupted");
             return false;
@@ -240,10 +240,10 @@ size_t BlockFilterIndex::WriteFilterToDisk(FlatFilePos& pos, const BlockFilter& 
     return data_size;
 }
 
-std::optional<uint256> BlockFilterIndex::ReadFilterHeader(int height, const uint256& expected_block_hash)
+std::optional<uint256> BlockFilterIndex::ReadFilterHeader(const interfaces::BlockRef& block)
 {
     DBVal entry;
-    if (!index_util::LookUpOne(*m_db, {expected_block_hash, height}, entry)) {
+    if (!index_util::LookUpOne(*m_db, block, entry)) {
         return std::nullopt;
     }
     return entry.header;
@@ -294,10 +294,10 @@ bool BlockFilterIndex::CustomRemove(const interfaces::BlockInfo& block)
     m_db->WriteBatch(batch);
 
     // Update cached header to the previous block hash
-    const uint256& previous_hash{*Assert(block.prev_hash)};
-    const auto last_header{ReadFilterHeader(block.height - 1, previous_hash)};
+    const interfaces::BlockRef previous{*Assert(block.prev_hash), block.height - 1};
+    const auto last_header{ReadFilterHeader(previous)};
     if (!last_header) {
-        LogError("previous block filter header not found; expected %s", previous_hash.ToString());
+        LogError("previous block filter header not found; expected %s", previous.hash.ToString());
         return false;
     }
     m_last_header = *last_header;

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -242,18 +242,11 @@ size_t BlockFilterIndex::WriteFilterToDisk(FlatFilePos& pos, const BlockFilter& 
 
 std::optional<uint256> BlockFilterIndex::ReadFilterHeader(int height, const uint256& expected_block_hash)
 {
-    std::pair<uint256, DBVal> read_out;
-    if (!m_db->Read(index_util::DBHeightKey(height), read_out)) {
+    DBVal entry;
+    if (!index_util::LookUpOne(*m_db, {expected_block_hash, height}, entry)) {
         return std::nullopt;
     }
-
-    if (read_out.first != expected_block_hash) {
-        LogError("previous block header belongs to unexpected block %s; expected %s",
-                 read_out.first.ToString(), expected_block_hash.ToString());
-        return std::nullopt;
-    }
-
-    return read_out.second.header;
+    return entry.header;
 }
 
 bool BlockFilterIndex::CustomAppend(const interfaces::BlockInfo& block)
@@ -301,7 +294,13 @@ bool BlockFilterIndex::CustomRemove(const interfaces::BlockInfo& block)
     m_db->WriteBatch(batch);
 
     // Update cached header to the previous block hash
-    m_last_header = *Assert(ReadFilterHeader(block.height - 1, *Assert(block.prev_hash)));
+    const uint256& previous_hash{*Assert(block.prev_hash)};
+    const auto last_header{ReadFilterHeader(block.height - 1, previous_hash)};
+    if (!last_header) {
+        LogError("previous block filter header not found; expected %s", previous_hash.ToString());
+        return false;
+    }
+    m_last_header = *last_header;
     return true;
 }
 

--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -60,7 +60,7 @@ private:
 
     bool Write(const BlockFilter& filter, uint32_t block_height, const uint256& filter_header);
 
-    std::optional<uint256> ReadFilterHeader(int height, const uint256& expected_block_hash);
+    std::optional<uint256> ReadFilterHeader(const interfaces::BlockRef& block);
 
 protected:
     bool CustomInit(const std::optional<interfaces::BlockRef>& block) override;

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -325,24 +325,14 @@ interfaces::Chain::NotifyOptions CoinStatsIndex::CustomOptions()
 // Revert a single block as part of a reorg
 bool CoinStatsIndex::RevertBlock(const interfaces::BlockInfo& block)
 {
-    std::pair<uint256, DBVal> read_out;
+    DBVal entry;
 
     // Ignore genesis block
     if (block.height > 0) {
-        if (!m_db->Read(index_util::DBHeightKey(block.height - 1), read_out)) {
+        const interfaces::BlockRef previous{*Assert(block.prev_hash), block.height - 1};
+        if (!index_util::LookUpOne(*m_db, previous, entry)) {
+            LogError("previous block entry not found; expected %s", previous.hash.ToString());
             return false;
-        }
-
-        uint256 expected_block_hash{*block.prev_hash};
-        if (read_out.first != expected_block_hash) {
-            LogWarning("previous block header belongs to unexpected block %s; expected %s",
-                      read_out.first.ToString(), expected_block_hash.ToString());
-
-            if (!m_db->Read(index_util::DBHashKey(expected_block_hash), read_out)) {
-                LogError("previous block header not found; expected %s",
-                          expected_block_hash.ToString());
-                return false;
-            }
         }
     }
 
@@ -383,20 +373,20 @@ bool CoinStatsIndex::RevertBlock(const interfaces::BlockInfo& block)
     // Check that the rolled back muhash is consistent with the DB read out
     uint256 out;
     m_muhash.Finalize(out);
-    Assert(read_out.second.muhash == out);
+    Assert(entry.muhash == out);
 
     // Apply the other values from the DB to the member variables
-    m_transaction_output_count = read_out.second.transaction_output_count;
-    m_total_amount = read_out.second.total_amount;
-    m_bogo_size = read_out.second.bogo_size;
-    m_total_subsidy = read_out.second.total_subsidy;
-    m_total_prevout_spent_amount = read_out.second.total_prevout_spent_amount;
-    m_total_new_outputs_ex_coinbase_amount = read_out.second.total_new_outputs_ex_coinbase_amount;
-    m_total_coinbase_amount = read_out.second.total_coinbase_amount;
-    m_total_unspendables_genesis_block = read_out.second.total_unspendables_genesis_block;
-    m_total_unspendables_bip30 = read_out.second.total_unspendables_bip30;
-    m_total_unspendables_scripts = read_out.second.total_unspendables_scripts;
-    m_total_unspendables_unclaimed_rewards = read_out.second.total_unspendables_unclaimed_rewards;
+    m_transaction_output_count = entry.transaction_output_count;
+    m_bogo_size = entry.bogo_size;
+    m_total_amount = entry.total_amount;
+    m_total_subsidy = entry.total_subsidy;
+    m_total_prevout_spent_amount = entry.total_prevout_spent_amount;
+    m_total_new_outputs_ex_coinbase_amount = entry.total_new_outputs_ex_coinbase_amount;
+    m_total_coinbase_amount = entry.total_coinbase_amount;
+    m_total_unspendables_genesis_block = entry.total_unspendables_genesis_block;
+    m_total_unspendables_bip30 = entry.total_unspendables_bip30;
+    m_total_unspendables_scripts = entry.total_unspendables_scripts;
+    m_total_unspendables_unclaimed_rewards = entry.total_unspendables_unclaimed_rewards;
     m_current_block_hash = *block.prev_hash;
 
     return true;

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -338,7 +338,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_reorg_restart, BuildChainTestingSetup)
         m_node.validation_signals->SyncWithValidationInterfaceQueue();
         return index.GetSummary();
     }};
-    auto summary_at{[](const CBlockIndex& tip, bool synced) { return IndexSummary{"basic block filter index", synced, tip.nHeight, tip.GetBlockHash()}; }};
+    auto summary_at{[](const CBlockIndex& tip) { return IndexSummary{"basic block filter index", /*synced=*/true, tip.nHeight, tip.GetBlockHash()}; }};
     const auto* old_tip{current_tip()};
 
     std::vector<std::shared_ptr<CBlock>> fork;
@@ -350,12 +350,12 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_reorg_restart, BuildChainTestingSetup)
         BOOST_REQUIRE(index.Init());
         index.Sync();
         chainstate.ForceFlushStateToDisk();
-        BOOST_CHECK(summary_after_callbacks(index) == summary_at(*old_tip, /*synced=*/true));
+        BOOST_CHECK(summary_after_callbacks(index) == summary_at(*old_tip));
 
         for (const auto& block : fork) {
             BOOST_REQUIRE(chainman.ProcessNewBlock(block, /*force_processing=*/true, /*min_pow_checked=*/true, nullptr));
         }
-        BOOST_CHECK(summary_after_callbacks(index) == summary_at(*current_tip(), /*synced=*/true));
+        BOOST_CHECK(summary_after_callbacks(index) == summary_at(*current_tip()));
         BOOST_CHECK_EQUAL(WITH_LOCK(::cs_main, return chainstate.GetLastFlushedBlock()), old_tip);
     }
 
@@ -368,8 +368,8 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_reorg_restart, BuildChainTestingSetup)
     BOOST_REQUIRE_EQUAL(current_tip(), old_tip);
 
     BlockFilterIndex index{interfaces::MakeChain(m_node), BlockFilterType::BASIC, /*n_cache_size=*/1_MiB, /*f_memory=*/false, /*f_wipe=*/false};
-    BOOST_CHECK(!index.Init()); // TODO: Initialize from old_tip's hash entry.
-    BOOST_CHECK(summary_after_callbacks(index) == summary_at(*old_tip, /*synced=*/false)); // TODO: Mark the recovered index as synced.
+    BOOST_REQUIRE(index.Init());
+    BOOST_CHECK(summary_after_callbacks(index) == summary_at(*old_tip));
 }
 
 class IndexReorgCrash : public BaseIndex

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -329,6 +329,49 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_init_destroy, BasicTestingSetup)
     BOOST_CHECK(filter_index == nullptr);
 }
 
+BOOST_FIXTURE_TEST_CASE(blockfilter_index_reorg_restart, BuildChainTestingSetup)
+{
+    auto& chainman{*Assert(m_node.chainman)};
+    auto& chainstate{chainman.ActiveChainstate()};
+    auto current_tip{[&] { return Assert(WITH_LOCK(::cs_main, return chainman.ActiveTip())); }};
+    auto summary_after_callbacks{[&](BlockFilterIndex& index) {
+        m_node.validation_signals->SyncWithValidationInterfaceQueue();
+        return index.GetSummary();
+    }};
+    auto summary_at{[](const CBlockIndex& tip, bool synced) { return IndexSummary{"basic block filter index", synced, tip.nHeight, tip.GetBlockHash()}; }};
+    const auto* old_tip{current_tip()};
+
+    std::vector<std::shared_ptr<CBlock>> fork;
+    BOOST_REQUIRE(BuildChain(old_tip->pprev, CScript{} << OP_FALSE, /*length=*/2, fork));
+
+    // Keep the locator at old_tip while the replacement fork overwrites its height entry.
+    {
+        BlockFilterIndex index{interfaces::MakeChain(m_node), BlockFilterType::BASIC, /*n_cache_size=*/1_MiB, /*f_memory=*/false, /*f_wipe=*/true};
+        BOOST_REQUIRE(index.Init());
+        index.Sync();
+        chainstate.ForceFlushStateToDisk();
+        BOOST_CHECK(summary_after_callbacks(index) == summary_at(*old_tip, /*synced=*/true));
+
+        for (const auto& block : fork) {
+            BOOST_REQUIRE(chainman.ProcessNewBlock(block, /*force_processing=*/true, /*min_pow_checked=*/true, nullptr));
+        }
+        BOOST_CHECK(summary_after_callbacks(index) == summary_at(*current_tip(), /*synced=*/true));
+        BOOST_CHECK_EQUAL(WITH_LOCK(::cs_main, return chainstate.GetLastFlushedBlock()), old_tip);
+    }
+
+    // After a crash, chainstate may restart at the flushed tip while the replacement fork's eager index writes remain.
+    auto* fork_first{Assert(current_tip()->pprev)};
+    BOOST_REQUIRE_EQUAL(fork_first->nHeight, old_tip->nHeight);
+    BlockValidationState state{};
+    BOOST_REQUIRE(chainstate.InvalidateBlock(state, fork_first));
+    BOOST_REQUIRE(chainstate.ActivateBestChain(state, nullptr));
+    BOOST_REQUIRE_EQUAL(current_tip(), old_tip);
+
+    BlockFilterIndex index{interfaces::MakeChain(m_node), BlockFilterType::BASIC, /*n_cache_size=*/1_MiB, /*f_memory=*/false, /*f_wipe=*/false};
+    BOOST_CHECK(!index.Init()); // TODO: Initialize from old_tip's hash entry.
+    BOOST_CHECK(summary_after_callbacks(index) == summary_at(*old_tip, /*synced=*/false)); // TODO: Mark the recovered index as synced.
+}
+
 class IndexReorgCrash : public BaseIndex
 {
 private:

--- a/src/test/coinstatsindex_tests.cpp
+++ b/src/test/coinstatsindex_tests.cpp
@@ -187,8 +187,8 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_reorg_restart, TestChain100Setup)
     BOOST_REQUIRE_EQUAL(current_tip(), replacement_tip);
     const auto summary{summary_after_callbacks(index)};
     // FatalErrorf requests shutdown, distinguishing a failed revert from a lagging index.
-    BOOST_CHECK(m_interrupt);                     // TODO: Recover the old parent from its hash entry.
-    BOOST_CHECK(summary == summary_at(*old_tip)); // TODO: Advance to replacement_tip.
+    BOOST_CHECK(!m_interrupt);
+    BOOST_CHECK(summary == summary_at(*replacement_tip));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/coinstatsindex_tests.cpp
+++ b/src/test/coinstatsindex_tests.cpp
@@ -123,4 +123,72 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_unclean_shutdown, TestChain100Setup)
     }
 }
 
+BOOST_FIXTURE_TEST_CASE(coinstatsindex_reorg_restart, TestChain100Setup)
+{
+    auto& chainman{*Assert(m_node.chainman)};
+    auto& chainstate{chainman.ActiveChainstate()};
+    auto current_tip{[&] { return Assert(WITH_LOCK(::cs_main, return chainman.ActiveTip())); }};
+    auto summary_after_callbacks{[&](CoinStatsIndex& index) {
+        m_node.validation_signals->SyncWithValidationInterfaceQueue();
+        return index.GetSummary();
+    }};
+    auto summary_at{[](const CBlockIndex& tip) { return IndexSummary{"coinstatsindex", /*synced=*/true, tip.nHeight, tip.GetBlockHash()}; }};
+    auto reconsider{[&](CBlockIndex& block) {
+        {
+            LOCK(::cs_main);
+            chainstate.ResetBlockFailureFlags(&block);
+            chainman.RecalculateBestHeader();
+        }
+        BlockValidationState state{};
+        BOOST_REQUIRE(chainstate.ActivateBestChain(state));
+    }};
+    auto* old_tip{current_tip()};
+    auto* old_first{Assert(old_tip->pprev)};
+    auto* fork_point{Assert(old_first->pprev)};
+
+    // Keep the locator at old_tip while a deeper replacement fork overwrites
+    // its last two height entries.
+    {
+        CoinStatsIndex index{interfaces::MakeChain(m_node), /*n_cache_size=*/1_MiB, /*f_memory=*/false, /*f_wipe=*/true};
+        BOOST_REQUIRE(index.Init());
+        index.Sync();
+        chainstate.ForceFlushStateToDisk();
+        BOOST_CHECK(summary_after_callbacks(index) == summary_at(*old_tip));
+
+        BlockValidationState state{};
+        BOOST_REQUIRE(chainstate.InvalidateBlock(state, old_first));
+        BOOST_REQUIRE(chainstate.ActivateBestChain(state));
+        BOOST_REQUIRE_EQUAL(current_tip(), fork_point);
+        for (int i{0}; i < 3; ++i) {
+            CreateAndProcessBlock({}, CScript{} << OP_FALSE);
+        }
+        BOOST_CHECK(summary_after_callbacks(index) == summary_at(*current_tip()));
+        BOOST_CHECK_EQUAL(WITH_LOCK(::cs_main, return chainstate.GetLastFlushedBlock()), old_tip);
+    }
+    auto* replacement_tip{current_tip()};
+    auto* replacement_first{Assert(replacement_tip->GetAncestor(old_first->nHeight))};
+
+    // Restore chainstate to the flushed branch without changing the index DB.
+    BlockValidationState state{};
+    BOOST_REQUIRE(chainstate.InvalidateBlock(state, replacement_first));
+    BOOST_REQUIRE(chainstate.ActivateBestChain(state));
+    reconsider(*old_first);
+    BOOST_REQUIRE_EQUAL(current_tip(), old_tip);
+
+    // Drain callbacks queued while the index was stopped before registering the restarted instance.
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    CoinStatsIndex index{interfaces::MakeChain(m_node), /*n_cache_size=*/1_MiB, /*f_memory=*/false, /*f_wipe=*/false};
+    BOOST_REQUIRE(index.Init());
+    BOOST_CHECK(index.GetSummary() == summary_at(*old_tip));
+
+    // Reverting old_tip requires its parent from the hash index because the
+    // replacement fork already occupies that height entry.
+    reconsider(*replacement_first);
+    BOOST_REQUIRE_EQUAL(current_tip(), replacement_tip);
+    const auto summary{summary_after_callbacks(index)};
+    // FatalErrorf requests shutdown, distinguishing a failed revert from a lagging index.
+    BOOST_CHECK(m_interrupt);                     // TODO: Recover the old parent from its hash entry.
+    BOOST_CHECK(summary == summary_at(*old_tip)); // TODO: Advance to replacement_tip.
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
**Problem:** [#34897](https://github.com/bitcoin/bitcoin/pull/34897) prevents durable index locators from advancing past flushed chainstate, but block-filter and CoinStats entries are still written eagerly.
During a reorg, replacement blocks can overwrite height entries needed by the locator branch before the locator advances.
After a crash restores that branch, `BlockFilterIndex::Init()` rejects a filter header preserved by hash, while a deeper CoinStats rewind reads a bare hash-index `DBVal` as `std::pair<uint256, DBVal>` and aborts.

**Fix:** Use the existing reorg-aware `index_util::LookUpOne()` for both lookups so they accept a matching height entry or read the expected hash entry using its stored type.
Keep the filter lookup keys together in a `BlockRef`.
If a filter header is genuinely missing during rewind, log the expected hash and return through the existing fatal-error path instead of asserting without a diagnostic.

**Reproducer:** The script flushes block A and its index locator, lets a longer fork overwrite A's height entry without flushing chainstate, then kills and restarts the node.
The parent rejects the index; the PR tip recovers A through its hash entry.

<details><summary>Crash/restart reproducer</summary>

```bash
D="$(mktemp -d)"
cli() { build/bin/bitcoin-cli -regtest "-datadir=$D" "$@"; }
bd() { build/bin/bitcoind -regtest "-datadir=$D" -blockfilterindex=1 -dbcache=1000 -daemonwait >/dev/null 2>&1; }
mine() { cli generatetodescriptor "$1" "$2" >/dev/null; }
flush() { cli gettxoutsetinfo none >/dev/null; cli syncwithvalidationinterfacequeue >/dev/null; }
stop() { cli stop >/dev/null 2>&1; }
down() { while test -e "$D/regtest/bitcoind.pid"; do sleep .1; done; }
crash() { local pid="$(cat "$D/regtest/bitcoind.pid")"; kill -9 "$pid"; while kill -0 "$pid" 2>/dev/null; do sleep .1; done; }
# Persist block A and its filter-index locator
    cmake -B build -GNinja >/dev/null 2>&1 && ninja -C build >/dev/null
    bd && mine 1 'raw(51)'
    A="$(cli getbestblockhash)"; flush
# Overwrite A's height entry without flushing the replacement fork
    cli invalidateblock "$A" && mine 2 'raw(52)' && cli reconsiderblock "$A"
    cli syncwithvalidationinterfacequeue >/dev/null; crash
# Restart from flushed block A and report initialization
    bd && echo -n 'height: ' && cli getblockcount && stop && down
    grep 'Cannot read last block filter header' "$D/regtest/debug.log"
```

**Before:**
> [error] Cannot read last block filter header; index may be corrupted

**After:**
> height: 1
</details>
