### PR TITLE
mempool: bound cumulative priority deltas

### DIFF
--- a/src/cluster_linearize.h
+++ b/src/cluster_linearize.h
@@ -18,6 +18,7 @@
 #include <random.h>
 #include <span.h>
 #include <util/feefrac.h>
+#include <util/overflow.h>
 #include <util/vecdeque.h>
 
 namespace cluster_linearize {
@@ -249,7 +250,7 @@ public:
     FeeFrac FeeRate(const SetType& elems) const noexcept
     {
         FeeFrac ret;
-        for (auto pos : elems) ret += entries[pos].feerate;
+        for (auto pos : elems) ret = FeeFrac::SaturatingAdd(ret, entries[pos].feerate);
         return ret;
     }
 
@@ -385,7 +386,7 @@ struct SetInfo
     {
         Assume(!transactions[pos]);
         transactions.Set(pos);
-        feerate += depgraph.FeeRate(pos);
+        feerate = FeeFrac::SaturatingAdd(feerate, depgraph.FeeRate(pos));
     }
 
     /** Add the transactions of other to this SetInfo (no overlap allowed). */
@@ -393,7 +394,7 @@ struct SetInfo
     {
         Assume(!transactions.Overlaps(other.transactions));
         transactions |= other.transactions;
-        feerate += other.feerate;
+        feerate = FeeFrac::SaturatingAdd(feerate, other.feerate);
         return *this;
     }
 
@@ -402,7 +403,7 @@ struct SetInfo
     {
         Assume(other.transactions.IsSubsetOf(transactions));
         transactions -= other.transactions;
-        feerate -= other.feerate;
+        feerate = FeeFrac::SaturatingSubtract(feerate, other.feerate);
         return *this;
     }
 
@@ -410,7 +411,7 @@ struct SetInfo
     SetInfo operator-(const SetInfo& other) const noexcept
     {
         Assume(other.transactions.IsSubsetOf(transactions));
-        return {transactions - other.transactions, feerate - other.feerate};
+        return {transactions - other.transactions, FeeFrac::SaturatingSubtract(feerate, other.feerate)};
     }
 
     /** Swap two SetInfo objects. */
@@ -454,7 +455,7 @@ std::vector<FeeFrac> ChunkLinearization(const DepGraph<SetType>& depgraph, std::
         auto new_chunk = depgraph.FeeRate(i);
         // As long as the new chunk has a higher feerate than the last chunk so far, absorb it.
         while (!ret.empty() && ByRatio{new_chunk} > ByRatio{ret.back()}) {
-            new_chunk += ret.back();
+            new_chunk = FeeFrac::SaturatingAdd(new_chunk, ret.back());
             ret.pop_back();
         }
         // Actually move that new chunk into the chunking.
@@ -1847,7 +1848,7 @@ std::tuple<std::vector<DepGraphIndex>, bool, uint64_t> Linearize(
  *                               potentially better linearization for the same graph.
  *
  * Postlinearization guarantees:
- * - The resulting chunks are connected.
+ * - The resulting chunks are connected as long as their fee sums do not saturate.
  * - If the input has a tree shape (either all transactions have at most one child, or all
  *   transactions have at most one parent), the result is optimal.
  * - Given a linearization L1 and a leaf transaction T in it. Let L2 be L1 with T moved to the end,
@@ -1862,7 +1863,8 @@ void PostLinearize(const DepGraph<SetType>& depgraph, std::span<DepGraphIndex> l
     // This algorithm performs a number of passes (currently 2); the even ones operate from back to
     // front, the odd ones from front to back. Each results in an equal-or-better linearization
     // than the one started from.
-    // - One pass in either direction guarantees that the resulting chunks are connected.
+    // - One pass in either direction guarantees that the resulting chunks are connected as long as
+    //   their fee sums do not saturate.
     // - Each direction corresponds to one shape of tree being linearized optimally (forward passes
     //   guarantee this for graphs where each transaction has at most one child; backward passes
     //   guarantee this for graphs where each transaction has at most one parent).
@@ -1966,7 +1968,7 @@ void PostLinearize(const DepGraph<SetType>& depgraph, std::span<DepGraphIndex> l
             entries[cur_group].group = SetType::Singleton(idx);
             entries[cur_group].deps = rev ? depgraph.Descendants(idx): depgraph.Ancestors(idx);
             entries[cur_group].feerate = depgraph.FeeRate(idx);
-            if (rev) entries[cur_group].feerate.fee = -entries[cur_group].feerate.fee;
+            if (rev) entries[cur_group].feerate.fee = SaturatingNegate(entries[cur_group].feerate.fee);
             entries[cur_group].prev_tx = NO_PREV_TX; // No previous transaction in group.
             entries[cur_group].first_tx = cur_group; // Transaction itself is first of group.
             // Insert the new group at the back of the groups linked list.
@@ -1993,7 +1995,7 @@ void PostLinearize(const DepGraph<SetType>& depgraph, std::span<DepGraphIndex> l
                     // but become unused.
                     entries[cur_group].group |= entries[prev_group].group;
                     entries[cur_group].deps |= entries[prev_group].deps;
-                    entries[cur_group].feerate += entries[prev_group].feerate;
+                    entries[cur_group].feerate = FeeFrac::SaturatingAdd(entries[cur_group].feerate, entries[prev_group].feerate);
                     // Make the first of the current group point to the tail of the previous group.
                     entries[entries[cur_group].first_tx].prev_tx = prev_group;
                     // The first of the previous group becomes the first of the newly-merged group.

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -108,9 +108,9 @@ void CCoinsViewCache::AddCoin(const COutPoint &outpoint, Coin&& coin, bool possi
            (bool)it->second.coin.IsCoinBase());
 }
 
-void CCoinsViewCache::EmplaceCoinInternalDANGER(COutPoint&& outpoint, Coin&& coin) {
+void CCoinsViewCache::EmplaceCoinInternalDANGER(const COutPoint& outpoint, Coin&& coin) {
     const auto mem_usage{coin.DynamicMemoryUsage()};
-    auto [it, inserted] = cacheCoins.try_emplace(std::move(outpoint), std::move(coin));
+    auto [it, inserted] = cacheCoins.try_emplace(outpoint, std::move(coin));
     if (inserted) {
         CCoinsCacheEntry::SetDirty(*it, m_sentinel);
         ++m_dirty_count;

--- a/src/coins.h
+++ b/src/coins.h
@@ -471,7 +471,7 @@ public:
      * NOT FOR GENERAL USE. Used only when loading coins from a UTXO snapshot.
      * @sa ChainstateManager::PopulateAndValidateSnapshot()
      */
-    void EmplaceCoinInternalDANGER(COutPoint&& outpoint, Coin&& coin);
+    void EmplaceCoinInternalDANGER(const COutPoint& outpoint, Coin&& coin);
 
     /**
      * Spend a coin. Pass moveto in order to get the deleted data.

--- a/src/kernel/mempool_entry.h
+++ b/src/kernel/mempool_entry.h
@@ -127,6 +127,11 @@ public:
         m_modified_fee = SaturatingAdd(m_modified_fee, fee_diff);
     }
 
+    void SetModifiedFee(CAmount modified_fee) const
+    {
+        m_modified_fee = modified_fee;
+    }
+
     // Update the LockPoints after a reorg
     void UpdateLockPoints(const LockPoints& lp) const
     {

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -236,7 +236,7 @@ struct RPCArg {
         std::string description,
         RPCArgOptions opts = {})
         : m_names{std::move(name)},
-          m_type{std::move(type)},
+          m_type{type},
           m_fallback{std::move(fallback)},
           m_description{std::move(description)},
           m_opts{std::move(opts)}
@@ -252,7 +252,7 @@ struct RPCArg {
         std::vector<RPCArg> inner,
         RPCArgOptions opts = {})
         : m_names{std::move(name)},
-          m_type{std::move(type)},
+          m_type{type},
           m_inner{std::move(inner)},
           m_fallback{std::move(fallback)},
           m_description{std::move(description)},
@@ -338,7 +338,7 @@ struct RPCResult {
         std::string description,
         std::vector<RPCResult> inner = {},
         RPCResultOptions opts = {})
-        : m_type{std::move(type)},
+        : m_type{type},
           m_key_name{std::move(m_key_name)},
           m_inner{std::move(inner)},
           m_optional{optional},
@@ -366,7 +366,7 @@ struct RPCResult {
         std::string description,
         std::vector<RPCResult> inner = {},
         RPCResultOptions opts = {})
-        : m_type{std::move(type)},
+        : m_type{type},
           m_key_name{std::move(m_key_name)},
           m_inner{std::move(inner)},
           m_optional{optional},

--- a/src/test/cluster_linearize_tests.cpp
+++ b/src/test/cluster_linearize_tests.cpp
@@ -8,6 +8,7 @@
 #include <util/bitset.h>
 #include <util/strencodings.h>
 
+#include <limits>
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
@@ -480,6 +481,21 @@ BOOST_AUTO_TEST_CASE(depgraph_optimal_tests)
     TestOptimalLinearization("855f8024008024816501807c81020284629b030383078631048044895c000002048078100100000000068315856a020000000004800784130300000000028167800c04000000000281758a14010000000885249a1a0100010004852ca63e020000010300"_hex_u8, {6, 1, 12, 5, 11, 3, 4, 10, 0, 8, 9, 7, 2});
     TestOptimalLinearization("855f97230080678a4f018210925d02856113038105892b04854e996105805a8a480000000000000283028b7a01000000000002846d9f080200000000000283189656030000000000018277862e0400000000000185508d200500000000000000"_hex_u8, {3, 0, 10, 7, 2, 1, 4, 8, 6, 5, 11, 9});
     TestOptimalLinearization("866faa23008646b71501851f96130282588f1103804d851c0000000003822097600100000003850a8f310200000003856e9201000000038656935f01000003855b8f5f020000018743923a0000000a812b810b010000098403a328020000068712970203000005833e98400400000200"_hex_u8, {11, 14, 1, 10, 4, 3, 5, 13, 9, 7, 6, 12, 8, 0, 2});
+}
+
+BOOST_AUTO_TEST_CASE(postlinearize_handles_saturated_reverse_fees)
+{
+    DepGraph<TestBitSet> depgraph;
+    const auto parent{depgraph.AddTransaction(FeeFrac{std::numeric_limits<int64_t>::min(), 1})};
+    const auto child{depgraph.AddTransaction(FeeFrac{std::numeric_limits<int64_t>::min(), 2})};
+    depgraph.AddDependencies(TestBitSet::Singleton(parent), child);
+
+    std::vector<DepGraphIndex> linearization{parent, child};
+    PostLinearize(depgraph, linearization);
+
+    BOOST_CHECK_EQUAL(linearization[0], parent);
+    BOOST_CHECK_EQUAL(linearization[1], child);
+    BOOST_CHECK_EQUAL(ChunkLinearizationInfo(depgraph, linearization).size(), 1U);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -193,7 +193,7 @@ void SimulationTest(CCoinsView* base, bool fake_best_block)
                     coin = newcoin;
                 }
                 if (COutPoint op(txid, 0); !stack.back()->map().contains(op) && !newcoin.out.scriptPubKey.IsUnspendable() && m_rng.randbool()) {
-                    stack.back()->EmplaceCoinInternalDANGER(std::move(op), std::move(newcoin));
+                    stack.back()->EmplaceCoinInternalDANGER(op, std::move(newcoin));
                 } else {
                     stack.back()->AddCoin(op, std::move(newcoin), /*possible_overwrite=*/!coin.IsSpent() || m_rng.randbool());
                 }
@@ -1109,11 +1109,11 @@ BOOST_AUTO_TEST_CASE(ccoins_emplace_duplicate_keeps_usage_balanced)
     const COutPoint outpoint{Txid::FromUint256(m_rng.rand256()), m_rng.rand32()};
 
     const Coin coin1{CTxOut{m_rng.randrange(10), CScript{} << m_rng.randbytes(CScriptBase::STATIC_SIZE + 1)}, 1, false};
-    cache.EmplaceCoinInternalDANGER(COutPoint{outpoint}, Coin{coin1});
+    cache.EmplaceCoinInternalDANGER(outpoint, Coin{coin1});
     cache.SelfTest();
 
     const Coin coin2{CTxOut{m_rng.randrange(20), CScript{} << m_rng.randbytes(CScriptBase::STATIC_SIZE + 2)}, 2, false};
-    cache.EmplaceCoinInternalDANGER(COutPoint{outpoint}, Coin{coin2});
+    cache.EmplaceCoinInternalDANGER(outpoint, Coin{coin2});
     cache.SelfTest();
 
     BOOST_CHECK(cache.AccessCoin(outpoint) == coin1);
@@ -1132,7 +1132,7 @@ BOOST_AUTO_TEST_CASE(ccoins_reset_guard)
     const COutPoint outpoint{Txid::FromUint256(m_rng.rand256()), m_rng.rand32()};
 
     const Coin coin{CTxOut{m_rng.randrange(10), CScript{} << m_rng.randbytes(CScriptBase::STATIC_SIZE + 1)}, 1, false};
-    cache.EmplaceCoinInternalDANGER(COutPoint{outpoint}, Coin{coin});
+    cache.EmplaceCoinInternalDANGER(outpoint, Coin{coin});
     BOOST_CHECK_EQUAL(cache.GetDirtyCount(), 1U);
 
     uint256 cache_best_block{m_rng.rand256()};

--- a/src/test/coinsviewoverlay_tests.cpp
+++ b/src/test/coinsviewoverlay_tests.cpp
@@ -48,7 +48,7 @@ void PopulateView(const CBlock& block, CCoinsView& view, bool spent = false)
         for (const auto& in : tx->vin) {
             Coin coin{};
             if (!spent) coin.out.nValue = 1;
-            cache.EmplaceCoinInternalDANGER(COutPoint{in.prevout}, std::move(coin));
+            cache.EmplaceCoinInternalDANGER(in.prevout, std::move(coin));
         }
     }
 

--- a/src/test/feefrac_tests.cpp
+++ b/src/test/feefrac_tests.cpp
@@ -5,6 +5,8 @@
 #include <util/feefrac.h>
 #include <random.h>
 
+#include <limits>
+
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE(feefrac_tests)
@@ -68,6 +70,15 @@ BOOST_AUTO_TEST_CASE(feefrac_operators)
     FeeFrac p4{3000, 300};
     BOOST_CHECK(p1 == p4-p3);
     BOOST_CHECK(p1 + p3 == p4);
+
+    const FeeFrac max_frac{std::numeric_limits<int64_t>::max(), std::numeric_limits<int32_t>::max()};
+    const FeeFrac min_frac{std::numeric_limits<int64_t>::min(), std::numeric_limits<int32_t>::min()};
+    const FeeFrac one{1, 1};
+    const FeeFrac negative_one{-1, -1};
+    BOOST_CHECK(FeeFrac::SaturatingAdd(max_frac, one) == max_frac);
+    BOOST_CHECK(FeeFrac::SaturatingAdd(min_frac, negative_one) == min_frac);
+    BOOST_CHECK(FeeFrac::SaturatingSubtract(min_frac, one) == min_frac);
+    BOOST_CHECK(FeeFrac::SaturatingSubtract(max_frac, negative_one) == max_frac);
 
     // Fee-rate comparison
     BOOST_CHECK(ByRatioNegSize{p1} > ByRatioNegSize{p2});

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -115,7 +115,7 @@ void TestCoinsView(FuzzedDataProvider& fuzzed_data_provider, CCoinsViewCache& co
                     const bool possible_overwrite{coins_view_cache.PeekCoin(outpoint) || fuzzed_data_provider.ConsumeBool()};
                     coins_view_cache.AddCoin(outpoint, std::move(coin), possible_overwrite);
                 } else {
-                    coins_view_cache.EmplaceCoinInternalDANGER(std::move(outpoint), std::move(coin));
+                    coins_view_cache.EmplaceCoinInternalDANGER(outpoint, std::move(coin));
                 }
             },
             [&] {

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -73,17 +73,6 @@ T Deserialize(DataStream&& ds, const P& params)
     return obj;
 }
 
-template <typename T, typename P>
-void DeserializeFromFuzzingInput(FuzzBufferType buffer, T&& obj, const P& params)
-{
-    try {
-        SpanReader{buffer} >> params(obj);
-    } catch (const std::ios_base::failure&) {
-        throw invalid_fuzzing_input_exception();
-    }
-    assert(buffer.empty() || !Serialize(obj, params).empty());
-}
-
 template <typename T>
 DataStream Serialize(const T& obj)
 {

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -58,14 +58,6 @@ struct invalid_fuzzing_input_exception : public std::exception {
 };
 
 template <typename T, typename P>
-DataStream Serialize(const T& obj, const P& params)
-{
-    DataStream ds{};
-    ds << params(obj);
-    return ds;
-}
-
-template <typename T, typename P>
 T Deserialize(DataStream&& ds, const P& params)
 {
     T obj;
@@ -116,7 +108,7 @@ T DeserializeConstructFromFuzzingInput(FuzzBufferType buffer)
 template <typename T, typename P>
 void AssertEqualAfterSerializeDeserialize(const T& obj, const P& params)
 {
-    assert(Deserialize<T>(Serialize(obj, params), params) == obj);
+    assert(Deserialize<T>(Serialize(params(obj)), params) == obj);
 }
 template <typename T>
 void AssertEqualAfterSerializeDeserialize(const T& obj)

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -12,6 +12,7 @@
 #include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
+#include <limits>
 #include <vector>
 
 BOOST_FIXTURE_TEST_SUITE(mempool_tests, TestingSetup)
@@ -48,6 +49,36 @@ BOOST_AUTO_TEST_CASE(MempoolLookupTest)
 
     // Lookup by Wtxid
     BOOST_CHECK(pool.get(CTransaction(tx).GetWitnessHash()));
+}
+
+BOOST_AUTO_TEST_CASE(MempoolPrioritisationSaturationTest)
+{
+    CTxMemPool& pool{*Assert(m_node.mempool)};
+    TestMemPoolEntryHelper entry;
+
+    CMutableTransaction tx;
+    tx.vin.resize(1);
+    tx.vin[0].scriptSig = CScript() << OP_1;
+    tx.vout.resize(1);
+    tx.vout[0].scriptPubKey = CScript() << OP_1 << OP_EQUAL;
+    tx.vout[0].nValue = 10 * COIN;
+
+    constexpr CAmount base_fee{10'000};
+    const Txid txid{tx.GetHash()};
+    {
+        LOCK2(cs_main, pool.cs);
+        TryAddToMempool(pool, entry.Fee(base_fee).FromTx(tx));
+    }
+
+    const CAmount min_delta{std::numeric_limits<CAmount>::min()};
+    pool.PrioritiseTransaction(txid, min_delta);
+    pool.PrioritiseTransaction(txid, -base_fee);
+
+    const auto prioritised{pool.GetPrioritisedTransactions()};
+    BOOST_REQUIRE_EQUAL(prioritised.size(), 1U);
+    BOOST_CHECK_EQUAL(prioritised.front().delta, min_delta);
+    BOOST_REQUIRE(prioritised.front().modified_fee.has_value());
+    BOOST_CHECK_EQUAL(*prioritised.front().modified_fee, min_delta); // TODO: derive the modified fee from the cumulative delta
 }
 
 BOOST_AUTO_TEST_CASE(MempoolRemoveTest)

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(MempoolPrioritisationSaturationTest)
     BOOST_REQUIRE_EQUAL(prioritised.size(), 1U);
     BOOST_CHECK_EQUAL(prioritised.front().delta, min_delta);
     BOOST_REQUIRE(prioritised.front().modified_fee.has_value());
-    BOOST_CHECK_EQUAL(*prioritised.front().modified_fee, min_delta); // TODO: derive the modified fee from the cumulative delta
+    BOOST_CHECK_EQUAL(*prioritised.front().modified_fee, min_delta + base_fee);
 }
 
 BOOST_AUTO_TEST_CASE(MempoolRemoveTest)

--- a/src/test/txgraph_tests.cpp
+++ b/src/test/txgraph_tests.cpp
@@ -8,7 +8,10 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <array>
+#include <limits>
 #include <memory>
+#include <set>
 #include <vector>
 
 BOOST_AUTO_TEST_SUITE(txgraph_tests)
@@ -376,6 +379,55 @@ BOOST_AUTO_TEST_CASE(txgraph_chunk_chain)
     graph->RemoveTransaction(refs[3]);
     BOOST_CHECK_EQUAL(graph->GetTransactionCount(TxGraph::Level::TOP), 1);
     block_builder_checker({{&refs[0]}});
+}
+
+BOOST_AUTO_TEST_CASE(txgraph_saturated_chunking_keeps_block_builder_connected)
+{
+    auto graph = MakeTxGraph(10, 100'000, HIGH_ACCEPTABLE_COST, PointerComparator);
+
+    static constexpr int64_t MAX_FEE{std::numeric_limits<int64_t>::max()};
+    const std::array feerates{
+        FeePerWeight{MAX_FEE, 2056},
+        FeePerWeight{8934011356766855619, 1040},
+        FeePerWeight{MAX_FEE, 2056},
+        FeePerWeight{MAX_FEE, 2056},
+        FeePerWeight{8933836393842009569, 2352},
+        FeePerWeight{8934011356766855619, 7592},
+        FeePerWeight{8934011353014096838, 2056},
+        FeePerWeight{3253225981, 9920},
+    };
+
+    std::vector<TxGraph::Ref> refs;
+    refs.reserve(feerates.size());
+    for (const auto& feerate : feerates) {
+        graph->AddTransaction(refs.emplace_back(), feerate);
+    }
+
+    graph->AddDependency(/*parent=*/refs[0], /*child=*/refs[1]);
+    graph->AddDependency(/*parent=*/refs[0], /*child=*/refs[4]);
+    graph->AddDependency(/*parent=*/refs[2], /*child=*/refs[4]);
+    graph->AddDependency(/*parent=*/refs[3], /*child=*/refs[4]);
+    graph->AddDependency(/*parent=*/refs[2], /*child=*/refs[7]);
+    graph->AddDependency(/*parent=*/refs[5], /*child=*/refs[7]);
+    graph->AddDependency(/*parent=*/refs[6], /*child=*/refs[7]);
+
+    graph->SanityCheck();
+
+    auto builder{graph->GetBlockBuilder()};
+    auto chunk{builder->GetCurrentChunk()};
+    BOOST_REQUIRE(chunk);
+    BOOST_CHECK_EQUAL(chunk->first.size(), refs.size());
+    BOOST_CHECK((chunk->second == FeePerWeight{MAX_FEE, 29128}));
+
+    const std::set<TxGraph::Ref*> returned{chunk->first.begin(), chunk->first.end()};
+    for (auto& ref : refs) {
+        BOOST_CHECK(returned.contains(&ref));
+        BOOST_CHECK(graph->GetMainChunkFeerate(ref) == chunk->second);
+    }
+
+    builder->Include();
+    BOOST_CHECK(!builder->GetCurrentChunk());
+    graph->SanityCheck();
 }
 
 BOOST_AUTO_TEST_CASE(txgraph_staging)

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -666,6 +666,19 @@ static void TestAddMatrix()
     BOOST_CHECK_EQUAL(MINI, SaturatingAdd(T{-1}, MINI + 1));
     BOOST_CHECK_EQUAL(MINI + 1, SaturatingAdd(T{-1}, MINI + 2));
     BOOST_CHECK_EQUAL(-1, SaturatingAdd(MINI, MAXI));
+
+    BOOST_CHECK_EQUAL(MAXI, SaturatingNegate(MINI));
+    BOOST_CHECK_EQUAL(MINI + 1, SaturatingNegate(MAXI));
+    BOOST_CHECK_EQUAL(0, SaturatingNegate(T{0}));
+    BOOST_CHECK_EQUAL(-1, SaturatingNegate(T{1}));
+    BOOST_CHECK_EQUAL(1, SaturatingNegate(T{-1}));
+
+    BOOST_CHECK_EQUAL(MINI, SaturatingSubtract(MINI, T{1}));
+    BOOST_CHECK_EQUAL(MAXI, SaturatingSubtract(MAXI, T{-1}));
+    BOOST_CHECK_EQUAL(MAXI, SaturatingSubtract(T{0}, MINI));
+    BOOST_CHECK_EQUAL(MAXI, SaturatingSubtract(T{-1}, MINI));
+    BOOST_CHECK_EQUAL(MINI + 1, SaturatingSubtract(MINI, T{-1}));
+    BOOST_CHECK_EQUAL(0, SaturatingSubtract(T{1}, T{1}));
 }
 
 BOOST_AUTO_TEST_CASE(util_overflow)

--- a/src/txgraph.cpp
+++ b/src/txgraph.cpp
@@ -2710,9 +2710,9 @@ void TxGraphImpl::CommitStaging() noexcept
     m_main_clusterset.m_deps_to_add = std::move(m_staging_clusterset->m_deps_to_add);
     m_main_clusterset.m_to_remove = std::move(m_staging_clusterset->m_to_remove);
     m_main_clusterset.m_group_data = std::move(m_staging_clusterset->m_group_data);
-    m_main_clusterset.m_oversized = std::move(m_staging_clusterset->m_oversized);
-    m_main_clusterset.m_txcount = std::move(m_staging_clusterset->m_txcount);
-    m_main_clusterset.m_txcount_oversized = std::move(m_staging_clusterset->m_txcount_oversized);
+    m_main_clusterset.m_oversized = m_staging_clusterset->m_oversized;
+    m_main_clusterset.m_txcount = m_staging_clusterset->m_txcount;
+    m_main_clusterset.m_txcount_oversized = m_staging_clusterset->m_txcount_oversized;
     // Delete the old staging graph, after all its information was moved to main.
     m_staging_clusterset.reset();
     Compact();

--- a/src/txgraph.cpp
+++ b/src/txgraph.cpp
@@ -298,6 +298,7 @@ public:
     void Merge(TxGraphImpl& graph, int level, Cluster& cluster) noexcept final;
     void ApplyDependencies(TxGraphImpl& graph, int level, std::span<std::pair<GraphIndex, GraphIndex>> to_apply) noexcept final;
     std::pair<uint64_t, bool> Relinearize(TxGraphImpl& graph, int level, uint64_t max_cost) noexcept final;
+    std::vector<SetInfo<SetType>> GetChunking() const noexcept;
     void AppendChunkFeerates(std::vector<FeeFrac>& ret) const noexcept final;
     uint64_t AppendTrimData(std::vector<TrimTxData>& ret, std::vector<std::pair<GraphIndex, GraphIndex>>& deps) const noexcept final;
     void GetAncestorRefs(const TxGraphImpl& graph, std::span<std::pair<Cluster*, DepGraphIndex>>& args, std::vector<TxGraph::Ref*>& output) noexcept final;
@@ -1069,6 +1070,20 @@ void SingletonClusterImpl::RemoveChunkData(TxGraphImpl& graph) noexcept
     graph.ClearChunkData(entry);
 }
 
+std::vector<SetInfo<Cluster::SetType>> GenericClusterImpl::GetChunking() const noexcept
+{
+    auto chunking{ChunkLinearizationInfo(m_depgraph, m_linearization)};
+    // Keep the regular chunks while compaction is splitting disconnected clusters.
+    if (!m_depgraph.IsConnected()) return chunking;
+    for (const auto& chunk : chunking) {
+        if (!m_depgraph.IsConnected(chunk.transactions)) {
+            // Saturated fee sums can merge independent subpackages.
+            return {SetInfo<SetType>{m_depgraph, m_depgraph.Positions()}};
+        }
+    }
+    return chunking;
+}
+
 void GenericClusterImpl::Updated(TxGraphImpl& graph, int level, bool rename) noexcept
 {
     // Update all the Locators for this Cluster's Entry objects.
@@ -1088,7 +1103,7 @@ void GenericClusterImpl::Updated(TxGraphImpl& graph, int level, bool rename) noe
     // entries remain consistent with the chunk index (otherwise unrelated chunk index operations
     // could cause the index to become corrupted, by inserting elements in the wrong place).
     if (level == 0 && (rename || IsAcceptable())) {
-        auto chunking = ChunkLinearizationInfo(m_depgraph, m_linearization);
+        auto chunking = GetChunking();
         LinearizationIndex lin_idx{0};
         /** The sum of all chunk feerate FeeFracs with the same feerate as the current chunk,
          *  up to and including the current chunk. */
@@ -1105,7 +1120,7 @@ void GenericClusterImpl::Updated(TxGraphImpl& graph, int level, bool rename) noe
             } else {
                 // Note that this is adding fees to fees, and sizes to sizes, so the overall
                 // ratio remains the same; it's just accounting for the size of the added chunk.
-                equal_feerate_chunk_feerate += chunk.feerate;
+                equal_feerate_chunk_feerate = FeeFrac::SaturatingAdd(equal_feerate_chunk_feerate, chunk.feerate);
             }
             // Determine the m_fallback_order maximum transaction in the chunk.
             auto it = chunk.transactions.begin();
@@ -1383,9 +1398,9 @@ void SingletonClusterImpl::Compact() noexcept
 
 void GenericClusterImpl::AppendChunkFeerates(std::vector<FeeFrac>& ret) const noexcept
 {
-    auto chunk_feerates = ChunkLinearization(m_depgraph, m_linearization);
-    ret.reserve(ret.size() + chunk_feerates.size());
-    ret.insert(ret.end(), chunk_feerates.begin(), chunk_feerates.end());
+    auto chunks = GetChunking();
+    ret.reserve(ret.size() + chunks.size());
+    for (const auto& chunk : chunks) ret.push_back(chunk.feerate);
 }
 
 void SingletonClusterImpl::AppendChunkFeerates(std::vector<FeeFrac>& ret) const noexcept
@@ -1398,7 +1413,7 @@ void SingletonClusterImpl::AppendChunkFeerates(std::vector<FeeFrac>& ret) const 
 uint64_t GenericClusterImpl::AppendTrimData(std::vector<TrimTxData>& ret, std::vector<std::pair<GraphIndex, GraphIndex>>& deps) const noexcept
 {
     Assume(IsAcceptable());
-    auto linchunking = ChunkLinearizationInfo(m_depgraph, m_linearization);
+    auto linchunking = GetChunking();
     LinearizationIndex pos{0};
     uint64_t size{0};
     auto prev_index = GraphIndex(-1);
@@ -2845,7 +2860,7 @@ void GenericClusterImpl::SanityCheck(const TxGraphImpl& graph, int level) const
     }
 
     // Compute the chunking of m_linearization.
-    auto linchunking = ChunkLinearizationInfo(m_depgraph, m_linearization);
+    auto linchunking = GetChunking();
     unsigned chunk_num{0};
 
     // Verify m_linearization.
@@ -2879,7 +2894,7 @@ void GenericClusterImpl::SanityCheck(const TxGraphImpl& graph, int level) const
                     equal_feerate_prefix = linchunking[chunk_num].feerate;
                 } else {
                     assert(ByRatio{linchunking[chunk_num].feerate} == ByRatio{equal_feerate_prefix});
-                    equal_feerate_prefix += linchunking[chunk_num].feerate;
+                    equal_feerate_prefix = FeeFrac::SaturatingAdd(equal_feerate_prefix, linchunking[chunk_num].feerate);
                 }
             }
             assert(entry.m_main_chunk_feerate == linchunking[chunk_num].feerate);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -644,9 +644,8 @@ void CTxMemPool::PrioritiseTransaction(const Txid& hash, const CAmount& nFeeDelt
         delta = SaturatingAdd(delta, nFeeDelta);
         txiter it = mapTx.find(hash);
         if (it != mapTx.end()) {
-            // PrioritiseTransaction calls stack on previous ones. Set the new
-            // transaction fee to be current modified fee + feedelta.
-            it->UpdateModifiedFee(nFeeDelta);
+            // Keep the modified fee consistent with the saturated delta.
+            it->SetModifiedFee(SaturatingAdd(it->GetFee(), delta));
             m_txgraph->SetTransactionFee(*it, it->GetModifiedFee());
             ++nTransactionsUpdated;
         }

--- a/src/util/feefrac.h
+++ b/src/util/feefrac.h
@@ -129,6 +129,18 @@ struct FeeFrac
         return {a.fee - b.fee, a.size - b.size};
     }
 
+    /** Saturating sum fee and size. */
+    static constexpr FeeFrac SaturatingAdd(const FeeFrac& a, const FeeFrac& b) noexcept
+    {
+        return {::SaturatingAdd(a.fee, b.fee), ::SaturatingAdd(a.size, b.size)};
+    }
+
+    /** Saturating subtract both fee and size. */
+    static constexpr FeeFrac SaturatingSubtract(const FeeFrac& a, const FeeFrac& b) noexcept
+    {
+        return {::SaturatingSubtract(a.fee, b.fee), ::SaturatingSubtract(a.size, b.size)};
+    }
+
     /** Check if two FeeFrac objects are equal (both same fee and same size). */
     friend inline bool operator==(const FeeFrac& a, const FeeFrac& b) noexcept
     {

--- a/src/util/overflow.h
+++ b/src/util/overflow.h
@@ -41,7 +41,7 @@ template <std::unsigned_integral T, std::unsigned_integral U>
 }
 
 template <std::integral T>
-[[nodiscard]] T SaturatingAdd(const T i, const T j) noexcept
+[[nodiscard]] constexpr T SaturatingAdd(const T i, const T j) noexcept
 {
     if constexpr (std::numeric_limits<T>::is_signed) {
         if (i > 0 && j > std::numeric_limits<T>::max() - i) {
@@ -56,6 +56,25 @@ template <std::integral T>
         }
     }
     return i + j;
+}
+
+template <std::signed_integral T>
+[[nodiscard]] constexpr T SaturatingSubtract(const T i, const T j) noexcept
+{
+    // Not SaturatingAdd(i, SaturatingNegate(j)), which is off by one when j is the minimum value.
+    if (j > 0 && i < std::numeric_limits<T>::min() + j) {
+        return std::numeric_limits<T>::min();
+    }
+    if (j < 0 && i > std::numeric_limits<T>::max() + j) {
+        return std::numeric_limits<T>::max();
+    }
+    return i - j;
+}
+
+template <std::signed_integral T>
+[[nodiscard]] constexpr T SaturatingNegate(const T i) noexcept
+{
+    return i == std::numeric_limits<T>::min() ? std::numeric_limits<T>::max() : -i;
 }
 
 /**

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5812,7 +5812,7 @@ util::Result<void> ChainstateManager::PopulateAndValidateSnapshot(
                     return util::Error{Untranslated(strprintf("Bad snapshot data after deserializing %d coins - bad tx out value",
                               coins_count - coins_left))};
                 }
-                coins_cache.EmplaceCoinInternalDANGER(std::move(outpoint), std::move(coin));
+                coins_cache.EmplaceCoinInternalDANGER(outpoint, std::move(coin));
 
                 --coins_left;
                 ++coins_processed;

--- a/test/functional/mining_prioritisetransaction.py
+++ b/test/functional/mining_prioritisetransaction.py
@@ -88,6 +88,27 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         self.generate(self.nodes[0], 1)
         assert_equal(self.nodes[0].getprioritisedtransactions(), {})
 
+    def test_saturated_fee_cluster(self):
+        self.log.info("Test that saturated modified fees can be linearized")
+        parent = self.wallet.create_self_transfer(fee_rate=0)
+        self.nodes[0].prioritisetransaction(txid=parent["txid"], fee_delta=COIN)
+        self.wallet.sendrawtransaction(from_node=self.nodes[0], tx_hex=parent["hex"])
+        child = self.wallet.create_self_transfer(utxo_to_spend=parent["new_utxo"], fee_rate=0)
+        self.nodes[0].prioritisetransaction(txid=child["txid"], fee_delta=COIN)
+        self.wallet.sendrawtransaction(from_node=self.nodes[0], tx_hex=child["hex"])
+        min_fee = -(1 << 63)
+        for txid in (parent["txid"], child["txid"]):
+            self.nodes[0].prioritisetransaction(txid=txid, fee_delta=min_fee)
+            self.nodes[0].prioritisetransaction(txid=txid, fee_delta=min_fee)
+            assert_equal(self.nodes[0].getprioritisedtransactions()[txid]["modified_fee"], min_fee)
+        assert_equal(self.nodes[0].getmempoolcluster(child["txid"])["txcount"], 2)
+
+        for txid in (parent["txid"], child["txid"]):
+            self.nodes[0].prioritisetransaction(txid=txid, fee_delta=(1 << 63) - 1)
+            self.nodes[0].prioritisetransaction(txid=txid, fee_delta=1)
+        assert_equal(self.nodes[0].getprioritisedtransactions(), {})
+        self.generate(self.nodes[0], 1)
+
     def test_replacement(self):
         self.log.info("Test tx prioritisation stays after a tx is replaced")
         conflicting_input = self.wallet.get_utxo()
@@ -228,6 +249,7 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         assert_raises_rpc_error(-3, "JSON value of type string is not of expected type number", self.nodes[0].prioritisetransaction, txid=txid, fee_delta='foo')
 
         self.test_large_fee_bump()
+        self.test_saturated_fee_cluster()
         self.test_replacement()
         self.test_diamond()
 


### PR DESCRIPTION
**Problem:** Authenticated `prioritisetransaction` calls can saturate `mapDeltas` at `INT64_MIN`.
Two dependent transactions with saturated negative deltas make `getmempoolentry` overflow its ancestor-fee total.
A release build can return a wrapped `2 BTC` result, while `-ftrapv` builds abort.
P2P and consensus paths do not supply priority deltas.

**Fix:** Keep priority deltas cumulative and bound the sum of their absolute values to `MAX_MONEY`.
Deltas loaded from `mempool.dat` use the same bound, which is updated when a delta changes and released when one is cleared.
The functional test checks the ancestor-fee and cluster RPCs for a parent-child pair with extreme negative requests.
The final fuzz commit removes the previous `-50 to 50 BTC` input gate.
