### PR TITLE
blockencodings: fix extra transaction accounting

### DIFF
--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -113,16 +113,17 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
     if (shorttxids.size() != cmpctblock.shorttxids.size())
         return READ_STATUS_FAILED; // Short ID collision
 
-    std::vector<bool> have_txn(txn_available.size());
+    enum class TxSource : uint8_t { NONE, MEMPOOL, EXTRA, COLLIDED };
+    std::vector tx_source(txn_available.size(), TxSource::NONE);
     {
     LOCK(pool->cs);
     for (const auto& [wtxid, txit] : pool->txns_randomized) {
         uint64_t shortid = cmpctblock.GetShortID(wtxid);
         std::unordered_map<uint64_t, uint16_t>::iterator idit = shorttxids.find(shortid);
         if (idit != shorttxids.end()) {
-            if (!have_txn[idit->second]) {
+            if (tx_source[idit->second] == TxSource::NONE) {
                 txn_available[idit->second] = txit->GetSharedTx();
-                have_txn[idit->second]  = true;
+                tx_source[idit->second] = TxSource::MEMPOOL;
                 mempool_count++;
             } else {
                 // If we find two mempool txn that match the short id, just request it.
@@ -130,6 +131,7 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
                 // but eating a round-trip due to FillBlock failure would be annoying
                 if (txn_available[idit->second]) {
                     txn_available[idit->second].reset();
+                    tx_source[idit->second] = TxSource::COLLIDED;
                     mempool_count--;
                 }
             }
@@ -146,9 +148,9 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
         uint64_t shortid = cmpctblock.GetShortID(extra_txn[i].first);
         std::unordered_map<uint64_t, uint16_t>::iterator idit = shorttxids.find(shortid);
         if (idit != shorttxids.end()) {
-            if (!have_txn[idit->second]) {
+            if (tx_source[idit->second] == TxSource::NONE) {
                 txn_available[idit->second] = extra_txn[i].second;
-                have_txn[idit->second]  = true;
+                tx_source[idit->second] = TxSource::EXTRA;
                 mempool_count++;
                 extra_count++;
             } else {
@@ -162,7 +164,8 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
                         txn_available[idit->second]->GetWitnessHash() != extra_txn[i].second->GetWitnessHash()) {
                     txn_available[idit->second].reset();
                     mempool_count--;
-                    extra_count--;
+                    extra_count -= (tx_source[idit->second] == TxSource::EXTRA);
+                    tx_source[idit->second] = TxSource::COLLIDED;
                 }
             }
         }

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -373,7 +373,7 @@ BOOST_AUTO_TEST_CASE(ReceiveWithExtraTransactions) {
         BOOST_CHECK( partial_block_with_extra_collision.IsTxAvailable(1));
         BOOST_CHECK(!partial_block_with_extra_collision.IsTxAvailable(2));
         BOOST_CHECK_EQUAL(partial_block_with_extra_collision.GetMempoolCount(), 1);
-        BOOST_CHECK_EQUAL(partial_block_with_extra_collision.GetExtraCount(), 0); // TODO: This should be 1
+        BOOST_CHECK_EQUAL(partial_block_with_extra_collision.GetExtraCount(), 1);
     }
 }
 

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -144,6 +144,12 @@ public:
     SERIALIZE_METHODS(TestHeaderAndShortIDs, obj) { READWRITE(obj.header, obj.nonce, Using<VectorFormatter<CustomUintFormatter<CBlockHeaderAndShortTxIDs::SHORTTXIDS_LENGTH>>>(obj.shorttxids), obj.prefilledtxn); }
 };
 
+struct TestPartiallyDownloadedBlock final : PartiallyDownloadedBlock {
+    using PartiallyDownloadedBlock::PartiallyDownloadedBlock;
+    size_t GetMempoolCount() const { return mempool_count; }
+    size_t GetExtraCount() const { return extra_count; }
+};
+
 BOOST_AUTO_TEST_CASE(NonCoinbasePreforwardRTTest)
 {
     CTxMemPool& pool = *Assert(m_node.mempool);
@@ -319,6 +325,13 @@ BOOST_AUTO_TEST_CASE(ReceiveWithExtraTransactions) {
     const CTransactionRef non_block_tx = MakeTransactionRef(std::move(mtx));
 
     CBlock block(BuildBlockTestCase(rand_ctx));
+    // Leave one transaction missing so scanning doesn't stop before the collision.
+    mtx = BuildTransactionTestCase();
+    mtx.vin[0].prevout.hash = Txid::FromUint256(rand_ctx.rand256());
+    block.vtx.push_back(MakeTransactionRef(std::move(mtx)));
+    block.hashMerkleRoot = BlockMerkleRoot(block);
+    while (!CheckProofOfWork(block.GetHash(), block.nBits, Params().GetConsensus())) ++block.nNonce;
+
     std::vector<std::pair<Wtxid, CTransactionRef>> extra_txn;
     extra_txn.resize(10);
 
@@ -352,6 +365,15 @@ BOOST_AUTO_TEST_CASE(ReceiveWithExtraTransactions) {
         // This transaction is now available via extra_txn:
         BOOST_CHECK(partial_block_with_extra.IsTxAvailable(1));
         BOOST_CHECK(partial_block_with_extra.IsTxAvailable(2));
+
+        // Simulate a mempool collision after finding an unrelated extra transaction.
+        extra_txn[2] = {block.vtx[2]->GetWitnessHash(), non_block_tx};
+        TestPartiallyDownloadedBlock partial_block_with_extra_collision{&pool};
+        BOOST_CHECK_EQUAL(partial_block_with_extra_collision.InitData(cmpctblock, extra_txn), READ_STATUS_OK);
+        BOOST_CHECK( partial_block_with_extra_collision.IsTxAvailable(1));
+        BOOST_CHECK(!partial_block_with_extra_collision.IsTxAvailable(2));
+        BOOST_CHECK_EQUAL(partial_block_with_extra_collision.GetMempoolCount(), 1);
+        BOOST_CHECK_EQUAL(partial_block_with_extra_collision.GetExtraCount(), 0); // TODO: This should be 1
     }
 }
 


### PR DESCRIPTION
**Problem:** When an `extra_txn` candidate collides with a transaction already found in the mempool, `InitData()` decrements `extra_count` even though the invalidated transaction did not come from `extra_txn`.
#35727 prevents underflow at zero with a saturating decrement, but that still consumes the credit for an unrelated extra transaction when the count is positive, leaving the logged count incorrect.

**Fix:** Track whether each short-ID slot was filled from the mempool or `extra_txn`, and decrement `extra_count` only when a collision invalidates an extra-sourced transaction.
The source remains set after a collision, preserving the existing behavior that later candidates cannot refill that slot.