### PR TITLE
node: fetch and retain pruned blocks for local reads

### DIFF
--- a/doc/release-notes-35531.md
+++ b/doc/release-notes-35531.md
@@ -1,0 +1,12 @@
+## Index
+
+- The transaction index (`-txindex`) now stores less data on disk, more than
+  halving the size of a fully rebuilt index. The index is backwards compatible,
+  so existing users will not see the space saving unless the index is recreated.
+  To do so, stop the node, delete the `<datadir>/indexes/txindex` directory, and
+  restart; rebuilding can take up to a few hours depending on hardware. Once
+  rebuilt, the index can no longer be read by previous releases, so downgrading
+  will require rebuilding it again.
+  Additionally, transactions that are only in blocks reorged out of the best
+  chain are no longer kept in the index. To look up such a transaction, pass its
+  (stale) block hash to the `getrawtransaction` RPC. (#35531)

--- a/doc/release-notes-35531.md
+++ b/doc/release-notes-35531.md
@@ -10,3 +10,27 @@
   Additionally, transactions that are only in blocks reorged out of the best
   chain are no longer kept in the index. To look up such a transaction, pass its
   (stale) block hash to the `getrawtransaction` RPC. (#35531)
+
+- Pruned nodes can opt in to fetching previously processed active-chain blocks
+  from outbound full-history peers for local RPC and wallet reads with
+  `-blockfetchproxy`. The option requires prune mode, is disabled by default,
+  and stores fetched blocks in the normal block files with a local-only marker.
+  This lets repeated local reads and restarts reuse the block without fetching
+  it again, while preventing this version from relaying or serving it to peers.
+  The containing block file remains subject to normal pruning and may be deleted
+  later. The serving peer can observe which block hashes are requested. Block
+  undo data is not fetched, so `getblock` verbosity 3 remains unavailable for
+  fetched blocks. Older versions do not understand the local-only marker and may
+  serve retained blocks after a downgrade. Reindexing also rebuilds the block
+  index without these markers and may make retained blocks servable.
+
+  With this option, a fully synced transaction index can remain enabled when
+  pruning. Existing indexes containing legacy full-txid entries must be
+  recreated first. Enabling an unsynced transaction index after its required
+  blocks have already been pruned still requires a full reindex.
+
+  Wallet rescans can use the proxy to inspect pruned blocks. Compact block
+  filters select blocks that match the wallet's known scripts, and a basic block
+  filter index is required when the rescan needs fetched blocks. This can restore
+  fully spent history for known descriptors, but it cannot discover transactions
+  involving scripts or derivation ranges the wallet does not know.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -214,6 +214,7 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   net_processing.cpp
   netgroup.cpp
   node/abort.cpp
+  node/blockfetch.cpp
   node/blockmanager_args.cpp
   node/blockstorage.cpp
   node/caches.cpp

--- a/src/chain.h
+++ b/src/chain.h
@@ -83,6 +83,8 @@ enum BlockStatus : uint32_t {
 
     BLOCK_STATUS_RESERVED    =   256, //!< Unused flag that was previously set on assumeutxo snapshot blocks and their
                                       //!< ancestors before they were validated, and unset when they were validated.
+
+    BLOCK_LOCAL_ONLY         =   512, //!< block data was fetched for local use and must not be served to peers
 };
 
 /** The block chain is a tree shaped structure starting with the

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -153,6 +153,20 @@ static leveldb::Options GetOptions(size_t nCacheSize, bool bloom_filter)
     return options;
 }
 
+bool CDBWrapper::HasKeyStartingWith(const fs::path& path, uint8_t prefix)
+{
+    leveldb::Options options;
+    options.paranoid_checks = true;
+    leveldb::DB* raw_db;
+    if (!leveldb::DB::Open(options, fs::PathToString(path), &raw_db).ok()) return false;
+    const std::unique_ptr<leveldb::DB> db{raw_db};
+
+    const std::unique_ptr<leveldb::Iterator> it{db->NewIterator({})};
+    const leveldb::Slice prefix_slice{reinterpret_cast<const char*>(&prefix), 1};
+    it->Seek(prefix_slice);
+    return it->Valid() && it->key().starts_with(prefix_slice);
+}
+
 struct CDBBatch::WriteBatchImpl {
     leveldb::WriteBatch batch;
 };

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -279,6 +279,9 @@ public:
      */
     bool IsEmpty();
 
+    //! Return true if a database at path exists and contains at least 1 entry beginning with prefix.
+    static bool HasKeyStartingWith(const fs::path& path, uint8_t prefix);
+
     template<typename K>
     size_t EstimateSize(const K& key_begin, const K& key_end) const
     {

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -66,13 +66,14 @@ protected:
     public:
         DB(const fs::path& path, size_t n_cache_size,
            bool f_memory = false, bool f_wipe = false, bool f_obfuscate = false, bool f_bloom = true);
+        virtual ~DB() = default;
 
         /// Read block locator of the chain that the index is in sync with.
         /// Note, the returned locator will be empty if no record exists.
-        CBlockLocator ReadBestBlock() const;
+        virtual CBlockLocator ReadBestBlock() const;
 
         /// Write block locator of the chain that the index is in sync with.
-        void WriteBestBlock(CDBBatch& batch, const CBlockLocator& locator);
+        virtual void WriteBestBlock(CDBBatch& batch, const CBlockLocator& locator);
     };
 
 private:

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -4,23 +4,30 @@
 
 #include <index/txindex.h>
 
+#include <chain.h>
 #include <common/args.h>
+#include <crypto/siphash.h>
 #include <dbwrapper.h>
 #include <flatfile.h>
 #include <index/base.h>
 #include <index/disktxpos.h>
+#include <index/txindex_key.h>
 #include <interfaces/chain.h>
 #include <node/blockstorage.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
+#include <random.h>
 #include <serialize.h>
 #include <streams.h>
+#include <sync.h>
 #include <uint256.h>
 #include <util/fs.h>
 #include <util/log.h>
 #include <validation.h>
 
+#include <array>
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <cstdio>
 #include <exception>
@@ -30,6 +37,7 @@
 
 constexpr uint8_t DB_TXINDEX{'t'};
 const std::string DB_BEST_BLOCK_V2{"best_block_v2"};
+static const std::string DB_TXID_HASH_SALT{"txid_hash_salt"};
 
 std::unique_ptr<TxIndex> g_txindex;
 
@@ -40,19 +48,31 @@ class TxIndex::DB : public BaseIndex::DB
 public:
     explicit DB(size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
 
-    /// Read the disk location of the transaction data with the given hash. Returns false if the
+    /// Read the legacy disk location of the transaction data with the given hash. Returns false if the
     /// transaction hash is not indexed.
     bool ReadTxPos(const Txid& txid, CDiskTxPos& pos) const;
 
-    /// Write a batch of transaction positions to the DB.
-    void WriteTxs(const std::vector<std::pair<Txid, CDiskTxPos>>& v_pos);
+    /// Write or erase a block of transaction positions to the DB.
+    void WriteTxs(const interfaces::BlockInfo& block, bool erase = false);
+
+    /// Used to hash the txid to compute the prefix.
+    const PresaltedSipHasher m_hasher;
 
     CBlockLocator ReadBestBlock() const override;
     void WriteBestBlock(CDBBatch& batch, const CBlockLocator& locator) override;
 };
 
 TxIndex::DB::DB(size_t n_cache_size, bool f_memory, bool f_wipe) :
-    BaseIndex::DB(gArgs.GetDataDirNet() / "indexes" / "txindex", n_cache_size, f_memory, f_wipe)
+    BaseIndex::DB(gArgs.GetDataDirNet() / "indexes" / "txindex", n_cache_size, f_memory, f_wipe),
+    m_hasher{[](CDBWrapper& db) {
+        std::pair<uint64_t, uint64_t> salt;
+        if (!db.Read(DB_TXID_HASH_SALT, salt)) {
+            FastRandomContext rng{};
+            salt = {rng.rand64(), rng.rand64()};
+            db.Write(DB_TXID_HASH_SALT, salt, /*fSync=*/true);
+        }
+        return PresaltedSipHasher{salt.first, salt.second};
+    }(*this)}
 {}
 
 bool TxIndex::DB::ReadTxPos(const Txid& txid, CDiskTxPos& pos) const
@@ -75,11 +95,22 @@ void TxIndex::DB::WriteBestBlock(CDBBatch& batch, const CBlockLocator& locator)
     batch.Write(DB_BEST_BLOCK_V2, locator);
 }
 
-void TxIndex::DB::WriteTxs(const std::vector<std::pair<Txid, CDiskTxPos>>& v_pos)
+void TxIndex::DB::WriteTxs(const interfaces::BlockInfo& block, bool erase)
 {
+    assert(block.data);
     CDBBatch batch(*this);
-    for (const auto& [txid, pos] : v_pos) {
-        batch.Write(std::make_pair(DB_TXINDEX, txid.ToUint256()), pos);
+    uint32_t tx_offset_in_block{static_cast<uint32_t>(GetSerializeSize(CBlockHeader{})) + GetSizeOfCompactSize(block.data->vtx.size())};
+    for (const auto& tx : block.data->vtx) {
+        const txindex::DBKey key{txindex::CreateKeyPrefix(m_hasher, tx->GetHash()),
+                                 txindex::BlockTxPosition{static_cast<uint32_t>(block.height), tx_offset_in_block}};
+        if (erase) {
+            batch.Erase(key);
+        } else {
+            // The tx position is encoded in the key, so the value is intentionally
+            // empty. A 0-length byte array avoids the spurious '\0' that "" would store.
+            batch.Write(key, std::array<std::byte, 0>{});
+        }
+        tx_offset_in_block += ::GetSerializeSize(TX_WITH_WITNESS(*tx));
     }
     WriteBatch(batch);
 }
@@ -90,20 +121,24 @@ TxIndex::TxIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, 
 
 TxIndex::~TxIndex() = default;
 
+interfaces::Chain::NotifyOptions TxIndex::CustomOptions()
+{
+    return {.disconnect_data = true};
+}
+
 bool TxIndex::CustomAppend(const interfaces::BlockInfo& block)
 {
     // Exclude genesis block transaction because outputs are not spendable.
     if (block.height == 0) return true;
 
-    assert(block.data);
-    CDiskTxPos pos({block.file_number, block.data_pos}, GetSizeOfCompactSize(block.data->vtx.size()));
-    std::vector<std::pair<Txid, CDiskTxPos>> vPos;
-    vPos.reserve(block.data->vtx.size());
-    for (const auto& tx : block.data->vtx) {
-        vPos.emplace_back(tx->GetHash(), pos);
-        pos.nTxOffset += ::GetSerializeSize(TX_WITH_WITNESS(*tx));
-    }
-    m_db->WriteTxs(vPos);
+    m_db->WriteTxs(block);
+    return true;
+}
+
+bool TxIndex::CustomRemove(const interfaces::BlockInfo& block)
+{
+    assert(block.height > 0);
+    m_db->WriteTxs(block, /*erase=*/true);
     return true;
 }
 
@@ -111,6 +146,41 @@ BaseIndex::DB& TxIndex::GetDB() const { return *m_db; }
 
 bool TxIndex::FindTx(const Txid& tx_hash, uint256& block_hash, CTransactionRef& tx) const
 {
+    const txindex::TxHashKeyPrefix prefix{txindex::CreateKeyPrefix(m_db->m_hasher, tx_hash)};
+    std::unique_ptr<CDBIterator> it{m_db->NewIterator()};
+    it->Seek(std::pair{txindex::DB_TXINDEX_HASHED, prefix});
+    txindex::DBKey key{prefix, {}};
+    for (; it->Valid() && it->GetKey(key) && key.hash_prefix == prefix; it->Next()) {
+        FlatFilePos tx_pos;
+        const CBlockIndex* block_index;
+        {
+            LOCK(cs_main);
+            block_index = m_chainstate->m_chain[key.pos.block_height];
+            if (!block_index) continue;
+            tx_pos = FlatFilePos{block_index->nFile, block_index->nDataPos + key.pos.tx_offset_in_block};
+        }
+        AutoFile file{m_chainstate->m_blockman.OpenBlockFile(tx_pos, /*fReadOnly=*/true)};
+        if (file.IsNull()) {
+            LogError("OpenBlockFile failed");
+            return false;
+        }
+        try {
+            file >> TX_WITH_WITNESS(tx);
+        } catch (const std::exception& e) {
+            LogError("Deserialize or I/O error - %s", e.what());
+            return false;
+        }
+        if (tx->GetHash() == tx_hash) {
+            // For BIP30 duplicate txs, this returns the earliest block.
+            // The legacy index returned the latest one instead,
+            // as each write overwrote the position under the same txid key.
+            block_hash = block_index->GetBlockHash();
+            return true;
+        }
+    }
+    tx.reset();
+    // Fall back to legacy if no hashed entry matched. This makes misses pay an
+    // extra lookup, but keeps existing full-txid entries readable after upgrade.
     CDiskTxPos postx;
     if (!m_db->ReadTxPos(tx_hash, postx)) {
         return false;

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -13,7 +13,9 @@
 #include <index/disktxpos.h>
 #include <index/txindex_key.h>
 #include <interfaces/chain.h>
+#include <node/blockfetch.h>
 #include <node/blockstorage.h>
+#include <node/interface_ui.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <random.h>
@@ -23,6 +25,7 @@
 #include <uint256.h>
 #include <util/fs.h>
 #include <util/log.h>
+#include <util/translation.h>
 #include <validation.h>
 
 #include <array>
@@ -136,6 +139,14 @@ TxIndex::TxIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, 
 
 TxIndex::~TxIndex() = default;
 
+bool TxIndex::CustomInit(const std::optional<interfaces::BlockRef>&)
+{
+    if (m_chainstate->m_blockman.IsPruneMode() && m_db->m_has_legacy) {
+        return InitError(Untranslated("Pruned txindex requires a recreated database without legacy entries. Delete indexes/txindex and restart to rebuild it."));
+    }
+    return true;
+}
+
 interfaces::Chain::NotifyOptions TxIndex::CustomOptions()
 {
     return {.disconnect_data = true};
@@ -159,27 +170,46 @@ bool TxIndex::CustomRemove(const interfaces::BlockInfo& block)
 
 BaseIndex::DB& TxIndex::GetDB() const { return *m_db; }
 
-bool TxIndex::FindTx(const Txid& tx_hash, uint256& block_hash, CTransactionRef& tx) const
+bool TxIndex::FindTx(const Txid& tx_hash, uint256& block_hash, CTransactionRef& tx, bool allow_block_fetch, bool allow_local_only) const
 {
+    tx.reset();
     const txindex::TxHashKeyPrefix prefix{txindex::CreateKeyPrefix(m_db->m_hasher, tx_hash)};
     std::unique_ptr<CDBIterator> it{m_db->NewIterator()};
     it->Seek(prefix);
     txindex::DBKey key{prefix, {}};
+    std::vector<const CBlockIndex*> missing_blocks;
     for (; it->Valid(); it->Next()) {
         if (!it->GetKey(key)) return false;
         if (key.hash_prefix != prefix) break;
         FlatFilePos tx_pos;
         const CBlockIndex* block_index;
+        bool have_data;
         {
             LOCK(cs_main);
             block_index = m_chainstate->m_chain[key.pos.block_height];
             if (!block_index) continue;
-            tx_pos = FlatFilePos{block_index->nFile, block_index->nDataPos + key.pos.tx_offset_in_block};
+            have_data = (block_index->nStatus & BLOCK_HAVE_DATA) != 0 &&
+                        (allow_local_only || !(block_index->nStatus & BLOCK_LOCAL_ONLY));
+            if (have_data) tx_pos = FlatFilePos{block_index->nFile, block_index->nDataPos + key.pos.tx_offset_in_block};
+        }
+        if (!have_data) {
+            if (allow_block_fetch && (missing_blocks.empty() || missing_blocks.back() != block_index)) {
+                missing_blocks.push_back(block_index);
+            }
+            continue;
         }
         AutoFile file{m_chainstate->m_blockman.OpenBlockFile(tx_pos, /*fReadOnly=*/true)};
         if (file.IsNull()) {
-            LogError("OpenBlockFile failed");
-            return false;
+            // Pruning may have raced the file open. Treat a still-present
+            // block as an I/O failure rather than hiding corruption behind a fetch.
+            if (WITH_LOCK(cs_main, return (block_index->nStatus & BLOCK_HAVE_DATA) != 0)) {
+                LogError("OpenBlockFile failed");
+                return false;
+            }
+            if (allow_block_fetch && (missing_blocks.empty() || missing_blocks.back() != block_index)) {
+                missing_blocks.push_back(block_index);
+            }
+            continue;
         }
         bool deserialized{false};
         std::string deserialize_error;
@@ -197,7 +227,7 @@ bool TxIndex::FindTx(const Txid& tx_hash, uint256& block_hash, CTransactionRef& 
                 continue;
             }
             if (candidate_tx->GetHash() == tx_hash) {
-                // For BIP30 duplicate txs, this returns the earliest block.
+                // Within this local-data pass, BIP30 duplicates return the earliest block.
                 // The legacy index returned the latest one instead,
                 // as each write overwrote the position under the same txid key.
                 tx = std::move(candidate_tx);
@@ -207,7 +237,20 @@ bool TxIndex::FindTx(const Txid& tx_hash, uint256& block_hash, CTransactionRef& 
         }
         if (!deserialized) LogDebug(BCLog::VALIDATION, "Skipping unreadable txindex candidate at height %d, offset %u: %s", key.pos.block_height, key.pos.tx_offset_in_block, deserialize_error);
     }
-    tx.reset();
+
+    // Avoid fetching a false-positive collision when another candidate can be
+    // resolved locally. Only fetch unavailable blocks after the local pass.
+    for (const CBlockIndex* block_index : missing_blocks) {
+        auto block{node::ReadBlockForLocalUse(*m_chain->context(), *block_index)};
+        if (!block) continue;
+        for (const auto& candidate_tx : (*block)->vtx) {
+            if (candidate_tx->GetHash() != tx_hash) continue;
+            tx = candidate_tx;
+            block_hash = block_index->GetBlockHash();
+            return true;
+        }
+    }
+
     if (!m_db->m_has_legacy) return false;
     // Fall back to legacy if no hashed entry matched. This makes misses pay an
     // extra lookup, but keeps existing full-txid entries readable after upgrade.
@@ -235,5 +278,13 @@ bool TxIndex::FindTx(const Txid& tx_hash, uint256& block_hash, CTransactionRef& 
         return false;
     }
     block_hash = header.GetHash();
+    if (!allow_local_only) {
+        LOCK(cs_main);
+        const CBlockIndex* index{m_chainstate->m_blockman.LookupBlockIndex(block_hash)};
+        if (index && (index->nStatus & BLOCK_LOCAL_ONLY)) {
+            tx.reset();
+            return false;
+        }
+    }
     return true;
 }

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -29,6 +29,7 @@
 #include <vector>
 
 constexpr uint8_t DB_TXINDEX{'t'};
+const std::string DB_BEST_BLOCK_V2{"best_block_v2"};
 
 std::unique_ptr<TxIndex> g_txindex;
 
@@ -45,6 +46,9 @@ public:
 
     /// Write a batch of transaction positions to the DB.
     void WriteTxs(const std::vector<std::pair<Txid, CDiskTxPos>>& v_pos);
+
+    CBlockLocator ReadBestBlock() const override;
+    void WriteBestBlock(CDBBatch& batch, const CBlockLocator& locator) override;
 };
 
 TxIndex::DB::DB(size_t n_cache_size, bool f_memory, bool f_wipe) :
@@ -54,6 +58,21 @@ TxIndex::DB::DB(size_t n_cache_size, bool f_memory, bool f_wipe) :
 bool TxIndex::DB::ReadTxPos(const Txid& txid, CDiskTxPos& pos) const
 {
     return Read(std::make_pair(DB_TXINDEX, txid.ToUint256()), pos);
+}
+
+CBlockLocator TxIndex::DB::ReadBestBlock() const
+{
+    CBlockLocator locator;
+    if (Read(DB_BEST_BLOCK_V2, locator)) {
+        return locator;
+    }
+    // If we don't have a locator yet, start from the legacy best block.
+    return BaseIndex::DB::ReadBestBlock();
+}
+
+void TxIndex::DB::WriteBestBlock(CDBBatch& batch, const CBlockLocator& locator)
+{
+    batch.Write(DB_BEST_BLOCK_V2, locator);
 }
 
 void TxIndex::DB::WriteTxs(const std::vector<std::pair<Txid, CDiskTxPos>>& v_pos)

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -165,7 +165,9 @@ bool TxIndex::FindTx(const Txid& tx_hash, uint256& block_hash, CTransactionRef& 
     std::unique_ptr<CDBIterator> it{m_db->NewIterator()};
     it->Seek(std::pair{txindex::DB_TXINDEX_HASHED, prefix});
     txindex::DBKey key{prefix, {}};
-    for (; it->Valid() && it->GetKey(key) && key.hash_prefix == prefix; it->Next()) {
+    for (; it->Valid(); it->Next()) {
+        if (!it->GetKey(key)) return false;
+        if (key.hash_prefix != prefix) break;
         FlatFilePos tx_pos;
         const CBlockIndex* block_index;
         {

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -163,7 +163,7 @@ bool TxIndex::FindTx(const Txid& tx_hash, uint256& block_hash, CTransactionRef& 
 {
     const txindex::TxHashKeyPrefix prefix{txindex::CreateKeyPrefix(m_db->m_hasher, tx_hash)};
     std::unique_ptr<CDBIterator> it{m_db->NewIterator()};
-    it->Seek(std::pair{txindex::DB_TXINDEX_HASHED, prefix});
+    it->Seek(prefix);
     txindex::DBKey key{prefix, {}};
     for (; it->Valid(); it->Next()) {
         if (!it->GetKey(key)) return false;
@@ -181,23 +181,31 @@ bool TxIndex::FindTx(const Txid& tx_hash, uint256& block_hash, CTransactionRef& 
             LogError("OpenBlockFile failed");
             return false;
         }
-        CTransactionRef candidate_tx;
-        try {
-            file >> TX_WITH_WITNESS(candidate_tx);
-        } catch (const std::exception& e) {
-            // A reorg may temporarily leave an old-branch position
-            // resolving through the new active block at this height.
-            LogDebug(BCLog::VALIDATION, "Skipping unreadable txindex candidate at height %d, offset %u: %s", key.pos.block_height, key.pos.tx_offset_in_block, e.what());
-            continue;
+        bool deserialized{false};
+        std::string deserialize_error;
+        for (uint32_t offset{0}; offset < txindex::BLOCK_TX_OFFSET_GRANULARITY; ++offset) {
+            CTransactionRef candidate_tx;
+            try {
+                file.seek(tx_pos.nPos + offset, SEEK_SET);
+                file >> TX_WITH_WITNESS(candidate_tx);
+                deserialized = true;
+            } catch (const std::exception& e) {
+                // A reorg may temporarily leave an old-branch position
+                // resolving through the new active block at this height, or
+                // this may not be the transaction's exact byte offset.
+                deserialize_error = e.what();
+                continue;
+            }
+            if (candidate_tx->GetHash() == tx_hash) {
+                // For BIP30 duplicate txs, this returns the earliest block.
+                // The legacy index returned the latest one instead,
+                // as each write overwrote the position under the same txid key.
+                tx = std::move(candidate_tx);
+                block_hash = block_index->GetBlockHash();
+                return true;
+            }
         }
-        if (candidate_tx->GetHash() == tx_hash) {
-            // For BIP30 duplicate txs, this returns the earliest block.
-            // The legacy index returned the latest one instead,
-            // as each write overwrote the position under the same txid key.
-            tx = std::move(candidate_tx);
-            block_hash = block_index->GetBlockHash();
-            return true;
-        }
+        if (!deserialized) LogDebug(BCLog::VALIDATION, "Skipping unreadable txindex candidate at height %d, offset %u: %s", key.pos.block_height, key.pos.tx_offset_in_block, deserialize_error);
     }
     tx.reset();
     if (!m_db->m_has_legacy) return false;

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -181,16 +181,20 @@ bool TxIndex::FindTx(const Txid& tx_hash, uint256& block_hash, CTransactionRef& 
             LogError("OpenBlockFile failed");
             return false;
         }
+        CTransactionRef candidate_tx;
         try {
-            file >> TX_WITH_WITNESS(tx);
+            file >> TX_WITH_WITNESS(candidate_tx);
         } catch (const std::exception& e) {
-            LogError("Deserialize or I/O error - %s", e.what());
-            return false;
+            // A reorg may temporarily leave an old-branch position
+            // resolving through the new active block at this height.
+            LogDebug(BCLog::VALIDATION, "Skipping unreadable txindex candidate at height %d, offset %u: %s", key.pos.block_height, key.pos.tx_offset_in_block, e.what());
+            continue;
         }
-        if (tx->GetHash() == tx_hash) {
+        if (candidate_tx->GetHash() == tx_hash) {
             // For BIP30 duplicate txs, this returns the earliest block.
             // The legacy index returned the latest one instead,
             // as each write overwrote the position under the same txid key.
+            tx = std::move(candidate_tx);
             block_hash = block_index->GetBlockHash();
             return true;
         }

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -58,12 +58,26 @@ public:
     /// Used to hash the txid to compute the prefix.
     const PresaltedSipHasher m_hasher;
 
+    /// Whether the database contains any legacy ('t' + txid) entries.
+    const bool m_has_legacy;
+
     CBlockLocator ReadBestBlock() const override;
     void WriteBestBlock(CDBBatch& batch, const CBlockLocator& locator) override;
+
+private:
+    DB(size_t n_cache_size, bool f_memory, bool f_wipe, bool f_obfuscate, bool f_bloom);
 };
 
+static fs::path TxIndexDBPath() { return gArgs.GetDataDirNet() / "indexes" / "txindex"; }
+
 TxIndex::DB::DB(size_t n_cache_size, bool f_memory, bool f_wipe) :
-    BaseIndex::DB(gArgs.GetDataDirNet() / "indexes" / "txindex", n_cache_size, f_memory, f_wipe),
+    // Enable bloom filters only if legacy entries are present (they are point lookups)
+    DB(n_cache_size, f_memory, f_wipe, /*f_obfuscate=*/false,
+       /*f_bloom=*/!f_memory && !f_wipe && CDBWrapper::HasKeyStartingWith(TxIndexDBPath(), DB_TXINDEX))
+{}
+
+TxIndex::DB::DB(size_t n_cache_size, bool f_memory, bool f_wipe, bool f_obfuscate, bool f_bloom) :
+    BaseIndex::DB(TxIndexDBPath(), n_cache_size, f_memory, f_wipe, f_obfuscate, f_bloom),
     m_hasher{[](CDBWrapper& db) {
         std::pair<uint64_t, uint64_t> salt;
         if (!db.Read(DB_TXID_HASH_SALT, salt)) {
@@ -72,7 +86,8 @@ TxIndex::DB::DB(size_t n_cache_size, bool f_memory, bool f_wipe) :
             db.Write(DB_TXID_HASH_SALT, salt, /*fSync=*/true);
         }
         return PresaltedSipHasher{salt.first, salt.second};
-    }(*this)}
+    }(*this)},
+    m_has_legacy{f_bloom}
 {}
 
 bool TxIndex::DB::ReadTxPos(const Txid& txid, CDiskTxPos& pos) const
@@ -179,6 +194,7 @@ bool TxIndex::FindTx(const Txid& tx_hash, uint256& block_hash, CTransactionRef& 
         }
     }
     tx.reset();
+    if (!m_db->m_has_legacy) return false;
     // Fall back to legacy if no hashed entry matched. This makes misses pay an
     // extra lookup, but keeps existing full-txid entries readable after upgrade.
     CDiskTxPos postx;

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -170,9 +170,10 @@ bool TxIndex::CustomRemove(const interfaces::BlockInfo& block)
 
 BaseIndex::DB& TxIndex::GetDB() const { return *m_db; }
 
-bool TxIndex::FindTx(const Txid& tx_hash, uint256& block_hash, CTransactionRef& tx, bool allow_block_fetch, bool allow_local_only) const
+bool TxIndex::FindTx(const Txid& tx_hash, uint256& block_hash, CTransactionRef& tx, bool allow_block_fetch, std::shared_ptr<const CBlock>* block_data, bool allow_local_only) const
 {
     tx.reset();
+    if (block_data) block_data->reset();
     const txindex::TxHashKeyPrefix prefix{txindex::CreateKeyPrefix(m_db->m_hasher, tx_hash)};
     std::unique_ptr<CDBIterator> it{m_db->NewIterator()};
     it->Seek(prefix);
@@ -247,6 +248,7 @@ bool TxIndex::FindTx(const Txid& tx_hash, uint256& block_hash, CTransactionRef& 
             if (candidate_tx->GetHash() != tx_hash) continue;
             tx = candidate_tx;
             block_hash = block_index->GetBlockHash();
+            if (block_data) *block_data = *block;
             return true;
         }
     }

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -65,19 +65,19 @@ public:
     void WriteBestBlock(CDBBatch& batch, const CBlockLocator& locator) override;
 
 private:
-    DB(size_t n_cache_size, bool f_memory, bool f_wipe, bool f_obfuscate, bool f_bloom);
+    DB(size_t n_cache_size, bool f_memory, bool f_wipe, bool has_legacy);
 };
 
 static fs::path TxIndexDBPath() { return gArgs.GetDataDirNet() / "indexes" / "txindex"; }
 
 TxIndex::DB::DB(size_t n_cache_size, bool f_memory, bool f_wipe) :
     // Enable bloom filters only if legacy entries are present (they are point lookups)
-    DB(n_cache_size, f_memory, f_wipe, /*f_obfuscate=*/false,
-       /*f_bloom=*/!f_memory && !f_wipe && CDBWrapper::HasKeyStartingWith(TxIndexDBPath(), DB_TXINDEX))
+    DB(n_cache_size, f_memory, f_wipe,
+       /*has_legacy=*/!f_memory && !f_wipe && CDBWrapper::HasKeyStartingWith(TxIndexDBPath(), DB_TXINDEX))
 {}
 
-TxIndex::DB::DB(size_t n_cache_size, bool f_memory, bool f_wipe, bool f_obfuscate, bool f_bloom) :
-    BaseIndex::DB(TxIndexDBPath(), n_cache_size, f_memory, f_wipe, f_obfuscate, f_bloom),
+TxIndex::DB::DB(size_t n_cache_size, bool f_memory, bool f_wipe, bool has_legacy) :
+    BaseIndex::DB(TxIndexDBPath(), n_cache_size, f_memory, f_wipe, /*f_obfuscate=*/false, /*f_bloom=*/has_legacy),
     m_hasher{[](CDBWrapper& db) {
         std::pair<uint64_t, uint64_t> salt;
         if (!db.Read(DB_TXID_HASH_SALT, salt)) {
@@ -87,7 +87,7 @@ TxIndex::DB::DB(size_t n_cache_size, bool f_memory, bool f_wipe, bool f_obfuscat
         }
         return PresaltedSipHasher{salt.first, salt.second};
     }(*this)},
-    m_has_legacy{f_bloom}
+    m_has_legacy{has_legacy}
 {}
 
 bool TxIndex::DB::ReadTxPos(const Txid& txid, CDiskTxPos& pos) const

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -6,15 +6,13 @@
 #define BITCOIN_INDEX_TXINDEX_H
 
 #include <index/base.h>
+#include <interfaces/chain.h>
 #include <primitives/transaction.h>
 
 #include <cstddef>
 #include <memory>
 
 class uint256;
-namespace interfaces {
-class Chain;
-}
 
 static constexpr bool DEFAULT_TXINDEX{false};
 
@@ -35,6 +33,10 @@ private:
 
 protected:
     bool CustomAppend(const interfaces::BlockInfo& block) override;
+
+    bool CustomRemove(const interfaces::BlockInfo& block) override;
+
+    interfaces::Chain::NotifyOptions CustomOptions() override;
 
     BaseIndex::DB& GetDB() const override;
 

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -13,6 +13,7 @@
 #include <memory>
 #include <optional>
 
+class CBlock;
 class uint256;
 namespace txindex_tests {
 class TxIndexTest;
@@ -60,9 +61,10 @@ public:
     /// @param[out]  block_hash  The hash of the block the transaction is found in. Undefined if false is returned.
     /// @param[out]  tx  The transaction itself. Undefined if false is returned.
     /// @param[in]   allow_block_fetch  Whether a pruned block may be fetched from a peer.
+    /// @param[out]  block_data  The full block, if it was needed and the transaction was found.
     /// @param[in]   allow_local_only  Whether blocks retained for trusted local callers may be read.
     /// @return  true if transaction is found, false otherwise
-    [[nodiscard]] bool FindTx(const Txid& tx_hash, uint256& block_hash, CTransactionRef& tx, bool allow_block_fetch = false, bool allow_local_only = true) const;
+    [[nodiscard]] bool FindTx(const Txid& tx_hash, uint256& block_hash, CTransactionRef& tx, bool allow_block_fetch = false, std::shared_ptr<const CBlock>* block_data = nullptr, bool allow_local_only = true) const;
 };
 
 /// The global transaction index, used in GetTransaction. May be null.

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -11,6 +11,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <optional>
 
 class uint256;
 namespace txindex_tests {
@@ -33,9 +34,11 @@ private:
     friend class txindex_tests::TxIndexTest;
     const std::unique_ptr<DB> m_db;
 
-    bool AllowPrune() const override { return false; }
+    bool AllowPrune() const override { return true; }
 
 protected:
+    bool CustomInit(const std::optional<interfaces::BlockRef>& block) override;
+
     bool CustomAppend(const interfaces::BlockInfo& block) override;
 
     bool CustomRemove(const interfaces::BlockInfo& block) override;
@@ -56,8 +59,10 @@ public:
     /// @param[in]   tx_hash  The hash of the transaction to be returned.
     /// @param[out]  block_hash  The hash of the block the transaction is found in. Undefined if false is returned.
     /// @param[out]  tx  The transaction itself. Undefined if false is returned.
+    /// @param[in]   allow_block_fetch  Whether a pruned block may be fetched from a peer.
+    /// @param[in]   allow_local_only  Whether blocks retained for trusted local callers may be read.
     /// @return  true if transaction is found, false otherwise
-    [[nodiscard]] bool FindTx(const Txid& tx_hash, uint256& block_hash, CTransactionRef& tx) const;
+    [[nodiscard]] bool FindTx(const Txid& tx_hash, uint256& block_hash, CTransactionRef& tx, bool allow_block_fetch = false, bool allow_local_only = true) const;
 };
 
 /// The global transaction index, used in GetTransaction. May be null.

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -48,10 +48,10 @@ public:
     /// Look up a transaction by hash.
     ///
     /// @param[in]   tx_hash  The hash of the transaction to be returned.
-    /// @param[out]  block_hash  The hash of the block the transaction is found in.
-    /// @param[out]  tx  The transaction itself.
+    /// @param[out]  block_hash  The hash of the block the transaction is found in. Undefined if false is returned.
+    /// @param[out]  tx  The transaction itself. Undefined if false is returned.
     /// @return  true if transaction is found, false otherwise
-    bool FindTx(const Txid& tx_hash, uint256& block_hash, CTransactionRef& tx) const;
+    [[nodiscard]] bool FindTx(const Txid& tx_hash, uint256& block_hash, CTransactionRef& tx) const;
 };
 
 /// The global transaction index, used in GetTransaction. May be null.

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -13,6 +13,9 @@
 #include <memory>
 
 class uint256;
+namespace txindex_tests {
+class TxIndexTest;
+}
 
 static constexpr bool DEFAULT_TXINDEX{false};
 
@@ -27,6 +30,7 @@ protected:
     class DB;
 
 private:
+    friend class txindex_tests::TxIndexTest;
     const std::unique_ptr<DB> m_db;
 
     bool AllowPrune() const override { return false; }

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -21,8 +21,8 @@ static constexpr bool DEFAULT_TXINDEX{false};
 
 /**
  * TxIndex is used to look up transactions included in the blockchain by hash.
- * The index is written to a LevelDB database and records the filesystem
- * location of each transaction by transaction hash.
+ * The index is written to a LevelDB database and records the block height and
+ * serialized block offset of each transaction by transaction hash.
  */
 class TxIndex final : public BaseIndex
 {

--- a/src/index/txindex_key.h
+++ b/src/index/txindex_key.h
@@ -21,53 +21,113 @@
 
 namespace txindex {
 constexpr uint8_t DB_TXINDEX_HASHED{'x'};
+constexpr uint8_t DB_TXINDEX_HASHED_COUNT{4};
+constexpr uint8_t TX_HASH_TAG_BITS{2};
+constexpr uint8_t TX_HASH_INLINE_BITS{38};
+constexpr uint8_t BLOCK_TX_OFFSET_GRANULARITY{2};
+constexpr uint64_t BLOCK_TX_POSITION_FACTOR{2'000'000};
+constexpr uint32_t MAX_TXINDEX_BLOCK_HEIGHT{(uint32_t{1} << 21) - 1};
+constexpr uint64_t BLOCK_TX_POSITION_LIMIT{BLOCK_TX_POSITION_FACTOR * (uint64_t{MAX_TXINDEX_BLOCK_HEIGHT} + 1)};
+constexpr uint8_t BLOCK_TX_POSITION_HIGH_BITS{2};
+constexpr uint8_t BLOCK_TX_POSITION_LOW_BITS{40};
+constexpr uint64_t BLOCK_TX_POSITION_LOW_MASK{(uint64_t{1} << BLOCK_TX_POSITION_LOW_BITS) - 1};
+constexpr uint8_t BLOCK_TX_POSITION_HIGH_MASK{(uint8_t{1} << BLOCK_TX_POSITION_HIGH_BITS) - 1};
+static_assert(DB_TXINDEX_HASHED_COUNT == uint8_t{1} << TX_HASH_TAG_BITS);
+static_assert(TX_HASH_TAG_BITS + TX_HASH_INLINE_BITS == 40);
+static_assert(BLOCK_TX_POSITION_HIGH_BITS + BLOCK_TX_POSITION_LOW_BITS == 42);
+static_assert(MAX_BLOCK_SERIALIZED_SIZE / BLOCK_TX_OFFSET_GRANULARITY <= BLOCK_TX_POSITION_FACTOR);
+static_assert(MAX_BLOCK_SERIALIZED_SIZE % BLOCK_TX_OFFSET_GRANULARITY == 0);
+static_assert(MIN_TRANSACTION_WEIGHT / WITNESS_SCALE_FACTOR >= BLOCK_TX_OFFSET_GRANULARITY);
+static_assert(BLOCK_TX_POSITION_LIMIT <= uint64_t{1} << 42);
+
+constexpr bool IsHashedKeyTag(uint8_t tag)
+{
+    return tag >= DB_TXINDEX_HASHED && tag < DB_TXINDEX_HASHED + DB_TXINDEX_HASHED_COUNT;
+}
 
 //! The location of a transaction: the height of the block that contains it and the
 //! transaction's serialized byte offset from the start of that block (including the
-//! header), so the on-disk position is simply block_data_pos + tx_offset_in_block.
+//! header), rounded down to an adjacent pair. Since valid transactions are at least
+//! 60 bytes, each pair contains at most one transaction position. FindTx can try the
+//! two positions beginning at block_data_pos + tx_offset_in_block.
 //!
-//! Since the offset is always less than the maximum serialized block size, we pack
-//! the position into a single integer code = max_block_size * height + offset, and
-//! split it apart as (height = code / max_block_size, offset = code % max_block_size).
+//! The packed position is code = 2,000,000 * height + offset / 2. Heights through
+//! 2,097,151 and every valid block offset fit in 42 bits.
 struct BlockTxPosition {
     uint32_t block_height{0};
     uint32_t tx_offset_in_block{0};
 
+    BlockTxPosition() = default;
+    BlockTxPosition(uint32_t height, uint32_t tx_offset)
+        : block_height{height}, tx_offset_in_block{tx_offset - tx_offset % BLOCK_TX_OFFSET_GRANULARITY}
+    {
+    }
+
     friend bool operator==(const BlockTxPosition&, const BlockTxPosition&) = default;
 
-    static constexpr int SERIALIZED_SIZE{6}; // Holds packed positions until height 70,368,744
+    bool ContainsOffset(uint32_t tx_offset) const
+    {
+        return tx_offset >= tx_offset_in_block && tx_offset - tx_offset_in_block < BLOCK_TX_OFFSET_GRANULARITY;
+    }
+
+    uint64_t GetCode() const
+    {
+        if (block_height > MAX_TXINDEX_BLOCK_HEIGHT) throw std::ios_base::failure("Block height exceeds txindex position format");
+        assert(tx_offset_in_block < MAX_BLOCK_SERIALIZED_SIZE);
+        assert(tx_offset_in_block % BLOCK_TX_OFFSET_GRANULARITY == 0);
+        return BLOCK_TX_POSITION_FACTOR * block_height + tx_offset_in_block / BLOCK_TX_OFFSET_GRANULARITY;
+    }
+
+    void SetCode(uint64_t code)
+    {
+        if (code >= BLOCK_TX_POSITION_LIMIT) throw std::ios_base::failure("Invalid txindex transaction position");
+        block_height = static_cast<uint32_t>(code / BLOCK_TX_POSITION_FACTOR);
+        tx_offset_in_block = static_cast<uint32_t>(code % BLOCK_TX_POSITION_FACTOR) * BLOCK_TX_OFFSET_GRANULARITY;
+    }
+};
+
+struct TxHashKeyPrefix {
+    static constexpr int SERIALIZED_SIZE{6};
+
+    uint8_t db_tag{DB_TXINDEX_HASHED};
+    std::array<std::byte, 5> hash{};
+
+    friend bool operator==(const TxHashKeyPrefix&, const TxHashKeyPrefix&) = default;
 
     template <typename Stream>
     void Serialize(Stream& s) const
     {
-        assert(tx_offset_in_block < MAX_BLOCK_SERIALIZED_SIZE);
-        const uint64_t code{uint64_t{MAX_BLOCK_SERIALIZED_SIZE} * block_height + tx_offset_in_block};
-        s << Using<BigEndianFormatter<SERIALIZED_SIZE>>(code);
+        assert(IsHashedKeyTag(db_tag));
+        assert((std::to_integer<uint8_t>(hash.back()) & BLOCK_TX_POSITION_HIGH_MASK) == 0);
+        ser_writedata8(s, db_tag);
+        s << hash;
     }
 
     template <typename Stream>
     void Unserialize(Stream& s)
     {
-        uint64_t code;
-        s >> Using<BigEndianFormatter<SERIALIZED_SIZE>>(code);
-        block_height = static_cast<uint32_t>(code / MAX_BLOCK_SERIALIZED_SIZE);
-        tx_offset_in_block = static_cast<uint32_t>(code % MAX_BLOCK_SERIALIZED_SIZE);
+        db_tag = ser_readdata8(s);
+        s >> hash;
+        if (!IsHashedKeyTag(db_tag) || (std::to_integer<uint8_t>(hash.back()) & BLOCK_TX_POSITION_HIGH_MASK) != 0) {
+            throw std::ios_base::failure("Invalid format for txindex hash prefix");
+        }
     }
 };
 
-using TxHashKeyPrefix = std::array<std::byte, 5>;
-
 inline TxHashKeyPrefix CreateKeyPrefix(const PresaltedSipHasher& hasher, const Txid& txid)
 {
-    // Normalize to big-endian so prefixes are stable across architectures.
+    const uint64_t hash{hasher(txid.ToUint256())};
+    const uint64_t inline_hash{((hash >> (64 - TX_HASH_TAG_BITS - TX_HASH_INLINE_BITS)) & ((uint64_t{1} << TX_HASH_INLINE_BITS) - 1)) << BLOCK_TX_POSITION_HIGH_BITS};
     std::array<std::byte, sizeof(uint64_t)> be_hash;
-    WriteBE64(be_hash.data(), hasher(txid.ToUint256()));
-    TxHashKeyPrefix prefix;
-    std::memcpy(prefix.data(), be_hash.data(), prefix.size());
+    WriteBE64(be_hash.data(), inline_hash);
+    TxHashKeyPrefix prefix{static_cast<uint8_t>(DB_TXINDEX_HASHED + (hash >> (64 - TX_HASH_TAG_BITS)))};
+    std::memcpy(prefix.hash.data(), be_hash.data() + be_hash.size() - prefix.hash.size(), prefix.hash.size());
     return prefix;
 }
 
 struct DBKey {
+    static constexpr int SERIALIZED_SIZE{11};
+
     TxHashKeyPrefix hash_prefix;
     BlockTxPosition pos;
 
@@ -76,15 +136,26 @@ struct DBKey {
     template <typename Stream>
     void Serialize(Stream& s) const
     {
-        ser_writedata8(s, DB_TXINDEX_HASHED);
-        s << hash_prefix << pos;
+        assert(IsHashedKeyTag(hash_prefix.db_tag));
+        assert((std::to_integer<uint8_t>(hash_prefix.hash.back()) & BLOCK_TX_POSITION_HIGH_MASK) == 0);
+        const uint64_t position{pos.GetCode()};
+        std::array<std::byte, 5> hash{hash_prefix.hash};
+        hash.back() |= std::byte{static_cast<uint8_t>(position >> BLOCK_TX_POSITION_LOW_BITS)};
+        ser_writedata8(s, hash_prefix.db_tag);
+        s << hash << Using<BigEndianFormatter<5>>(position & BLOCK_TX_POSITION_LOW_MASK);
     }
 
     template <typename Stream>
     void Unserialize(Stream& s)
     {
-        if (ser_readdata8(s) != DB_TXINDEX_HASHED) throw std::ios_base::failure("Invalid format for txindex DB key");
-        s >> hash_prefix >> pos;
+        hash_prefix.db_tag = ser_readdata8(s);
+        s >> hash_prefix.hash;
+        if (!IsHashedKeyTag(hash_prefix.db_tag)) throw std::ios_base::failure("Invalid format for txindex DB key");
+        const uint8_t position_high{static_cast<uint8_t>(std::to_integer<uint8_t>(hash_prefix.hash.back()) & BLOCK_TX_POSITION_HIGH_MASK)};
+        hash_prefix.hash.back() &= std::byte{static_cast<uint8_t>(~BLOCK_TX_POSITION_HIGH_MASK)};
+        uint64_t position_low;
+        s >> Using<BigEndianFormatter<5>>(position_low);
+        pos.SetCode(uint64_t{position_high} << BLOCK_TX_POSITION_LOW_BITS | position_low);
         if (!s.empty()) throw std::ios_base::failure("Invalid size for txindex DB key");
     }
 };

--- a/src/index/txindex_key.h
+++ b/src/index/txindex_key.h
@@ -1,0 +1,92 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_INDEX_TXINDEX_KEY_H
+#define BITCOIN_INDEX_TXINDEX_KEY_H
+
+#include <consensus/consensus.h>
+#include <crypto/common.h>
+#include <crypto/siphash.h>
+#include <primitives/transaction.h>
+#include <serialize.h>
+
+#include <array>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <ios>
+#include <string>
+
+namespace txindex {
+constexpr uint8_t DB_TXINDEX_HASHED{'x'};
+
+//! The location of a transaction: the height of the block that contains it and the
+//! transaction's serialized byte offset from the start of that block (including the
+//! header), so the on-disk position is simply block_data_pos + tx_offset_in_block.
+//!
+//! Since the offset is always less than the maximum serialized block size, we pack
+//! the position into a single integer code = max_block_size * height + offset, and
+//! split it apart as (height = code / max_block_size, offset = code % max_block_size).
+struct BlockTxPosition {
+    uint32_t block_height{0};
+    uint32_t tx_offset_in_block{0};
+
+    friend bool operator==(const BlockTxPosition&, const BlockTxPosition&) = default;
+
+    static constexpr int SERIALIZED_SIZE{6}; // Holds packed positions until height 70,368,744
+
+    template <typename Stream>
+    void Serialize(Stream& s) const
+    {
+        assert(tx_offset_in_block < MAX_BLOCK_SERIALIZED_SIZE);
+        const uint64_t code{uint64_t{MAX_BLOCK_SERIALIZED_SIZE} * block_height + tx_offset_in_block};
+        s << Using<BigEndianFormatter<SERIALIZED_SIZE>>(code);
+    }
+
+    template <typename Stream>
+    void Unserialize(Stream& s)
+    {
+        uint64_t code;
+        s >> Using<BigEndianFormatter<SERIALIZED_SIZE>>(code);
+        block_height = static_cast<uint32_t>(code / MAX_BLOCK_SERIALIZED_SIZE);
+        tx_offset_in_block = static_cast<uint32_t>(code % MAX_BLOCK_SERIALIZED_SIZE);
+    }
+};
+
+using TxHashKeyPrefix = std::array<std::byte, 5>;
+
+inline TxHashKeyPrefix CreateKeyPrefix(const PresaltedSipHasher& hasher, const Txid& txid)
+{
+    // Normalize to big-endian so prefixes are stable across architectures.
+    std::array<std::byte, sizeof(uint64_t)> be_hash;
+    WriteBE64(be_hash.data(), hasher(txid.ToUint256()));
+    TxHashKeyPrefix prefix;
+    std::memcpy(prefix.data(), be_hash.data(), prefix.size());
+    return prefix;
+}
+
+struct DBKey {
+    TxHashKeyPrefix hash_prefix;
+    BlockTxPosition pos;
+
+    explicit DBKey(const TxHashKeyPrefix& hash_in, const BlockTxPosition& pos_in) : hash_prefix{hash_in}, pos{pos_in} {}
+
+    template <typename Stream>
+    void Serialize(Stream& s) const
+    {
+        ser_writedata8(s, DB_TXINDEX_HASHED);
+        s << hash_prefix << pos;
+    }
+
+    template <typename Stream>
+    void Unserialize(Stream& s)
+    {
+        if (ser_readdata8(s) != DB_TXINDEX_HASHED) throw std::ios_base::failure("Invalid format for txindex DB key");
+        s >> hash_prefix >> pos;
+    }
+};
+} // namespace txindex
+
+#endif // BITCOIN_INDEX_TXINDEX_KEY_H

--- a/src/index/txindex_key.h
+++ b/src/index/txindex_key.h
@@ -85,6 +85,7 @@ struct DBKey {
     {
         if (ser_readdata8(s) != DB_TXINDEX_HASHED) throw std::ios_base::failure("Invalid format for txindex DB key");
         s >> hash_prefix >> pos;
+        if (!s.empty()) throw std::ios_base::failure("Invalid size for txindex DB key");
     }
 };
 } // namespace txindex

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -549,9 +549,11 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
                              DEFAULT_PERSIST_V1_DAT),
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-pid=<file>", strprintf("Specify pid file. Relative paths will be prefixed by a net-specific datadir location. (default: %s)", BITCOIN_PID_FILENAME), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    argsman.AddArg("-prune=<n>", strprintf("Reduce storage requirements by enabling pruning (deleting) of old blocks. This allows the pruneblockchain RPC to be called to delete specific blocks and enables automatic pruning of old blocks if a target size in MiB is provided. This mode is incompatible with -txindex. "
-            "Warning: Reverting this setting requires re-downloading the entire blockchain. "
-            "(default: 0 = disable pruning blocks, 1 = allow manual pruning via RPC, >=%u = automatically prune block files to stay under the specified target size in MiB)", MIN_DISK_SPACE_FOR_BLOCK_FILES / 1_MiB), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-prune=<n>", strprintf("Reduce storage requirements by enabling pruning (deleting) of old blocks. This allows the pruneblockchain RPC to be called to delete specific blocks and enables automatic pruning of old blocks if a target size in MiB is provided. Using -txindex additionally requires -blockfetchproxy. "
+                                           "Warning: Reverting this setting requires re-downloading the entire blockchain. "
+                                           "(default: 0 = disable pruning blocks, 1 = allow manual pruning via RPC, >=%u = automatically prune block files to stay under the specified target size in MiB)",
+                                           MIN_DISK_SPACE_FOR_BLOCK_FILES / 1_MiB),
+                   ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-reindex", "If enabled, wipe chain state and block index, and rebuild them from blk*.dat files on disk. Also wipe and rebuild other optional indexes that are active. If an assumeutxo snapshot was loaded, its chainstate will be wiped as well. The snapshot can then be reloaded via RPC.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-reindex-chainstate", "If enabled, wipe chain state, and rebuild it from blk*.dat files on disk. If an assumeutxo snapshot was loaded, its chainstate will be wiped as well. The snapshot can then be reloaded via RPC.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-settings=<file>", strprintf("Specify path to dynamic settings data file. Can be disabled with -nosettings. File is written at runtime and not meant to be edited by users (use %s instead for custom settings). Relative paths will be prefixed by datadir location. (default: %s)", BITCOIN_CONF_FILENAME, BITCOIN_SETTINGS_FILENAME), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
@@ -1029,8 +1031,8 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     }
 
     if (args.GetIntArg("-prune", 0)) {
-        if (args.GetBoolArg("-txindex", DEFAULT_TXINDEX))
-            return InitError(_("Prune mode is incompatible with -txindex."));
+        if (args.GetBoolArg("-txindex", DEFAULT_TXINDEX) && !args.GetBoolArg("-blockfetchproxy", DEFAULT_BLOCK_FETCH_PROXY))
+            return InitError(_("Prune mode with -txindex requires -blockfetchproxy."));
         if (args.GetBoolArg("-txospenderindex", DEFAULT_TXOSPENDERINDEX))
             return InitError(_("Prune mode is incompatible with -txospenderindex."));
         if (args.GetBoolArg("-reindex-chainstate", false)) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -301,6 +301,8 @@ void Interrupt(NodeContext& node)
         node.tor_controller->Interrupt();
     }
     InterruptMapPort();
+    if (node.peerman)
+        node.peerman->InterruptLocalBlockFetches();
     if (node.connman)
         node.connman->Interrupt();
     for (auto* index : node.indexes) {
@@ -524,6 +526,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
     argsman.AddArg("-blocknotify=<cmd>", "Execute command when the best block changes (%s in cmd is replaced by block hash)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 #endif
     argsman.AddArg("-blockreconstructionextratxn=<n>", strprintf("Extra transactions to keep in memory for compact block reconstructions (default: %u)", DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-blockfetchproxy", strprintf("Fetch pruned blocks from outbound full-history peers for local RPC and wallet reads, and retain them as local-only block data. Peers can observe the requested block hashes. Requires -prune. (default: %u)", DEFAULT_BLOCK_FETCH_PROXY), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-blocksonly", strprintf("Whether to reject transactions from network peers. Disables automatic broadcast and rebroadcast of transactions, unless the source peer has the 'forcerelay' permission. RPC transactions are not affected. (default: %u)", DEFAULT_BLOCKSONLY), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-coinstatsindex", strprintf("Maintain coinstats index used by the gettxoutsetinfo RPC (default: %u)", DEFAULT_COINSTATSINDEX), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-conf=<file>", strprintf("Specify path to read-only configuration file. Relative paths will be prefixed by datadir location (only useable from command line, not configuration file) (default: %s)", BITCOIN_CONF_FILENAME), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
@@ -1033,6 +1036,9 @@ bool AppInitParameterInteraction(const ArgsManager& args)
         if (args.GetBoolArg("-reindex-chainstate", false)) {
             return InitError(_("Prune mode is incompatible with -reindex-chainstate. Use full -reindex instead."));
         }
+    }
+    if (args.GetBoolArg("-blockfetchproxy", DEFAULT_BLOCK_FETCH_PROXY) && !args.GetIntArg("-prune", 0)) {
+        return InitError(_("-blockfetchproxy requires prune mode."));
     }
 
     // If -forcednsseed is set to true, ensure -dnsseed has not been set to false

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -180,10 +180,10 @@ public:
     //! the specified block hash are verified.
     virtual double guessVerificationProgress(const uint256& block_hash) = 0;
 
-    //! Return true if data is available for all blocks in the specified range
-    //! of blocks. This checks all blocks that are ancestors of block_hash in
-    //! the height range from min_height to max_height, inclusive.
-    virtual bool hasBlocks(const uint256& block_hash, int min_height = 0, std::optional<int> max_height = {}) = 0;
+    //! Return true if data is available for all blocks in the specified range,
+    //! optionally including blocks fetchable for local use. This checks all
+    //! ancestors of block_hash from min_height to max_height, inclusive.
+    virtual bool hasBlocks(const uint256& block_hash, int min_height = 0, std::optional<int> max_height = {}, bool allow_fetch = true) = 0;
 
     //! Check if transaction is RBF opt in.
     virtual RBFTransactionState isRBFOptIn(const CTransaction& tx) = 0;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -66,6 +66,7 @@
 #include <array>
 #include <atomic>
 #include <compare>
+#include <condition_variable>
 #include <cstddef>
 #include <deque>
 #include <exception>
@@ -108,6 +109,9 @@ static constexpr auto CHAIN_SYNC_TIMEOUT{20min};
 static constexpr auto STALE_CHECK_INTERVAL{10min};
 /** How frequently to check for extra outbound peers and disconnect */
 static constexpr auto EXTRA_PEER_CHECK_INTERVAL{45s};
+/** Bound local historical reads so RPC and wallet callers cannot occupy all block download slots. */
+static constexpr uint32_t MAX_LOCAL_BLOCK_REQUESTS{4};
+static constexpr auto LOCAL_BLOCK_REQUEST_TIMEOUT{30s};
 /** Minimum time an outbound-peer-eviction candidate must be connected for, in order to evict */
 static constexpr auto MINIMUM_CONNECT_TIME{30s};
 /** SHA256("main address relay")[0:8] */
@@ -245,6 +249,8 @@ struct Peer {
 
     //! Whether this peer is an inbound connection
     const bool m_is_inbound;
+    //! Whether this is an outbound block-relay-only connection
+    const bool m_is_block_relay;
 
     /** Protects misbehavior data members */
     Mutex m_misbehavior_mutex;
@@ -413,10 +419,8 @@ struct Peer {
      * timestamp the peer sent in the version message. */
     std::atomic<std::chrono::seconds> m_time_offset{0s};
 
-    explicit Peer(NodeId id, ServiceFlags our_services, bool is_inbound)
-        : m_id{id}
-        , m_our_services{our_services}
-        , m_is_inbound{is_inbound}
+    explicit Peer(NodeId id, ServiceFlags our_services, bool is_inbound, bool is_block_relay)
+        : m_id{id}, m_our_services{our_services}, m_is_inbound{is_inbound}, m_is_block_relay{is_block_relay}
     {}
 
 private:
@@ -521,10 +525,10 @@ public:
 
     /** Implement NetEventsInterface */
     void InitializeNode(const CNode& node, ServiceFlags our_services) override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex, !m_tx_download_mutex);
-    void FinalizeNode(const CNode& node) override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex, !m_headers_presync_mutex, !m_tx_download_mutex);
+    void FinalizeNode(const CNode& node) override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex, !m_headers_presync_mutex, !m_tx_download_mutex, !m_local_block_requests_mutex);
     bool HasAllDesirableServiceFlags(ServiceFlags services) const override;
     bool ProcessMessages(CNode& node, std::atomic<bool>& interrupt) override
-        EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex, !m_most_recent_block_mutex, !m_headers_presync_mutex, g_msgproc_mutex, !m_tx_download_mutex);
+        EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex, !m_most_recent_block_mutex, !m_headers_presync_mutex, g_msgproc_mutex, !m_tx_download_mutex, !m_local_block_requests_mutex);
     bool SendMessages(CNode& node) override
         EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex, !m_most_recent_block_mutex, g_msgproc_mutex, !m_tx_download_mutex);
 
@@ -532,7 +536,11 @@ public:
     void StartScheduledTasks(CScheduler& scheduler) override;
     void CheckForStaleTipAndEvictPeers() override;
     util::Expected<void, std::string> FetchBlock(NodeId peer_id, const CBlockIndex& block_index) override
-        EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
+        EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex, !m_local_block_requests_mutex);
+    util::Expected<std::shared_ptr<const CBlock>, std::string> FetchBlockForLocalUse(const CBlockIndex& block_index) override
+        EXCLUSIVE_LOCKS_REQUIRED(!cs_main, !m_peer_mutex, !m_local_block_requests_mutex);
+    bool BlockFetchProxyEnabled() const override { return m_opts.block_fetch_proxy; }
+    void InterruptLocalBlockFetches() override EXCLUSIVE_LOCKS_REQUIRED(!m_local_block_requests_mutex);
     bool GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats) const override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
     std::vector<node::TxOrphanage::OrphanInfo> GetOrphanTransactions() override EXCLUSIVE_LOCKS_REQUIRED(!m_tx_download_mutex);
     PeerManagerInfo GetInfo() const override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
@@ -553,7 +561,7 @@ public:
 private:
     void ProcessMessage(Peer& peer, CNode& pfrom, const std::string& msg_type, DataStream& vRecv, NodeClock::time_point time_received,
                         const std::atomic<bool>& interruptMsgProc)
-        EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex, !m_most_recent_block_mutex, !m_headers_presync_mutex, g_msgproc_mutex, !m_tx_download_mutex);
+        EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex, !m_most_recent_block_mutex, !m_headers_presync_mutex, g_msgproc_mutex, !m_tx_download_mutex, !m_local_block_requests_mutex);
 
     /** Consider evicting an outbound peer based on the amount of time they've been behind our tip */
     void ConsiderEviction(CNode& pto, Peer& peer, std::chrono::seconds time_in_seconds) EXCLUSIVE_LOCKS_REQUIRED(cs_main, g_msgproc_mutex);
@@ -799,7 +807,21 @@ private:
     TimeOffsets m_outbound_time_offsets{m_warnings};
 
     const Options m_opts;
+    // All fields other than cv are guarded by m_local_block_requests_mutex.
+    struct LocalBlockRequest {
+        std::condition_variable cv;
+        std::shared_ptr<const CBlock> block;
+        std::string error;
+        NodeId peer_id{-1};
+        bool done{false};
+    };
+    Mutex m_local_block_requests_mutex;
+    std::map<uint256, std::shared_ptr<LocalBlockRequest>> m_local_block_requests GUARDED_BY(m_local_block_requests_mutex);
+    bool m_local_block_fetches_interrupted GUARDED_BY(m_local_block_requests_mutex){false};
 
+    bool SendBlockRequest(NodeId peer_id, const uint256& hash);
+    bool CompleteLocalBlockRequest(const uint256& hash, NodeId peer_id, const std::shared_ptr<const CBlock>& block, const std::string& error)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_local_block_requests_mutex);
     bool RejectIncomingTxs(const CNode& peer) const;
 
     /** Whether we've completed initial sync yet, for determining when to turn
@@ -1626,7 +1648,7 @@ void PeerManagerImpl::InitializeNode(const CNode& node, ServiceFlags our_service
         our_services = static_cast<ServiceFlags>(our_services | NODE_BLOOM);
     }
 
-    PeerRef peer = std::make_shared<Peer>(nodeid, our_services, node.IsInboundConn());
+    PeerRef peer = std::make_shared<Peer>(nodeid, our_services, node.IsInboundConn(), node.IsBlockOnlyConn());
     {
         LOCK(m_peer_mutex);
         m_peer_map.emplace_hint(m_peer_map.end(), nodeid, peer);
@@ -1741,6 +1763,23 @@ void PeerManagerImpl::FinalizeNode(const CNode& node)
         WITH_LOCK(m_tx_download_mutex, m_txdownloadman.CheckIsEmpty());
     }
     } // cs_main
+    std::vector<std::shared_ptr<LocalBlockRequest>> canceled_requests;
+    {
+        LOCK(m_local_block_requests_mutex);
+        for (auto it{m_local_block_requests.begin()}; it != m_local_block_requests.end();) {
+            const auto& request{it->second};
+            if (request->peer_id != nodeid) {
+                ++it;
+                continue;
+            }
+            request->error = "Peer disconnected while fetching historical block";
+            request->done = true;
+            canceled_requests.push_back(request);
+            it = m_local_block_requests.erase(it);
+        }
+    }
+    for (const auto& request : canceled_requests)
+        request->cv.notify_all();
     if (node.fSuccessfullyConnected &&
         !node.IsBlockOnlyConn() && !node.IsPrivateBroadcastConn() && !node.IsInboundConn()) {
         // Only change visible addrman state for full outbound peers.  We don't
@@ -1989,11 +2028,14 @@ util::Expected<void, std::string> PeerManagerImpl::FetchBlock(NodeId peer_id, co
 {
     if (m_chainman.m_blockman.LoadingBlocks()) return util::Unexpected{"Loading blocks ..."};
 
+    const uint256& hash{block_index.GetBlockHash()};
     // The lock must be taken here before fetching Peer so another thread does
     // not delete the CNodeState from under the current thread, causing an
     // assertion failure in BlockRequested. This lock can be replaced with a
     // net-specific lock when more of CNodeState is moved into Peer.
+    LOCK(m_local_block_requests_mutex);
     LOCK(cs_main);
+    if (m_local_block_requests.contains(hash)) return util::Unexpected{"Block is already requested for local use"};
 
     // Ensure this peer exists and hasn't been disconnected
     PeerRef peer = GetPeerRef(peer_id);
@@ -2003,26 +2045,192 @@ util::Expected<void, std::string> PeerManagerImpl::FetchBlock(NodeId peer_id, co
     if (!CanServeWitnesses(*peer)) return util::Unexpected{"Pre-SegWit peer"};
 
     // Forget about all prior requests
-    RemoveBlockRequest(block_index.GetBlockHash(), std::nullopt);
+    RemoveBlockRequest(hash, std::nullopt);
 
     // Mark block as in-flight
     if (!BlockRequested(peer_id, block_index)) return util::Unexpected{"Already requested from this peer"};
 
-    // Construct message to request the block
-    const uint256& hash{block_index.GetBlockHash()};
-    std::vector<CInv> invs{CInv(MSG_BLOCK | MSG_WITNESS_FLAG, hash)};
-
-    // Send block request message to the peer
-    bool success = m_connman.ForNode(peer_id, [this, &invs](CNode* node) {
-        this->MakeAndPushMessage(*node, NetMsgType::GETDATA, invs);
-        return true;
-    });
-
-    if (!success) return util::Unexpected{"Peer not fully connected"};
+    if (!SendBlockRequest(peer_id, hash)) return util::Unexpected{"Peer not fully connected"};
 
     LogDebug(BCLog::NET, "Requesting block %s from peer=%d\n",
-                 hash.ToString(), peer_id);
+             hash.ToString(), peer_id);
     return {};
+}
+
+bool PeerManagerImpl::SendBlockRequest(NodeId peer_id, const uint256& hash)
+{
+    const std::vector<CInv> invs{CInv(MSG_BLOCK | MSG_WITNESS_FLAG, hash)};
+    return m_connman.ForNode(peer_id, [this, &invs](CNode* node) {
+        MakeAndPushMessage(*node, NetMsgType::GETDATA, invs);
+        return true;
+    });
+}
+
+bool PeerManagerImpl::CompleteLocalBlockRequest(const uint256& hash, NodeId peer_id, const std::shared_ptr<const CBlock>& block, const std::string& error)
+{
+    std::shared_ptr<LocalBlockRequest> request;
+    {
+        LOCK(m_local_block_requests_mutex);
+        const auto it{m_local_block_requests.find(hash)};
+        if (it == m_local_block_requests.end() || it->second->peer_id != peer_id) return false;
+        WITH_LOCK(cs_main, RemoveBlockRequest(hash, peer_id));
+        request = it->second;
+        request->block = block;
+        request->error = error;
+        request->done = true;
+        m_local_block_requests.erase(it);
+    }
+    request->cv.notify_all();
+    return true;
+}
+
+util::Expected<std::shared_ptr<const CBlock>, std::string> PeerManagerImpl::FetchBlockForLocalUse(const CBlockIndex& block_index)
+{
+    AssertLockNotHeld(cs_main);
+    if (!m_opts.block_fetch_proxy) return util::Unexpected{"Block fetch proxy is disabled"};
+
+    const uint256& hash{block_index.GetBlockHash()};
+    {
+        LOCK(cs_main);
+        if (!m_chainman.ActiveChain().Contains(block_index) || block_index.nTx == 0) {
+            return util::Unexpected{"Block is not a previously processed active-chain block"};
+        }
+    }
+
+    std::shared_ptr<LocalBlockRequest> request;
+    bool make_request{false};
+    {
+        LOCK(m_local_block_requests_mutex);
+        if (m_local_block_fetches_interrupted) {
+            return util::Unexpected{"Interrupted while fetching historical block"};
+        }
+        if (const auto it{m_local_block_requests.find(hash)}; it != m_local_block_requests.end()) {
+            request = it->second;
+        } else {
+            if (m_local_block_requests.size() >= MAX_LOCAL_BLOCK_REQUESTS) {
+                return util::Unexpected{"Too many local block fetches in progress"};
+            }
+            request = std::make_shared<LocalBlockRequest>();
+            m_local_block_requests.emplace(hash, request);
+            make_request = true;
+        }
+    }
+
+    if (make_request) {
+        PeerRef selected_peer;
+        bool request_failed{false};
+        {
+            LOCK(m_local_block_requests_mutex);
+            LOCK(cs_main);
+            const auto it{m_local_block_requests.find(hash)};
+            if (it == m_local_block_requests.end() || it->second != request || request->done) {
+                request_failed = true;
+            } else if (!m_chainman.ActiveChain().Contains(block_index) || block_index.nTx == 0) {
+                request->error = "Block is not a previously processed active-chain block";
+                request->done = true;
+                m_local_block_requests.erase(it);
+                request_failed = true;
+            } else {
+                std::vector<PeerRef> candidates;
+                for (const PeerRef& peer : GetAllPeers()) {
+                    CNodeState* state{State(peer->m_id)};
+                    if (!state || peer->m_is_inbound || peer->m_is_block_relay || !(peer->m_their_services & NODE_NETWORK) || !CanServeWitnesses(*peer)) continue;
+                    ProcessBlockAvailability(peer->m_id);
+                    if (!PeerHasHeader(state, &block_index) || state->vBlocksInFlight.size() >= MAX_BLOCKS_IN_TRANSIT_PER_PEER) continue;
+                    candidates.push_back(peer);
+                }
+                if (candidates.empty()) {
+                    request->error = "No outbound full-history peer has the requested block";
+                    request->done = true;
+                    m_local_block_requests.erase(it);
+                    request_failed = true;
+                } else {
+                    FastRandomContext rng{};
+                    selected_peer = candidates[rng.randrange(candidates.size())];
+                    if (IsBlockRequested(hash) || !BlockRequested(selected_peer->m_id, block_index)) {
+                        request->error = "Block is already being requested";
+                        request->done = true;
+                        m_local_block_requests.erase(it);
+                        request_failed = true;
+                    } else {
+                        request->peer_id = selected_peer->m_id;
+                    }
+                }
+            }
+        }
+
+        if (request_failed) {
+            request->cv.notify_all();
+        } else {
+            const bool sent{SendBlockRequest(selected_peer->m_id, hash)};
+            if (!sent) {
+                bool notify{false};
+                {
+                    LOCK(m_local_block_requests_mutex);
+                    LOCK(cs_main);
+                    if (const auto it{m_local_block_requests.find(hash)};
+                        it != m_local_block_requests.end() && it->second == request && !request->done) {
+                        RemoveBlockRequest(hash, selected_peer->m_id);
+                        request->error = "Peer disconnected before the block request was sent";
+                        request->done = true;
+                        m_local_block_requests.erase(it);
+                        notify = true;
+                    }
+                }
+                if (notify) request->cv.notify_all();
+            } else {
+                LogDebug(BCLog::NET, "Requesting block %s from peer=%d for local use", hash.ToString(), selected_peer->m_id);
+            }
+        }
+    }
+
+    std::shared_ptr<const CBlock> block;
+    std::string error;
+    bool timed_out{false};
+    {
+        WAIT_LOCK(m_local_block_requests_mutex, lock);
+        if (!request->cv.wait_for(lock, LOCAL_BLOCK_REQUEST_TIMEOUT, [&] { return request->done; })) {
+            request->error = "Timed out waiting for historical block";
+            request->done = true;
+            {
+                LOCK(cs_main);
+                if (request->peer_id != -1) RemoveBlockRequest(hash, request->peer_id);
+            }
+            if (const auto it{m_local_block_requests.find(hash)}; it != m_local_block_requests.end() && it->second == request) {
+                m_local_block_requests.erase(it);
+            }
+            error = request->error;
+            timed_out = true;
+        } else {
+            if (!request->block) return util::Unexpected{request->error};
+            block = request->block;
+        }
+    }
+    if (timed_out) {
+        request->cv.notify_all();
+        return util::Unexpected{std::move(error)};
+    }
+    return block;
+}
+
+void PeerManagerImpl::InterruptLocalBlockFetches()
+{
+    std::vector<std::shared_ptr<LocalBlockRequest>> requests;
+    {
+        LOCK(m_local_block_requests_mutex);
+        LOCK(cs_main);
+        m_local_block_fetches_interrupted = true;
+        for (const auto& [hash, request] : m_local_block_requests) {
+            if (request->done) continue;
+            if (request->peer_id != -1) RemoveBlockRequest(hash, request->peer_id);
+            request->error = "Interrupted while fetching historical block";
+            request->done = true;
+            requests.push_back(request);
+        }
+        m_local_block_requests.clear();
+    }
+    for (const auto& request : requests)
+        request->cv.notify_all();
 }
 
 std::unique_ptr<PeerManager> PeerManager::make(CConnman& connman, AddrMan& addrman,
@@ -2432,6 +2640,9 @@ void PeerManagerImpl::ProcessGetBlockData(CNode& pfrom, Peer& peer, const CInv& 
         // Pruned nodes may have deleted the block, so check whether
         // it's available before trying to send.
         if (!(pindex->nStatus & BLOCK_HAVE_DATA)) {
+            return;
+        }
+        if (pindex->nStatus & BLOCK_LOCAL_ONLY) {
             return;
         }
         can_direct_fetch = CanDirectFetch();
@@ -4318,7 +4529,9 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
             // If pruning, don't inv blocks unless we have on disk and are likely to still have
             // for some reasonable time window (1 hour) that block relay might require.
             const int nPrunedBlocksLikelyToHave = MIN_BLOCKS_TO_KEEP - 3600 / m_chainparams.GetConsensus().nPowTargetSpacing;
-            if (m_chainman.m_blockman.IsPruneMode() && (!(pindex->nStatus & BLOCK_HAVE_DATA) || pindex->nHeight <= m_chainman.ActiveChain().Tip()->nHeight - nPrunedBlocksLikelyToHave)) {
+            if (m_chainman.m_blockman.IsPruneMode() &&
+                (!(pindex->nStatus & BLOCK_HAVE_DATA) || (pindex->nStatus & BLOCK_LOCAL_ONLY) ||
+                 pindex->nHeight <= m_chainman.ActiveChain().Tip()->nHeight - nPrunedBlocksLikelyToHave)) {
                 LogDebug(BCLog::NET, " getblocks stopping, pruned or too old block at %d %s\n", pindex->nHeight, pindex->GetBlockHash().ToString());
                 break;
             }
@@ -4350,24 +4563,24 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
                 recent_block = m_most_recent_block;
             // Unlock m_most_recent_block_mutex to avoid cs_main lock inversion
         }
-        if (recent_block) {
-            SendBlockTransactions(pfrom, peer, *recent_block, req);
-            return;
-        }
-
         FlatFilePos block_pos{};
         {
             LOCK(cs_main);
 
             const CBlockIndex* pindex = m_chainman.m_blockman.LookupBlockIndex(req.blockhash);
-            if (!pindex || !(pindex->nStatus & BLOCK_HAVE_DATA)) {
+            if (!pindex || !(pindex->nStatus & BLOCK_HAVE_DATA) || (pindex->nStatus & BLOCK_LOCAL_ONLY)) {
                 LogDebug(BCLog::NET, "Peer %d sent us a getblocktxn for a block we don't have\n", pfrom.GetId());
                 return;
             }
 
-            if (pindex->nHeight >= m_chainman.ActiveChain().Height() - MAX_BLOCKTXN_DEPTH) {
+            if (!recent_block && pindex->nHeight >= m_chainman.ActiveChain().Height() - MAX_BLOCKTXN_DEPTH) {
                 block_pos = pindex->GetBlockPos();
             }
+        }
+
+        if (recent_block) {
+            SendBlockTransactions(pfrom, peer, *recent_block, req);
+            return;
         }
 
         if (!block_pos.IsNull()) {
@@ -4886,27 +5099,54 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         std::shared_ptr<CBlock> pblock = std::make_shared<CBlock>();
         vRecv >> TX_WITH_WITNESS(*pblock);
 
-        LogDebug(BCLog::NET, "received block %s peer=%d\n", pblock->GetHash().ToString(), pfrom.GetId());
+        const uint256 hash{pblock->GetHash()};
+        LogDebug(BCLog::NET, "received block %s peer=%d\n", hash.ToString(), pfrom.GetId());
 
         const CBlockIndex* prev_block{WITH_LOCK(m_chainman.GetMutex(), return m_chainman.m_blockman.LookupBlockIndex(pblock->hashPrevBlock))};
 
-        // Check for possible mutation if it connects to something we know so we can check for DEPLOYMENT_SEGWIT being active
-        if (prev_block && IsBlockMutated(/*block=*/*pblock,
-                           /*check_witness_root=*/DeploymentActiveAfter(prev_block, m_chainman, Consensus::DEPLOYMENT_SEGWIT))) {
+        bool has_local_request{false};
+        bool matches_local_request{false};
+        {
+            LOCK(m_local_block_requests_mutex);
+            const auto it{m_local_block_requests.find(hash)};
+            has_local_request = it != m_local_block_requests.end();
+            matches_local_request = has_local_request && it->second->peer_id == peer.m_id;
+        }
+
+        // Preserve the existing behavior for blocks with unknown parents. A
+        // local request is always for a known active-chain block, except genesis.
+        if ((prev_block || matches_local_request) &&
+            IsBlockMutated(/*block=*/*pblock,
+                           /*check_witness_root=*/prev_block && DeploymentActiveAfter(prev_block, m_chainman, Consensus::DEPLOYMENT_SEGWIT))) {
             LogDebug(BCLog::NET, "Received mutated block from peer=%d\n", peer.m_id);
             Misbehaving(peer, "mutated block");
-            WITH_LOCK(cs_main, RemoveBlockRequest(pblock->GetHash(), peer.m_id));
+            WITH_LOCK(cs_main, RemoveBlockRequest(hash, peer.m_id));
+            CompleteLocalBlockRequest(hash, peer.m_id, /*block=*/nullptr, "Peer returned a mutated historical block");
+            return;
+        }
+
+        if (matches_local_request) {
+            WITH_LOCK(cs_main, RemoveBlockRequest(hash, peer.m_id));
+            const bool stored{m_chainman.ProcessNewBlock(pblock, /*force_processing=*/true,
+                                                         /*min_pow_checked=*/true, /*new_block=*/nullptr,
+                                                         /*local_only=*/true)};
+            if (stored) {
+                CompleteLocalBlockRequest(hash, peer.m_id, pblock, /*error=*/{});
+            } else {
+                CompleteLocalBlockRequest(hash, peer.m_id, /*block=*/nullptr, "Failed to store historical block");
+            }
             return;
         }
 
         bool forceProcessing = false;
-        const uint256 hash(pblock->GetHash());
         bool min_pow_checked = false;
         {
             LOCK(cs_main);
             // Always process the block if we requested it, since we may
             // need it even when it's not a candidate for a new best tip.
-            forceProcessing = IsBlockRequested(hash);
+            // A response from another peer must not turn a local-only fetch
+            // into normally servable block data.
+            forceProcessing = IsBlockRequested(hash) && !has_local_request;
             RemoveBlockRequest(hash, pfrom.GetId());
             // mapBlockSource is only used for punishing peers and setting
             // which peers send us compact blocks, so the race between here and
@@ -5120,6 +5360,8 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
             for (CInv &inv : vInv) {
                 if (inv.IsGenTxMsg()) {
                     tx_invs.emplace_back(ToGenTxid(inv));
+                } else if (inv.IsGenBlkMsg()) {
+                    CompleteLocalBlockRequest(inv.hash, pfrom.GetId(), /*block=*/nullptr, "Peer does not have the requested historical block");
                 }
             }
         }

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -28,6 +28,7 @@ class AddrMan;
 class CTxMemPool;
 class ChainstateManager;
 class BanMan;
+class CBlock;
 class CBlockIndex;
 class CScheduler;
 class DataStream;
@@ -44,6 +45,8 @@ static constexpr bool DEFAULT_TXRECONCILIATION_ENABLE{false};
 static const uint32_t DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN{100};
 static const bool DEFAULT_PEERBLOOMFILTERS = false;
 static const bool DEFAULT_PEERBLOCKFILTERS = false;
+/** Whether missing historical blocks may be fetched for local callers. */
+static constexpr bool DEFAULT_BLOCK_FETCH_PROXY{false};
 /** Maximum number of outstanding CMPCTBLOCK requests for the same block. */
 static const unsigned int MAX_CMPCTBLOCKS_INFLIGHT_PER_BLOCK = 3;
 /** Number of headers sent in one getheaders result. We rely on the assumption that if a peer sends
@@ -96,6 +99,8 @@ public:
         uint32_t max_headers_result{MAX_HEADERS_RESULTS};
         //! Whether private broadcast is used for sending transactions.
         bool private_broadcast{DEFAULT_PRIVATE_BROADCAST};
+        //! Whether missing historical blocks may be fetched for local callers.
+        bool block_fetch_proxy{DEFAULT_BLOCK_FETCH_PROXY};
     };
 
     static std::unique_ptr<PeerManager> make(CConnman& connman, AddrMan& addrman,
@@ -110,6 +115,18 @@ public:
      * @param[in]  block_index  The blockindex
      */
     virtual util::Expected<void, std::string> FetchBlock(NodeId peer_id, const CBlockIndex& block_index) = 0;
+
+    /**
+     * Fetch and retain a previously processed block for local use.
+     * The block is stored in the normal block files, but not served to peers.
+     */
+    virtual util::Expected<std::shared_ptr<const CBlock>, std::string> FetchBlockForLocalUse(const CBlockIndex& block_index) = 0;
+
+    /** Whether missing historical blocks may be fetched for local callers. */
+    virtual bool BlockFetchProxyEnabled() const = 0;
+
+    /** Interrupt local historical block fetches during shutdown. */
+    virtual void InterruptLocalBlockFetches() = 0;
 
     /** Begin running background tasks, should only be called once */
     virtual void StartScheduledTasks(CScheduler& scheduler) = 0;

--- a/src/node/blockfetch.cpp
+++ b/src/node/blockfetch.cpp
@@ -1,0 +1,39 @@
+// Copyright (c) 2026-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/blockfetch.h>
+
+#include <chain.h>
+#include <net_processing.h>
+#include <node/blockstorage.h>
+#include <node/context.h>
+#include <primitives/block.h>
+#include <sync.h>
+#include <util/check.h>
+#include <util/expected.h>
+#include <validation.h>
+
+#include <utility>
+
+namespace node {
+util::Expected<std::shared_ptr<const CBlock>, std::string> ReadBlockForLocalUse(const NodeContext& node, const CBlockIndex& block_index, bool allow_fetch)
+{
+    ChainstateManager& chainman{*Assert(node.chainman)};
+    const bool have_data{WITH_LOCK(cs_main, return (block_index.nStatus & BLOCK_HAVE_DATA) != 0)};
+    if (have_data) {
+        auto block{std::make_shared<CBlock>()};
+        if (chainman.m_blockman.ReadBlock(*block, block_index)) return std::shared_ptr<const CBlock>{std::move(block)};
+
+        // Pruning may have raced the read. Treat a still-present block as an I/O
+        // failure rather than hiding corruption behind a network fetch.
+        if (WITH_LOCK(cs_main, return (block_index.nStatus & BLOCK_HAVE_DATA) != 0)) {
+            return util::Unexpected{"Block data could not be read from disk"};
+        }
+    }
+
+    if (!allow_fetch) return util::Unexpected{"Block not found on disk"};
+    if (!node.peerman) return util::Unexpected{"Peer manager is not available"};
+    return node.peerman->FetchBlockForLocalUse(block_index);
+}
+} // namespace node

--- a/src/node/blockfetch.h
+++ b/src/node/blockfetch.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2026-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODE_BLOCKFETCH_H
+#define BITCOIN_NODE_BLOCKFETCH_H
+
+#include <util/expected.h>
+
+#include <memory>
+#include <string>
+
+class CBlock;
+class CBlockIndex;
+
+namespace node {
+struct NodeContext;
+
+/** Read a block from disk, or optionally fetch a pruned active-chain block for local use. */
+util::Expected<std::shared_ptr<const CBlock>, std::string> ReadBlockForLocalUse(const NodeContext& node, const CBlockIndex& block_index, bool allow_fetch = true);
+} // namespace node
+
+#endif // BITCOIN_NODE_BLOCKFETCH_H

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -276,6 +276,7 @@ void BlockManager::PruneOneBlockFile(const int fileNumber)
         if (pindex->nFile == fileNumber) {
             pindex->nStatus &= ~BLOCK_HAVE_DATA;
             pindex->nStatus &= ~BLOCK_HAVE_UNDO;
+            pindex->nStatus &= ~BLOCK_LOCAL_ONLY;
             pindex->nFile = 0;
             pindex->nDataPos = 0;
             pindex->nUndoPos = 0;

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -316,6 +316,7 @@ void BlockManager::FindFilesToPruneManual(
 
     int count = 0;
     for (int fileNumber = 0; fileNumber < this->MaxBlockfileNum(); fileNumber++) {
+        if (IsCurrentBlockfile(fileNumber)) continue;
         const auto& fileinfo = m_blockfile_info[fileNumber];
         if (fileinfo.nSize == 0 || fileinfo.nHeightLast > (unsigned)last_block_can_prune || fileinfo.nHeightFirst < (unsigned)min_block_to_prune) {
             continue;
@@ -379,6 +380,7 @@ void BlockManager::FindFilesToPrune(
         }
 
         for (int fileNumber = 0; fileNumber < this->MaxBlockfileNum(); fileNumber++) {
+            if (IsCurrentBlockfile(fileNumber)) continue;
             const auto& fileinfo = m_blockfile_info[fileNumber];
             nBytesToPrune = fileinfo.nSize + fileinfo.nUndoSize;
 

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -48,6 +48,9 @@ class BlockValidationState;
 class CBlockUndo;
 class Chainstate;
 class ChainstateManager;
+namespace blockmanager_tests {
+class BlockManagerTest;
+}
 namespace Consensus {
 struct Params;
 }
@@ -194,6 +197,7 @@ enum class ReadRawError {
  */
 class BlockManager
 {
+    friend class ::blockmanager_tests::BlockManagerTest;
     friend Chainstate;
     friend ChainstateManager;
 
@@ -279,6 +283,14 @@ private:
         const auto& normal = m_blockfile_cursors[BlockfileType::NORMAL].value_or(empty_cursor);
         const auto& assumed = m_blockfile_cursors[BlockfileType::ASSUMED].value_or(empty_cursor);
         return std::max(normal.file_num, assumed.file_num);
+    }
+    bool IsCurrentBlockfile(int file_num) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
+    {
+        AssertLockHeld(::cs_main);
+        for (const auto& cursor : m_blockfile_cursors) {
+            if (cursor && cursor->file_num == file_num) return true;
+        }
+        return false;
     }
 
     /** Global flag to indicate we should check to see if there are

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -33,6 +33,7 @@
 #include <net_types.h>
 #include <netaddress.h>
 #include <netbase.h>
+#include <node/blockfetch.h>
 #include <node/blockstorage.h>
 #include <node/coin.h>
 #include <node/context.h>
@@ -444,7 +445,7 @@ public:
 };
 
 // NOLINTNEXTLINE(misc-no-recursion)
-bool FillBlock(const CBlockIndex* index, const FoundBlock& block, UniqueLock<RecursiveMutex>& lock, const CChain& active, const BlockManager& blockman) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+bool FillBlock(const CBlockIndex* index, const FoundBlock& block, UniqueLock<RecursiveMutex>& lock, const CChain& active, const NodeContext& node) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (!index) return false;
     if (block.m_hash) *block.m_hash = index->GetBlockHash();
@@ -454,10 +455,17 @@ bool FillBlock(const CBlockIndex* index, const FoundBlock& block, UniqueLock<Rec
     if (block.m_mtp_time) *block.m_mtp_time = index->GetMedianTimePast();
     if (block.m_in_active_chain) *block.m_in_active_chain = active[index->nHeight] == index;
     if (block.m_locator) { *block.m_locator = GetLocator(index); }
-    if (block.m_next_block) FillBlock(active[index->nHeight] == index ? active[index->nHeight + 1] : nullptr, *block.m_next_block, lock, active, blockman);
+    if (block.m_next_block) FillBlock(active[index->nHeight] == index ? active[index->nHeight + 1] : nullptr, *block.m_next_block, lock, active, node);
     if (block.m_data) {
         REVERSE_LOCK(lock, cs_main);
-        if (!blockman.ReadBlock(*block.m_data, *index)) block.m_data->SetNull();
+        const bool allow_fetch{node.peerman && node.peerman->BlockFetchProxyEnabled()};
+        auto block_data{ReadBlockForLocalUse(node, *index, allow_fetch)};
+        if (block_data) {
+            *block.m_data = **block_data;
+        } else {
+            if (allow_fetch) LogWarning("Unable to read block %s for local use: %s", index->GetBlockHash().ToString(), block_data.error());
+            block.m_data->SetNull();
+        }
     }
     block.found = true;
     return true;
@@ -600,13 +608,13 @@ public:
     bool findBlock(const uint256& hash, const FoundBlock& block) override
     {
         WAIT_LOCK(cs_main, lock);
-        return FillBlock(chainman().m_blockman.LookupBlockIndex(hash), block, lock, chainman().ActiveChain(), chainman().m_blockman);
+        return FillBlock(chainman().m_blockman.LookupBlockIndex(hash), block, lock, chainman().ActiveChain(), m_node);
     }
     bool findFirstBlockWithTimeAndHeight(int64_t min_time, int min_height, const FoundBlock& block) override
     {
         WAIT_LOCK(cs_main, lock);
         const CChain& active = chainman().ActiveChain();
-        return FillBlock(active.FindEarliestAtLeast(min_time, min_height), block, lock, active, chainman().m_blockman);
+        return FillBlock(active.FindEarliestAtLeast(min_time, min_height), block, lock, active, m_node);
     }
     bool findAncestorByHeight(const uint256& block_hash, int ancestor_height, const FoundBlock& ancestor_out) override
     {
@@ -614,10 +622,10 @@ public:
         const CChain& active = chainman().ActiveChain();
         if (const CBlockIndex* block = chainman().m_blockman.LookupBlockIndex(block_hash)) {
             if (const CBlockIndex* ancestor = block->GetAncestor(ancestor_height)) {
-                return FillBlock(ancestor, ancestor_out, lock, active, chainman().m_blockman);
+                return FillBlock(ancestor, ancestor_out, lock, active, m_node);
             }
         }
-        return FillBlock(nullptr, ancestor_out, lock, active, chainman().m_blockman);
+        return FillBlock(nullptr, ancestor_out, lock, active, m_node);
     }
     bool findAncestorByHash(const uint256& block_hash, const uint256& ancestor_hash, const FoundBlock& ancestor_out) override
     {
@@ -625,7 +633,7 @@ public:
         const CBlockIndex* block = chainman().m_blockman.LookupBlockIndex(block_hash);
         const CBlockIndex* ancestor = chainman().m_blockman.LookupBlockIndex(ancestor_hash);
         if (block && ancestor && block->GetAncestor(ancestor->nHeight) != ancestor) ancestor = nullptr;
-        return FillBlock(ancestor, ancestor_out, lock, chainman().ActiveChain(), chainman().m_blockman);
+        return FillBlock(ancestor, ancestor_out, lock, chainman().ActiveChain(), m_node);
     }
     bool findCommonAncestor(const uint256& block_hash1, const uint256& block_hash2, const FoundBlock& ancestor_out, const FoundBlock& block1_out, const FoundBlock& block2_out) override
     {
@@ -637,9 +645,9 @@ public:
         // Using & instead of && below to avoid short circuiting and leaving
         // output uninitialized. Cast bool to int to avoid -Wbitwise-instead-of-logical
         // compiler warnings.
-        return int{FillBlock(ancestor, ancestor_out, lock, active, chainman().m_blockman)} &
-               int{FillBlock(block1, block1_out, lock, active, chainman().m_blockman)} &
-               int{FillBlock(block2, block2_out, lock, active, chainman().m_blockman)};
+        return int{FillBlock(ancestor, ancestor_out, lock, active, m_node)} &
+               int{FillBlock(block1, block1_out, lock, active, m_node)} &
+               int{FillBlock(block2, block2_out, lock, active, m_node)};
     }
     void findCoins(std::map<COutPoint, Coin>& coins) override { return FindCoins(m_node, coins); }
     double guessVerificationProgress(const uint256& block_hash) override
@@ -647,19 +655,20 @@ public:
         LOCK(chainman().GetMutex());
         return chainman().GuessVerificationProgress(chainman().m_blockman.LookupBlockIndex(block_hash));
     }
-    bool hasBlocks(const uint256& block_hash, int min_height, std::optional<int> max_height) override
+    bool hasBlocks(const uint256& block_hash, int min_height, std::optional<int> max_height, bool allow_fetch) override
     {
-        // hasBlocks returns true if all ancestors of block_hash in specified
-        // range have block data (are not pruned), false if any ancestors in
-        // specified range are missing data.
+        // hasBlocks returns true if all ancestors of block_hash in the
+        // specified range can be read from disk or, when enabled, fetched for
+        // local use.
         //
         // For simplicity and robustness, min_height and max_height are only
         // used to limit the range, and passing min_height that's too low or
         // max_height that's too high will not crash or change the result.
+        const bool can_fetch{allow_fetch && m_node.peerman && m_node.peerman->BlockFetchProxyEnabled()};
         LOCK(::cs_main);
         if (const CBlockIndex* block = chainman().m_blockman.LookupBlockIndex(block_hash)) {
             if (max_height && block->nHeight >= *max_height) block = block->GetAncestor(*max_height);
-            for (; block->nStatus & BLOCK_HAVE_DATA; block = block->pprev) {
+            for (; (block->nStatus & BLOCK_HAVE_DATA) || (can_fetch && block->nTx > 0 && chainman().ActiveChain().Contains(*block)); block = block->pprev) {
                 // Check pprev to not segfault if min_height is too low
                 if (block->nHeight <= min_height || !block->pprev) return true;
             }

--- a/src/node/peerman_args.cpp
+++ b/src/node/peerman_args.cpp
@@ -14,6 +14,7 @@ namespace node {
 
 void ApplyArgsManOptions(const ArgsManager& argsman, PeerManager::Options& options)
 {
+    if (auto value{argsman.GetBoolArg("-blockfetchproxy")}) options.block_fetch_proxy = *value;
     if (auto value{argsman.GetBoolArg("-txreconciliation")}) options.reconcile_txs = *value;
 
     if (auto value{argsman.GetIntArg("-blockreconstructionextratxn")}) {
@@ -28,4 +29,3 @@ void ApplyArgsManOptions(const ArgsManager& argsman, PeerManager::Options& optio
 }
 
 } // namespace node
-

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -3,17 +3,19 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <node/transaction.h>
+
 #include <consensus/validation.h>
 #include <index/txindex.h>
 #include <net.h>
 #include <net_processing.h>
+#include <node/blockfetch.h>
 #include <node/blockstorage.h>
 #include <node/context.h>
 #include <node/types.h>
 #include <txmempool.h>
 #include <validation.h>
 #include <validationinterface.h>
-#include <node/transaction.h>
 
 namespace node {
 static TransactionError HandleATMPError(const TxValidationState& state, std::string& err_string_out)
@@ -139,7 +141,7 @@ TransactionError BroadcastTransaction(NodeContext& node,
     return TransactionError::OK;
 }
 
-CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMemPool* const mempool, const Txid& hash, const BlockManager& blockman, uint256& hashBlock)
+CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMemPool* const mempool, const Txid& hash, const NodeContext& node, uint256& hashBlock, bool allow_block_fetch, bool allow_local_only)
 {
     if (mempool && !block_index) {
         CTransactionRef ptx = mempool->get(hash);
@@ -148,7 +150,7 @@ CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMe
     if (g_txindex) {
         CTransactionRef tx;
         uint256 block_hash;
-        if (g_txindex->FindTx(hash, block_hash, tx)) {
+        if (g_txindex->FindTx(hash, block_hash, tx, allow_block_fetch, allow_local_only)) {
             if (!block_index || block_index->GetBlockHash() == block_hash) {
                 // Don't return the transaction if the provided block hash doesn't match.
                 // The case where a transaction appears in multiple blocks (e.g. reorgs or
@@ -159,13 +161,12 @@ CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMe
         }
     }
     if (block_index) {
-        CBlock block;
-        if (blockman.ReadBlock(block, *block_index)) {
-            for (const auto& tx : block.vtx) {
-                if (tx->GetHash() == hash) {
-                    hashBlock = block_index->GetBlockHash();
-                    return tx;
-                }
+        auto block{ReadBlockForLocalUse(node, *block_index, allow_block_fetch)};
+        if (!block) return nullptr;
+        for (const auto& tx : (*block)->vtx) {
+            if (tx->GetHash() == hash) {
+                hashBlock = block_index->GetBlockHash();
+                return tx;
             }
         }
     }

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -141,8 +141,9 @@ TransactionError BroadcastTransaction(NodeContext& node,
     return TransactionError::OK;
 }
 
-CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMemPool* const mempool, const Txid& hash, const NodeContext& node, uint256& hashBlock, bool allow_block_fetch, bool allow_local_only)
+CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMemPool* const mempool, const Txid& hash, const NodeContext& node, uint256& hashBlock, bool allow_block_fetch, std::shared_ptr<const CBlock>* block_data, bool allow_local_only)
 {
+    if (block_data) block_data->reset();
     if (mempool && !block_index) {
         CTransactionRef ptx = mempool->get(hash);
         if (ptx) return ptx;
@@ -150,7 +151,7 @@ CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMe
     if (g_txindex) {
         CTransactionRef tx;
         uint256 block_hash;
-        if (g_txindex->FindTx(hash, block_hash, tx, allow_block_fetch, allow_local_only)) {
+        if (g_txindex->FindTx(hash, block_hash, tx, allow_block_fetch, block_data, allow_local_only)) {
             if (!block_index || block_index->GetBlockHash() == block_hash) {
                 // Don't return the transaction if the provided block hash doesn't match.
                 // The case where a transaction appears in multiple blocks (e.g. reorgs or
@@ -166,6 +167,7 @@ CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMe
         for (const auto& tx : (*block)->vtx) {
             if (tx->GetHash() == hash) {
                 hashBlock = block_index->GetBlockHash();
+                if (block_data) *block_data = *block;
                 return tx;
             }
         }

--- a/src/node/transaction.h
+++ b/src/node/transaction.h
@@ -10,7 +10,10 @@
 #include <policy/feerate.h>
 #include <primitives/transaction.h>
 
+#include <memory>
+
 class CBlockIndex;
+class CBlock;
 class CTxMemPool;
 namespace Consensus {
 struct Params;
@@ -68,10 +71,11 @@ static const CAmount DEFAULT_MAX_BURN_AMOUNT{0};
  * @param[in]  node            Node context used to access blocks
  * @param[out] hashBlock       The block hash, if the tx was found via -txindex or block_index
  * @param[in]  allow_block_fetch  Whether a pruned block may be fetched from a peer
+ * @param[out] block_data      The full block, if it was needed and the transaction was found
  * @param[in]  allow_local_only  Whether blocks retained for trusted local callers may be read
  * @returns                    The tx if found, otherwise nullptr
  */
-CTransactionRef GetTransaction(const CBlockIndex* block_index, const CTxMemPool* mempool, const Txid& hash, const NodeContext& node, uint256& hashBlock, bool allow_block_fetch = false, bool allow_local_only = true);
+CTransactionRef GetTransaction(const CBlockIndex* block_index, const CTxMemPool* mempool, const Txid& hash, const NodeContext& node, uint256& hashBlock, bool allow_block_fetch = false, std::shared_ptr<const CBlock>* block_data = nullptr, bool allow_local_only = true);
 } // namespace node
 
 #endif // BITCOIN_NODE_TRANSACTION_H

--- a/src/node/transaction.h
+++ b/src/node/transaction.h
@@ -17,7 +17,6 @@ struct Params;
 }
 
 namespace node {
-class BlockManager;
 struct NodeContext;
 
 /** Maximum fee rate for sendrawtransaction and testmempoolaccept RPC calls.
@@ -63,14 +62,16 @@ static const CAmount DEFAULT_MAX_BURN_AMOUNT{0};
  * If -txindex is available, check it next for the tx.
  * Finally, if block_index is provided, check for tx by reading entire block from disk.
  *
- * @param[in]  block_index     The block to read from disk, or nullptr
+ * @param[in]  block_index     The block to read, or nullptr
  * @param[in]  mempool         If provided, check mempool for tx
  * @param[in]  hash            The txid
- * @param[in]  blockman        Used to access and read blocks from disk
+ * @param[in]  node            Node context used to access blocks
  * @param[out] hashBlock       The block hash, if the tx was found via -txindex or block_index
+ * @param[in]  allow_block_fetch  Whether a pruned block may be fetched from a peer
+ * @param[in]  allow_local_only  Whether blocks retained for trusted local callers may be read
  * @returns                    The tx if found, otherwise nullptr
  */
-CTransactionRef GetTransaction(const CBlockIndex* block_index, const CTxMemPool* mempool, const Txid& hash, const BlockManager& blockman, uint256& hashBlock);
+CTransactionRef GetTransaction(const CBlockIndex* block_index, const CTxMemPool* mempool, const Txid& hash, const NodeContext& node, uint256& hashBlock, bool allow_block_fetch = false, bool allow_local_only = true);
 } // namespace node
 
 #endif // BITCOIN_NODE_TRANSACTION_H

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -416,8 +416,8 @@ static bool rest_block(const std::any& context,
         if (!pblockindex) {
             return RESTERR(req, HTTP_NOT_FOUND, hashStr + " not found");
         }
-        if (!(pblockindex->nStatus & BLOCK_HAVE_DATA)) {
-            if (chainman.m_blockman.IsBlockPruned(*pblockindex)) {
+        if (!(pblockindex->nStatus & BLOCK_HAVE_DATA) || (pblockindex->nStatus & BLOCK_LOCAL_ONLY)) {
+            if (chainman.m_blockman.IsBlockPruned(*pblockindex) || (pblockindex->nStatus & BLOCK_LOCAL_ONLY)) {
                 return RESTERR(req, HTTP_NOT_FOUND, hashStr + " not available (pruned data)");
             }
             return RESTERR(req, HTTP_NOT_FOUND, hashStr + " not available (not fully downloaded)");

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -855,7 +855,8 @@ static bool rest_tx(const std::any& context, HTTPRequest* req, const std::string
     const NodeContext* const node = GetNodeContext(context, req);
     if (!node) return false;
     uint256 hashBlock = uint256();
-    const CTransactionRef tx{GetTransaction(/*block_index=*/nullptr, node->mempool.get(), *hash,  node->chainman->m_blockman, hashBlock)};
+    const CTransactionRef tx{GetTransaction(/*block_index=*/nullptr, node->mempool.get(), *hash, *node, hashBlock,
+                                            /*allow_block_fetch=*/false, /*allow_local_only=*/false)};
     if (!tx) {
         return RESTERR(req, HTTP_NOT_FOUND, hashStr + " not found");
     }

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -856,7 +856,8 @@ static bool rest_tx(const std::any& context, HTTPRequest* req, const std::string
     if (!node) return false;
     uint256 hashBlock = uint256();
     const CTransactionRef tx{GetTransaction(/*block_index=*/nullptr, node->mempool.get(), *hash, *node, hashBlock,
-                                            /*allow_block_fetch=*/false, /*allow_local_only=*/false)};
+                                            /*allow_block_fetch=*/false, /*block_data=*/nullptr,
+                                            /*allow_local_only=*/false)};
     if (!tx) {
         return RESTERR(req, HTTP_NOT_FOUND, hashStr + " not found");
     }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -27,6 +27,7 @@
 #include <logging/timer.h>
 #include <net.h>
 #include <net_processing.h>
+#include <node/blockfetch.h>
 #include <node/blockstorage.h>
 #include <node/context.h>
 #include <node/transaction.h>
@@ -55,9 +56,8 @@
 #include <validationinterface.h>
 #include <versionbits.h>
 
-#include <cstdint>
-
 #include <condition_variable>
+#include <cstdint>
 #include <iterator>
 #include <memory>
 #include <mutex>
@@ -710,19 +710,29 @@ static CBlock GetBlockChecked(BlockManager& blockman, const CBlockIndex& blockin
     return block;
 }
 
-static std::vector<std::byte> GetRawBlockChecked(BlockManager& blockman, const CBlockIndex& blockindex)
+static std::vector<std::byte> GetRawBlockChecked(NodeContext& node, const CBlockIndex& blockindex)
 {
+    const bool allow_fetch{node.peerman && node.peerman->BlockFetchProxyEnabled()};
     FlatFilePos pos{};
     {
         LOCK(cs_main);
-        CheckBlockDataAvailability(blockman, blockindex, /*check_for_undo=*/false);
-        pos = blockindex.GetBlockPos();
+        if (blockindex.nStatus & BLOCK_HAVE_DATA) {
+            pos = blockindex.GetBlockPos();
+        } else if (blockindex.nTx == 0 || !allow_fetch) {
+            CheckBlockDataAvailability(Assert(node.chainman)->m_blockman, blockindex, /*check_for_undo=*/false);
+        }
     }
 
-    if (auto data{blockman.ReadRawBlock(pos)}) return std::move(*data);
-    // Block not found on disk. This shouldn't normally happen unless the block was
-    // pruned right after we released the lock above.
-    throw JSONRPCError(RPC_MISC_ERROR, "Block not found on disk");
+    if (!pos.IsNull()) {
+        if (auto data{Assert(node.chainman)->m_blockman.ReadRawBlock(pos)}) return std::move(*data);
+    }
+
+    auto block{node::ReadBlockForLocalUse(node, blockindex, allow_fetch)};
+    if (!block) throw JSONRPCError(RPC_MISC_ERROR, block.error());
+
+    DataStream stream;
+    stream << TX_WITH_WITNESS(**block);
+    return {stream.begin(), stream.end()};
 }
 
 static CBlockUndo GetUndoChecked(BlockManager& blockman, const CBlockIndex& blockindex)
@@ -855,7 +865,8 @@ static RPCMethod getblock()
 
     const CBlockIndex* pblockindex;
     const CBlockIndex* tip;
-    ChainstateManager& chainman = EnsureAnyChainman(request.context);
+    NodeContext& node{EnsureAnyNodeContext(request.context)};
+    ChainstateManager& chainman{*Assert(node.chainman)};
     {
         LOCK(cs_main);
         pblockindex = chainman.m_blockman.LookupBlockIndex(hash);
@@ -864,9 +875,14 @@ static RPCMethod getblock()
         if (!pblockindex) {
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
         }
+        // Verbosity 3 requires undo data, which the proxy cannot fetch. Check
+        // before downloading and retaining block data that cannot satisfy it.
+        if (verbosity >= 3 && pblockindex->nHeight > 0) {
+            CheckBlockDataAvailability(chainman.m_blockman, *pblockindex, /*check_for_undo=*/true);
+        }
     }
 
-    const std::vector<std::byte> block_data{GetRawBlockChecked(chainman.m_blockman, *pblockindex)};
+    const std::vector<std::byte> block_data{GetRawBlockChecked(node, *pblockindex)};
 
     if (verbosity <= 0) {
         return HexStr(block_data);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -153,7 +153,7 @@ PartiallySignedTransaction ProcessPSBT(const std::string& psbt_string, const std
         // Look in the txindex
         if (g_txindex) {
             uint256 block_hash;
-            g_txindex->FindTx(psbt_input.prev_txid, block_hash, tx);
+            if (!g_txindex->FindTx(psbt_input.prev_txid, block_hash, tx)) tx.reset();
         }
         // If we still don't have it look in the mempool
         if (!tx) {

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -153,7 +153,7 @@ PartiallySignedTransaction ProcessPSBT(const std::string& psbt_string, const std
         // Look in the txindex
         if (g_txindex) {
             uint256 block_hash;
-            if (!g_txindex->FindTx(psbt_input.prev_txid, block_hash, tx)) tx.reset();
+            if (!g_txindex->FindTx(psbt_input.prev_txid, block_hash, tx, /*allow_block_fetch=*/true)) tx.reset();
         }
         // If we still don't have it look in the mempool
         if (!tx) {
@@ -300,7 +300,7 @@ static RPCMethod getrawtransaction()
     }
 
     uint256 hash_block;
-    const CTransactionRef tx = GetTransaction(blockindex, node.mempool.get(), txid, chainman.m_blockman, hash_block);
+    const CTransactionRef tx = GetTransaction(blockindex, node.mempool.get(), txid, node, hash_block, /*allow_block_fetch=*/true);
     if (!tx) {
         std::string errmsg;
         if (blockindex) {

--- a/src/rpc/txoutproof.cpp
+++ b/src/rpc/txoutproof.cpp
@@ -9,6 +9,8 @@
 #include <index/txindex.h>
 #include <merkleblock.h>
 #include <node/blockstorage.h>
+#include <node/context.h>
+#include <node/transaction.h>
 #include <primitives/transaction.h>
 #include <rpc/blockchain.h>
 #include <rpc/server.h>
@@ -57,7 +59,8 @@ static RPCMethod gettxoutproof()
 
             const CBlockIndex* pblockindex = nullptr;
             uint256 hashBlock;
-            ChainstateManager& chainman = EnsureAnyChainman(request.context);
+            const node::NodeContext& node{EnsureAnyNodeContext(request.context)};
+            ChainstateManager& chainman{*Assert(node.chainman)};
             if (!request.params[1].isNull()) {
                 LOCK(cs_main);
                 hashBlock = ParseHashV(request.params[1], "blockhash");
@@ -86,7 +89,7 @@ static RPCMethod gettxoutproof()
             }
 
             if (pblockindex == nullptr) {
-                const CTransactionRef tx = GetTransaction(/*block_index=*/nullptr, /*mempool=*/nullptr, *setTxids.begin(), chainman.m_blockman, hashBlock);
+                const CTransactionRef tx = GetTransaction(/*block_index=*/nullptr, /*mempool=*/nullptr, *setTxids.begin(), node, hashBlock, /*allow_block_fetch=*/true);
                 if (!tx || hashBlock.IsNull()) {
                     throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction not yet in block");
                 }

--- a/src/rpc/txoutproof.cpp
+++ b/src/rpc/txoutproof.cpp
@@ -8,6 +8,8 @@
 #include <coins.h>
 #include <index/txindex.h>
 #include <merkleblock.h>
+#include <net_processing.h>
+#include <node/blockfetch.h>
 #include <node/blockstorage.h>
 #include <node/context.h>
 #include <node/transaction.h>
@@ -19,6 +21,9 @@
 #include <univalue.h>
 #include <util/strencodings.h>
 #include <validation.h>
+
+#include <memory>
+#include <utility>
 
 using node::GetTransaction;
 
@@ -59,6 +64,7 @@ static RPCMethod gettxoutproof()
 
             const CBlockIndex* pblockindex = nullptr;
             uint256 hashBlock;
+            std::shared_ptr<const CBlock> block_data;
             const node::NodeContext& node{EnsureAnyNodeContext(request.context)};
             ChainstateManager& chainman{*Assert(node.chainman)};
             if (!request.params[1].isNull()) {
@@ -89,7 +95,7 @@ static RPCMethod gettxoutproof()
             }
 
             if (pblockindex == nullptr) {
-                const CTransactionRef tx = GetTransaction(/*block_index=*/nullptr, /*mempool=*/nullptr, *setTxids.begin(), node, hashBlock, /*allow_block_fetch=*/true);
+                const CTransactionRef tx = GetTransaction(/*block_index=*/nullptr, /*mempool=*/nullptr, *setTxids.begin(), node, hashBlock, /*allow_block_fetch=*/true, &block_data);
                 if (!tx || hashBlock.IsNull()) {
                     throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction not yet in block");
                 }
@@ -101,17 +107,24 @@ static RPCMethod gettxoutproof()
                 }
             }
 
-            {
-                LOCK(cs_main);
-                CheckBlockDataAvailability(chainman.m_blockman, *pblockindex, /*check_for_undo=*/false);
-            }
-            CBlock block;
-            if (!chainman.m_blockman.ReadBlock(block, *pblockindex)) {
-                throw JSONRPCError(RPC_INTERNAL_ERROR, "Can't read block from disk");
+            if (!block_data && node.peerman && node.peerman->BlockFetchProxyEnabled()) {
+                auto fetched_block{node::ReadBlockForLocalUse(node, *pblockindex)};
+                if (!fetched_block) throw JSONRPCError(RPC_MISC_ERROR, fetched_block.error());
+                block_data = *fetched_block;
+            } else if (!block_data) {
+                {
+                    LOCK(cs_main);
+                    CheckBlockDataAvailability(chainman.m_blockman, *pblockindex, /*check_for_undo=*/false);
+                }
+                auto block{std::make_shared<CBlock>()};
+                if (!chainman.m_blockman.ReadBlock(*block, *pblockindex)) {
+                    throw JSONRPCError(RPC_INTERNAL_ERROR, "Can't read block from disk");
+                }
+                block_data = std::move(block);
             }
 
             unsigned int ntxFound = 0;
-            for (const auto& tx : block.vtx) {
+            for (const auto& tx : block_data->vtx) {
                 if (setTxids.contains(tx->GetHash())) {
                     ntxFound++;
                 }
@@ -121,7 +134,7 @@ static RPCMethod gettxoutproof()
             }
 
             DataStream ssMB{};
-            CMerkleBlock mb(block, setTxids);
+            CMerkleBlock mb(*block_data, setTxids);
             ssMB << mb;
             std::string strHex = HexStr(ssMB);
             return strHex;

--- a/src/test/blockmanager_tests.cpp
+++ b/src/test/blockmanager_tests.cpp
@@ -27,6 +27,44 @@ using node::MAX_BLOCKFILE_SIZE;
 // use BasicTestingSetup here for the data directory configuration, setup, and cleanup
 BOOST_FIXTURE_TEST_SUITE(blockmanager_tests, BasicTestingSetup)
 
+class BlockManagerTest
+{
+public:
+    static void SetBlockfileCursors(BlockManager& blockman, int normal, int assumed) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+    {
+        AssertLockHeld(cs_main);
+        blockman.m_blockfile_cursors[node::BlockfileType::NORMAL] = node::BlockfileCursor{normal};
+        blockman.m_blockfile_cursors[node::BlockfileType::ASSUMED] = node::BlockfileCursor{assumed};
+    }
+
+    static bool IsCurrentBlockfile(const BlockManager& blockman, int file_num) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+    {
+        AssertLockHeld(cs_main);
+        return blockman.IsCurrentBlockfile(file_num);
+    }
+};
+
+BOOST_AUTO_TEST_CASE(blockmanager_current_blockfiles)
+{
+    KernelNotifications notifications{Assert(m_node.shutdown_request), m_node.exit_status, *Assert(m_node.warnings)};
+    const BlockManager::Options blockman_opts{
+        .chainparams = Params(),
+        .blocks_dir = m_args.GetBlocksDirPath(),
+        .notifications = notifications,
+        .block_tree_db_params = DBParams{
+            .path = m_args.GetDataDirNet() / "blocks" / "index",
+            .cache_bytes = 0,
+        },
+    };
+    BlockManager blockman{*Assert(m_node.shutdown_signal), blockman_opts};
+
+    LOCK(cs_main);
+    BlockManagerTest::SetBlockfileCursors(blockman, /*normal=*/2, /*assumed=*/5);
+    BOOST_CHECK(BlockManagerTest::IsCurrentBlockfile(blockman, 2));
+    BOOST_CHECK(BlockManagerTest::IsCurrentBlockfile(blockman, 5));
+    BOOST_CHECK(!BlockManagerTest::IsCurrentBlockfile(blockman, 1));
+}
+
 BOOST_AUTO_TEST_CASE(blockmanager_find_block_pos)
 {
     const auto params {CreateChainParams(ArgsManager{}, ChainType::MAIN)};

--- a/src/test/fuzz/CMakeLists.txt
+++ b/src/test/fuzz/CMakeLists.txt
@@ -132,6 +132,7 @@ add_executable(fuzz
   tx_out.cpp
   tx_pool.cpp
   txgraph.cpp
+  txindex.cpp
   txorphan.cpp
   txrequest.cpp
   utxo_snapshot.cpp

--- a/src/test/fuzz/txindex.cpp
+++ b/src/test/fuzz/txindex.cpp
@@ -1,0 +1,76 @@
+// Copyright (c) 2026-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit/.
+
+#include <consensus/consensus.h>
+#include <crypto/siphash.h>
+#include <index/txindex_key.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+#include <random.h>
+#include <serialize.h>
+#include <streams.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <uint256.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <iterator>
+#include <vector>
+
+FUZZ_TARGET(txindex_position)
+{
+    FuzzedDataProvider provider{buffer.data(), buffer.size()};
+    const uint8_t shuffle_attempts{provider.ConsumeIntegralInRange<uint8_t>(0, 7)};
+    FastRandomContext rng{ConsumeUInt256(provider)};
+    const PresaltedSipHasher hasher{rng.rand64(), rng.rand64()};
+    constexpr uint32_t min_tx_size{MIN_TRANSACTION_WEIGHT / WITNESS_SCALE_FACTOR};
+    constexpr uint32_t max_tx_count{MAX_BLOCK_WEIGHT / MIN_TRANSACTION_WEIGHT};
+
+    std::vector<uint32_t> tx_sizes;
+    uint32_t remaining{MAX_BLOCK_SERIALIZED_SIZE - static_cast<uint32_t>(GetSerializeSize(CBlockHeader{})) - 9};
+    while (remaining >= min_tx_size && tx_sizes.size() < max_tx_count && provider.remaining_bytes() > 0) {
+        const uint32_t tx_size{provider.ConsumeIntegralInRange<uint32_t>(min_tx_size, remaining)};
+        tx_sizes.push_back(tx_size);
+        remaining -= tx_size;
+    }
+    if (tx_sizes.empty()) tx_sizes.push_back(min_tx_size);
+
+    for (uint8_t attempt{0}; attempt <= shuffle_attempts; ++attempt) {
+        const uint32_t height{rng.randrange(txindex::MAX_TXINDEX_BLOCK_HEIGHT + 1)};
+        const auto prefix{txindex::CreateKeyPrefix(hasher, Txid::FromUint256(rng.rand256()))};
+        std::vector<uint32_t> tx_offsets;
+        uint32_t tx_offset{static_cast<uint32_t>(GetSerializeSize(CBlockHeader{})) + GetSizeOfCompactSize(tx_sizes.size())};
+        for (const uint32_t tx_size : tx_sizes) {
+            tx_offsets.push_back(tx_offset);
+            tx_offset += tx_size;
+        }
+        assert(tx_offset <= MAX_BLOCK_SERIALIZED_SIZE);
+
+        DataStream prefix_stream;
+        prefix_stream << prefix;
+        assert(prefix_stream.size() == txindex::TxHashKeyPrefix::SERIALIZED_SIZE);
+
+        for (const uint32_t expected_offset : tx_offsets) {
+            DataStream stream;
+            stream << txindex::DBKey{prefix, txindex::BlockTxPosition{height, expected_offset}};
+            assert(stream.size() == txindex::DBKey::SERIALIZED_SIZE);
+
+            txindex::DBKey decoded{prefix, {}};
+            stream >> decoded;
+            assert(stream.empty());
+            assert(decoded.hash_prefix == prefix);
+            assert(decoded.pos.block_height == height);
+
+            const auto match{std::lower_bound(tx_offsets.begin(), tx_offsets.end(), decoded.pos.tx_offset_in_block)};
+            assert(match != tx_offsets.end());
+            assert(decoded.pos.ContainsOffset(*match));
+            assert(*match == expected_offset);
+            assert(std::next(match) == tx_offsets.end() || !decoded.pos.ContainsOffset(*std::next(match)));
+        }
+        if (attempt < shuffle_attempts) std::shuffle(tx_sizes.begin(), tx_sizes.end(), rng);
+    }
+}

--- a/src/test/txindex_tests.cpp
+++ b/src/test/txindex_tests.cpp
@@ -3,16 +3,72 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <addresstype.h>
+#include <chain.h>
 #include <chainparams.h>
+#include <common/args.h>
+#include <consensus/amount.h>
+#include <consensus/validation.h>
+#include <dbwrapper.h>
+#include <flatfile.h>
+#include <index/disktxpos.h>
 #include <index/txindex.h>
+#include <index/txindex_key.h>
 #include <interfaces/chain.h>
+#include <key.h>
+#include <node/blockstorage.h>
+#include <primitives/block.h>
+#include <script/script.h>
+#include <streams.h>
+#include <sync.h>
 #include <test/util/setup_common.h>
 #include <util/byte_units.h>
 #include <validation.h>
 
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE(txindex_tests)
+
+// Grants tests access to the otherwise non-public txindex database handle.
+class TxIndexTest
+{
+public:
+    static CDBWrapper& GetDB(const TxIndex& txindex) { return static_cast<CDBWrapper&>(txindex.GetDB()); }
+};
+
+namespace {
+
+PresaltedSipHasher ReadHasher(const CDBWrapper& db)
+{
+    std::pair<uint64_t, uint64_t> salt;
+    BOOST_REQUIRE(db.Read(std::string{"txid_hash_salt"}, salt));
+    return PresaltedSipHasher{salt.first, salt.second};
+}
+
+std::vector<txindex::BlockTxPosition> BucketPositions(CDBWrapper& db, const txindex::TxHashKeyPrefix& prefix)
+{
+    std::vector<txindex::BlockTxPosition> positions;
+    std::unique_ptr<CDBIterator> it{db.NewIterator()};
+    txindex::DBKey key{prefix, {}};
+    for (it->Seek(std::pair{txindex::DB_TXINDEX_HASHED, prefix}); it->Valid() && it->GetKey(key) && key.hash_prefix == prefix; it->Next()) {
+        positions.push_back(key.pos);
+    }
+    return positions;
+}
+
+FlatFilePos BlockFilePos(const ChainstateManager& chainman, uint32_t height)
+{
+    LOCK(cs_main);
+    const CBlockIndex* block_index{chainman.ActiveChain()[height]};
+    BOOST_REQUIRE(block_index);
+    return {block_index->nFile, block_index->nDataPos};
+}
+
+} // namespace
 
 BOOST_FIXTURE_TEST_CASE(txindex_initial_sync, TestChain100Setup)
 {
@@ -63,6 +119,138 @@ BOOST_FIXTURE_TEST_CASE(txindex_initial_sync, TestChain100Setup)
     }
 
     // shutdown sequence (c.f. Shutdown() in init.cpp)
+    txindex.Stop();
+}
+
+BOOST_FIXTURE_TEST_CASE(txindex_collision_scan_path, TestChain100Setup)
+{
+    TxIndex txindex(interfaces::MakeChain(m_node), 1_MiB, true);
+    BOOST_REQUIRE(txindex.Init());
+    txindex.Sync();
+
+    CDBWrapper& db{TxIndexTest::GetDB(txindex)};
+    const PresaltedSipHasher hasher{ReadHasher(db)};
+
+    // The first coinbase is at a lower height than the second, so its encoded
+    // position sorts first if it shares the second's prefix. Forge a colliding
+    // entry under the second coinbase's prefix pointing at the first coinbase, so
+    // looking up the second tx must scan that false positive first.
+    const Txid fake_txid{m_coinbase_txns.front()->GetHash()};
+    const Txid target_txid{m_coinbase_txns.at(1)->GetHash()};
+    const auto fake_prefix{txindex::CreateKeyPrefix(hasher, fake_txid)};
+    const auto target_prefix{txindex::CreateKeyPrefix(hasher, target_txid)};
+    // Distinct prefixes guarantee the target's bucket initially holds only the target.
+    BOOST_REQUIRE(fake_prefix != target_prefix);
+
+    // Read the first coinbase's encoded position straight from its bucket.
+    const auto fake_bucket{BucketPositions(db, fake_prefix)};
+    BOOST_REQUIRE_EQUAL(fake_bucket.size(), 1U);
+    const txindex::BlockTxPosition fake_pos{fake_bucket.front()};
+
+    db.Write(txindex::DBKey{target_prefix, fake_pos}, "");
+
+    // The target's bucket now holds the forged false positive first, then the real target.
+    const auto target_bucket{BucketPositions(db, target_prefix)};
+    BOOST_REQUIRE_EQUAL(target_bucket.size(), 2U);
+    BOOST_CHECK(target_bucket[0] == fake_pos);
+    BOOST_CHECK(target_bucket[1] != fake_pos);
+
+    CTransactionRef tx_disk;
+    uint256 block_hash;
+    BOOST_REQUIRE(txindex.FindTx(target_txid, block_hash, tx_disk));
+    BOOST_REQUIRE(tx_disk);
+    BOOST_CHECK(tx_disk->GetHash() == target_txid);
+
+    // A database created fresh by this version cannot contain legacy entries, so
+    // lookups skip the legacy fallback: drop the first coinbase's hashed entry and
+    // re-add it under the old 't' + txid schema (a physical CDiskTxPos), then
+    // confirm the lookup misses even though the legacy row exists.
+    // BlockTxPosition offsets are from the block start (header included), while
+    // the legacy CDiskTxPos.nTxOffset is measured after the header.
+    const CDiskTxPos fake_physical{BlockFilePos(*m_node.chainman, fake_pos.block_height), fake_pos.tx_offset_in_block - static_cast<uint32_t>(GetSerializeSize(CBlockHeader{}))};
+    db.Erase(txindex::DBKey{fake_prefix, fake_pos});
+    db.Write(std::make_pair(static_cast<uint8_t>('t'), fake_txid.ToUint256()), fake_physical);
+    CTransactionRef legacy_tx;
+    BOOST_CHECK(!txindex.FindTx(fake_txid, block_hash, legacy_tx));
+
+    txindex.Stop();
+}
+
+BOOST_FIXTURE_TEST_CASE(txindex_legacy_fallback, TestChain100Setup)
+{
+    // Seed the on-disk database with a legacy ('t' + txid) entry before the index
+    // is opened, as if it had been written by a pre-hashing version.
+    const Txid legacy_txid{m_coinbase_txns.front()->GetHash()};
+    // The block at height 1 holds only the coinbase, so the tx starts right after
+    // the header and the 1-byte tx count.
+    const CDiskTxPos legacy_pos{BlockFilePos(*m_node.chainman, 1), 1};
+    {
+        CDBWrapper db{DBParams{.path = gArgs.GetDataDirNet() / "indexes" / "txindex", .cache_bytes = 1_MiB}};
+        db.Write(std::make_pair(static_cast<uint8_t>('t'), legacy_txid.ToUint256()), legacy_pos);
+    }
+
+    TxIndex txindex(interfaces::MakeChain(m_node), 1_MiB, /*f_memory=*/false);
+    BOOST_REQUIRE(txindex.Init());
+    txindex.Sync();
+
+    // Drop the hashed entries so only the legacy row remains, then confirm the
+    // lookup succeeds through the fallback.
+    CDBWrapper& db{TxIndexTest::GetDB(txindex)};
+    const auto prefix{txindex::CreateKeyPrefix(ReadHasher(db), legacy_txid)};
+    const auto bucket{BucketPositions(db, prefix)};
+    BOOST_REQUIRE(!bucket.empty());
+    for (const auto& pos : bucket) db.Erase(txindex::DBKey{prefix, pos});
+
+    CTransactionRef tx_disk;
+    uint256 block_hash;
+    BOOST_REQUIRE(txindex.FindTx(legacy_txid, block_hash, tx_disk));
+    BOOST_REQUIRE(tx_disk);
+    BOOST_CHECK(tx_disk->GetHash() == legacy_txid);
+
+    txindex.Stop();
+}
+
+BOOST_FIXTURE_TEST_CASE(txindex_reorg_erases_entries, TestChain100Setup)
+{
+    TxIndex txindex(interfaces::MakeChain(m_node), 1_MiB, true);
+    BOOST_REQUIRE(txindex.Init());
+    txindex.Sync();
+
+    const CScript coinbase_script{CScript() << ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG};
+
+    // Mine a unique (non-coinbase) transaction into a new block at height 101.
+    CMutableTransaction unique_mtx{CreateValidMempoolTransaction(
+        /*input_transaction=*/m_coinbase_txns[0],
+        /*input_vout=*/0,
+        /*input_height=*/1,
+        /*input_signing_key=*/coinbaseKey,
+        /*output_destination=*/CScript() << OP_TRUE,
+        /*output_amount=*/CAmount{1 * COIN},
+        /*submit=*/false)};
+    const Txid unique_txid{MakeTransactionRef(unique_mtx)->GetHash()};
+    CreateAndProcessBlock({unique_mtx}, coinbase_script);
+    BOOST_REQUIRE(txindex.BlockUntilSyncedToCurrentChain());
+
+    CTransactionRef tx_disk;
+    uint256 block_hash;
+    BOOST_REQUIRE(txindex.FindTx(unique_txid, block_hash, tx_disk));
+    BOOST_CHECK(tx_disk->GetHash() == unique_txid);
+
+    ChainstateManager& chainman{*m_node.chainman};
+
+    // Invalidate the block holding the unique transaction, then mine a longer branch.
+    {
+        CBlockIndex* tip{WITH_LOCK(cs_main, return chainman.ActiveChain().Tip())};
+        BlockValidationState state;
+        BOOST_REQUIRE(chainman.ActiveChainstate().InvalidateBlock(state, tip));
+    }
+    CreateAndProcessBlock({}, coinbase_script);
+    CreateAndProcessBlock({}, coinbase_script);
+    BOOST_REQUIRE(txindex.BlockUntilSyncedToCurrentChain());
+
+    // The disconnected transaction's entry must have been erased.
+    BOOST_CHECK(!txindex.FindTx(unique_txid, block_hash, tx_disk));
+
     txindex.Stop();
 }
 

--- a/src/test/txindex_tests.cpp
+++ b/src/test/txindex_tests.cpp
@@ -7,6 +7,7 @@
 #include <chainparams.h>
 #include <common/args.h>
 #include <consensus/amount.h>
+#include <consensus/consensus.h>
 #include <consensus/validation.h>
 #include <dbwrapper.h>
 #include <flatfile.h>
@@ -149,13 +150,20 @@ BOOST_FIXTURE_TEST_CASE(txindex_collision_scan_path, TestChain100Setup)
     BOOST_REQUIRE_EQUAL(fake_bucket.size(), 1U);
     const txindex::BlockTxPosition fake_pos{fake_bucket.front()};
 
+    // Model the short window during a reorg where an old-branch position is
+    // resolved through the new active block at the same height. This offset is
+    // within the serialized format but beyond the test block file.
+    const txindex::BlockTxPosition stale_pos{0, MAX_BLOCK_SERIALIZED_SIZE - 1};
+    db.Write(txindex::DBKey{target_prefix, stale_pos}, "");
     db.Write(txindex::DBKey{target_prefix, fake_pos}, "");
 
-    // The target's bucket now holds the forged false positive first, then the real target.
+    // The target's bucket now holds the stale position and forged false positive
+    // before the real target.
     const auto target_bucket{BucketPositions(db, target_prefix)};
-    BOOST_REQUIRE_EQUAL(target_bucket.size(), 2U);
-    BOOST_CHECK(target_bucket[0] == fake_pos);
-    BOOST_CHECK(target_bucket[1] != fake_pos);
+    BOOST_REQUIRE_EQUAL(target_bucket.size(), 3U);
+    BOOST_CHECK(target_bucket[0] == stale_pos);
+    BOOST_CHECK(target_bucket[1] == fake_pos);
+    BOOST_CHECK(target_bucket[2] != fake_pos);
 
     CTransactionRef tx_disk;
     uint256 block_hash;

--- a/src/test/txindex_tests.cpp
+++ b/src/test/txindex_tests.cpp
@@ -24,12 +24,14 @@
 #include <util/byte_units.h>
 #include <validation.h>
 
+#include <boost/test/unit_test.hpp>
+
+#include <array>
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <utility>
 #include <vector>
-
-#include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE(txindex_tests)
 
@@ -203,6 +205,23 @@ BOOST_FIXTURE_TEST_CASE(txindex_legacy_fallback, TestChain100Setup)
 
     CTransactionRef tx_disk;
     uint256 block_hash;
+
+    // A malformed hashed row in this bucket must fail closed instead of
+    // falling through to the valid legacy row.
+    const auto malformed_key{std::pair{txindex::DB_TXINDEX_HASHED, prefix}};
+    db.Write(malformed_key, std::array<std::byte, 0>{});
+    BOOST_CHECK(!txindex.FindTx(legacy_txid, block_hash, tx_disk));
+    BOOST_CHECK(!tx_disk);
+    db.Erase(malformed_key);
+
+    // CDBIterator accepts trailing bytes after a deserialized key, so also
+    // cover an overlong hashed row before falling back to the legacy entry.
+    const auto overlong_key{std::pair{txindex::DBKey{prefix, bucket.front()}, uint8_t{0}}};
+    db.Write(overlong_key, std::array<std::byte, 0>{});
+    BOOST_CHECK(!txindex.FindTx(legacy_txid, block_hash, tx_disk));
+    BOOST_CHECK(!tx_disk);
+    db.Erase(overlong_key);
+
     BOOST_REQUIRE(txindex.FindTx(legacy_txid, block_hash, tx_disk));
     BOOST_REQUIRE(tx_disk);
     BOOST_CHECK(tx_disk->GetHash() == legacy_txid);

--- a/src/test/txindex_tests.cpp
+++ b/src/test/txindex_tests.cpp
@@ -9,6 +9,7 @@
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
 #include <consensus/validation.h>
+#include <crypto/siphash.h>
 #include <dbwrapper.h>
 #include <flatfile.h>
 #include <index/disktxpos.h>
@@ -18,18 +19,25 @@
 #include <key.h>
 #include <node/blockstorage.h>
 #include <primitives/block.h>
+#include <primitives/transaction.h>
+#include <random.h>
 #include <script/script.h>
+#include <serialize.h>
 #include <streams.h>
 #include <sync.h>
 #include <test/util/setup_common.h>
+#include <uint256.h>
 #include <util/byte_units.h>
 #include <validation.h>
 
 #include <boost/test/unit_test.hpp>
 
+#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <iterator>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -57,7 +65,7 @@ std::vector<txindex::BlockTxPosition> BucketPositions(CDBWrapper& db, const txin
     std::vector<txindex::BlockTxPosition> positions;
     std::unique_ptr<CDBIterator> it{db.NewIterator()};
     txindex::DBKey key{prefix, {}};
-    for (it->Seek(std::pair{txindex::DB_TXINDEX_HASHED, prefix}); it->Valid() && it->GetKey(key) && key.hash_prefix == prefix; it->Next()) {
+    for (it->Seek(prefix); it->Valid() && it->GetKey(key) && key.hash_prefix == prefix; it->Next()) {
         positions.push_back(key.pos);
     }
     return positions;
@@ -71,7 +79,81 @@ FlatFilePos BlockFilePos(const ChainstateManager& chainman, uint32_t height)
     return {block_index->nFile, block_index->nDataPos};
 }
 
+void CheckPositionEncoding(const std::vector<uint32_t>& tx_sizes, uint32_t height, const txindex::TxHashKeyPrefix& prefix)
+{
+    std::vector<uint32_t> tx_offsets;
+    uint32_t tx_offset{static_cast<uint32_t>(GetSerializeSize(CBlockHeader{})) + GetSizeOfCompactSize(tx_sizes.size())};
+    for (const uint32_t tx_size : tx_sizes) {
+        tx_offsets.push_back(tx_offset);
+        tx_offset += tx_size;
+    }
+    BOOST_REQUIRE_LE(tx_offset, MAX_BLOCK_SERIALIZED_SIZE);
+
+    DataStream prefix_stream;
+    prefix_stream << prefix;
+    BOOST_CHECK_EQUAL(prefix_stream.size(), txindex::TxHashKeyPrefix::SERIALIZED_SIZE);
+
+    for (const uint32_t expected_offset : tx_offsets) {
+        DataStream stream;
+        stream << txindex::DBKey{prefix, txindex::BlockTxPosition{height, expected_offset}};
+        BOOST_CHECK_EQUAL(stream.size(), txindex::DBKey::SERIALIZED_SIZE);
+
+        txindex::DBKey decoded{prefix, {}};
+        stream >> decoded;
+        BOOST_CHECK(stream.empty());
+        BOOST_CHECK(decoded.hash_prefix == prefix);
+        BOOST_CHECK_EQUAL(decoded.pos.block_height, height);
+
+        const auto match{std::lower_bound(tx_offsets.begin(), tx_offsets.end(), decoded.pos.tx_offset_in_block)};
+        BOOST_REQUIRE(match != tx_offsets.end());
+        BOOST_CHECK(decoded.pos.ContainsOffset(*match));
+        BOOST_CHECK_EQUAL(*match, expected_offset);
+        BOOST_CHECK(std::next(match) == tx_offsets.end() || !decoded.pos.ContainsOffset(*std::next(match)));
+    }
+}
+
+void CheckRandomPositionEncoding(uint32_t generate_attempts, uint32_t shuffle_attempts)
+{
+    FastRandomContext rng{/*fDeterministic=*/true};
+    const PresaltedSipHasher hasher{rng.rand64(), rng.rand64()};
+    constexpr uint32_t min_tx_size{MIN_TRANSACTION_WEIGHT / WITNESS_SCALE_FACTOR};
+    constexpr uint32_t typical_max_tx_size{10'000};
+
+    for (uint32_t generate{0}; generate < generate_attempts; ++generate) {
+        std::vector<uint32_t> tx_sizes;
+        uint32_t remaining{MAX_BLOCK_SERIALIZED_SIZE - static_cast<uint32_t>(GetSerializeSize(CBlockHeader{})) - 9};
+        const uint32_t generated_max_tx_size{rng.randbool() ? typical_max_tx_size : remaining};
+        while (remaining >= min_tx_size) {
+            const uint32_t max_tx_size{std::min(remaining, generated_max_tx_size)};
+            const uint32_t tx_size{min_tx_size + rng.randrange(max_tx_size - min_tx_size + 1)};
+            tx_sizes.push_back(tx_size);
+            remaining -= tx_size;
+        }
+
+        for (uint32_t shuffle{0}; shuffle <= shuffle_attempts; ++shuffle) {
+            const auto prefix{txindex::CreateKeyPrefix(hasher, Txid::FromUint256(rng.rand256()))};
+            CheckPositionEncoding(tx_sizes, rng.randrange(txindex::MAX_TXINDEX_BLOCK_HEIGHT + 1), prefix);
+            if (shuffle < shuffle_attempts) std::shuffle(tx_sizes.begin(), tx_sizes.end(), rng);
+        }
+    }
+}
+
 } // namespace
+
+BOOST_AUTO_TEST_CASE(txindex_position_encoding)
+{
+    CheckRandomPositionEncoding(/*generate_attempts=*/10, /*shuffle_attempts=*/4);
+
+    constexpr uint32_t min_tx_size{MIN_TRANSACTION_WEIGHT / WITNESS_SCALE_FACTOR};
+    const uint32_t first_tx_size{MAX_BLOCK_SERIALIZED_SIZE - static_cast<uint32_t>(GetSerializeSize(CBlockHeader{})) - GetSizeOfCompactSize(2) - min_tx_size};
+    for (uint8_t tag{txindex::DB_TXINDEX_HASHED}; tag < txindex::DB_TXINDEX_HASHED + txindex::DB_TXINDEX_HASHED_COUNT; ++tag) {
+        CheckPositionEncoding({first_tx_size, min_tx_size}, txindex::MAX_TXINDEX_BLOCK_HEIGHT, txindex::TxHashKeyPrefix{tag});
+    }
+
+    DataStream stream;
+    const txindex::DBKey overflow_key{txindex::TxHashKeyPrefix{}, txindex::BlockTxPosition{txindex::MAX_TXINDEX_BLOCK_HEIGHT + 1, 0}};
+    BOOST_CHECK_THROW(stream << overflow_key, std::ios_base::failure);
+}
 
 BOOST_FIXTURE_TEST_CASE(txindex_initial_sync, TestChain100Setup)
 {
@@ -177,7 +259,7 @@ BOOST_FIXTURE_TEST_CASE(txindex_collision_scan_path, TestChain100Setup)
     // confirm the lookup misses even though the legacy row exists.
     // BlockTxPosition offsets are from the block start (header included), while
     // the legacy CDiskTxPos.nTxOffset is measured after the header.
-    const CDiskTxPos fake_physical{BlockFilePos(*m_node.chainman, fake_pos.block_height), fake_pos.tx_offset_in_block - static_cast<uint32_t>(GetSerializeSize(CBlockHeader{}))};
+    const CDiskTxPos fake_physical{BlockFilePos(*m_node.chainman, fake_pos.block_height), static_cast<uint32_t>(GetSizeOfCompactSize(1))};
     db.Erase(txindex::DBKey{fake_prefix, fake_pos});
     db.Write(std::make_pair(static_cast<uint8_t>('t'), fake_txid.ToUint256()), fake_physical);
     CTransactionRef legacy_tx;
@@ -216,7 +298,7 @@ BOOST_FIXTURE_TEST_CASE(txindex_legacy_fallback, TestChain100Setup)
 
     // A malformed hashed row in this bucket must fail closed instead of
     // falling through to the valid legacy row.
-    const auto malformed_key{std::pair{txindex::DB_TXINDEX_HASHED, prefix}};
+    const auto malformed_key{prefix};
     db.Write(malformed_key, std::array<std::byte, 0>{});
     BOOST_CHECK(!txindex.FindTx(legacy_txid, block_hash, tx_disk));
     BOOST_CHECK(!tx_disk);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3778,7 +3778,7 @@ void Chainstate::TryAddBlockIndexCandidate(CBlockIndex* pindex)
 }
 
 /** Mark a block as having its data received and checked (up to BLOCK_VALID_TRANSACTIONS). */
-void ChainstateManager::ReceivedBlockTransactions(const CBlock& block, CBlockIndex* pindexNew, const FlatFilePos& pos)
+void ChainstateManager::ReceivedBlockTransactions(const CBlock& block, CBlockIndex* pindexNew, const FlatFilePos& pos, bool local_only)
 {
     AssertLockHeld(cs_main);
     pindexNew->nTx = block.vtx.size();
@@ -3798,6 +3798,11 @@ void ChainstateManager::ReceivedBlockTransactions(const CBlock& block, CBlockInd
     pindexNew->nDataPos = pos.nPos;
     pindexNew->nUndoPos = 0;
     pindexNew->nStatus |= BLOCK_HAVE_DATA;
+    if (local_only) {
+        pindexNew->nStatus |= BLOCK_LOCAL_ONLY;
+    } else {
+        pindexNew->nStatus &= ~BLOCK_LOCAL_ONLY;
+    }
     if (DeploymentActiveAt(*pindexNew, *this, Consensus::DEPLOYMENT_SEGWIT)) {
         pindexNew->nStatus |= BLOCK_OPT_WITNESS;
     }
@@ -4311,7 +4316,7 @@ void ChainstateManager::ReportHeadersPresync(int64_t height, int64_t timestamp)
 }
 
 /** Store block on disk. If dbp is non-nullptr, the file is known to already reside on disk */
-bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, BlockValidationState& state, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock, bool min_pow_checked)
+bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, BlockValidationState& state, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock, bool min_pow_checked, bool local_only)
 {
     const CBlock& block = *pblock;
 
@@ -4374,7 +4379,7 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
 
     // Header is valid/has work, merkle tree and segwit merkle tree are good...RELAY NOW
     // (but if it does not build on our best tip, let the SendMessages loop relay it)
-    if (!IsInitialBlockDownload() && ActiveTip() == pindex->pprev && m_options.signals) {
+    if (!local_only && !IsInitialBlockDownload() && ActiveTip() == pindex->pprev && m_options.signals) {
         m_options.signals->NewPoWValidBlock(pindex, pblock);
     }
 
@@ -4392,7 +4397,7 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
                 return false;
             }
         }
-        ReceivedBlockTransactions(block, pindex, blockPos);
+        ReceivedBlockTransactions(block, pindex, blockPos, local_only);
     } catch (const std::runtime_error& e) {
         return FatalError(GetNotifications(), state, strprintf(_("System error while saving block to disk: %s"), e.what()));
     }
@@ -4418,7 +4423,7 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
     return true;
 }
 
-bool ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& block, bool force_processing, bool min_pow_checked, bool* new_block)
+bool ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& block, bool force_processing, bool min_pow_checked, bool* new_block, bool local_only)
 {
     AssertLockNotHeld(cs_main);
 
@@ -4439,7 +4444,7 @@ bool ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& blo
         bool ret = CheckBlock(*block, state, GetConsensus());
         if (ret) {
             // Store to disk
-            ret = AcceptBlock(block, state, &pindex, force_processing, nullptr, new_block, min_pow_checked);
+            ret = AcceptBlock(block, state, &pindex, force_processing, nullptr, new_block, min_pow_checked, local_only);
         }
         if (!ret) {
             if (m_options.signals) {

--- a/src/validation.h
+++ b/src/validation.h
@@ -1266,7 +1266,7 @@ public:
      * @param[out]  new_block A boolean which is set to indicate if the block was first received via this call
      * @returns     If the block was processed, independently of block validity
      */
-    bool ProcessNewBlock(const std::shared_ptr<const CBlock>& block, bool force_processing, bool min_pow_checked, bool* new_block) LOCKS_EXCLUDED(cs_main);
+    bool ProcessNewBlock(const std::shared_ptr<const CBlock>& block, bool force_processing, bool min_pow_checked, bool* new_block, bool local_only = false) LOCKS_EXCLUDED(cs_main);
 
     /**
      * Process incoming block headers.
@@ -1301,9 +1301,9 @@ public:
      *
      * @returns   False if the block or header is invalid, or if saving to disk fails (likely a fatal error); true otherwise.
      */
-    bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, BlockValidationState& state, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock, bool min_pow_checked) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, BlockValidationState& state, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock, bool min_pow_checked, bool local_only = false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
-    void ReceivedBlockTransactions(const CBlock& block, CBlockIndex* pindexNew, const FlatFilePos& pos) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    void ReceivedBlockTransactions(const CBlock& block, CBlockIndex* pindexNew, const FlatFilePos& pos, bool local_only = false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     /**
      * Try to add a transaction to the memory pool.

--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <blockfilter.h>
 #include <core_io.h>
 #include <key_io.h>
 #include <policy/rbf.h>
@@ -896,7 +897,14 @@ RPCMethod rescanblockchain()
             }
         }
 
-        // We can't rescan unavailable blocks, stop and throw an error
+        // We can't rescan unavailable blocks, stop and throw an error. Fetching
+        // pruned blocks is only practical when compact filters select them.
+        const bool blocks_on_disk{pwallet->chain().hasBlocks(pwallet->GetLastBlockHash(), start_height, stop_height, /*allow_fetch=*/false)};
+        if (!blocks_on_disk &&
+            pwallet->chain().hasBlocks(pwallet->GetLastBlockHash(), start_height, stop_height, /*allow_fetch=*/true) &&
+            !pwallet->chain().hasBlockFilterIndex(BlockFilterType::BASIC)) {
+            throw JSONRPCError(RPC_MISC_ERROR, "Block fetch proxy wallet rescans require -blockfilterindex=1");
+        }
         if (!pwallet->chain().hasBlocks(pwallet->GetLastBlockHash(), start_height, stop_height)) {
             if (pwallet->chain().havePruned() && pwallet->chain().getPruneHeight() >= start_height) {
                 throw JSONRPCError(RPC_MISC_ERROR, "Can't rescan beyond pruned data. Use RPC call getblockchaininfo to determine your pruned height.");

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1894,11 +1894,20 @@ CWallet::ScanResult CWallet::ScanForWalletTransactions(const uint256& start_bloc
     std::unique_ptr<FastWalletRescanFilter> fast_rescan_filter;
     if (chain().hasBlockFilterIndex(BlockFilterType::BASIC)) fast_rescan_filter = std::make_unique<FastWalletRescanFilter>(*this);
 
+    uint256 tip_hash{WITH_LOCK(cs_wallet, return GetLastBlockHash())};
+    const bool fetch_required{!chain().hasBlocks(tip_hash, start_height, max_height, /*allow_fetch=*/false) &&
+                              chain().hasBlocks(tip_hash, start_height, max_height, /*allow_fetch=*/true)};
+    if (fetch_required && !fast_rescan_filter) {
+        WalletLogPrintf("Block fetch proxy wallet rescans require -blockfilterindex=1\n");
+        result.last_failed_block = start_block;
+        result.status = ScanResult::FAILURE;
+        return result;
+    }
+
     WalletLogPrintf("Rescan started from block %s... (%s)\n", start_block.ToString(),
                     fast_rescan_filter ? "fast variant using block filters" : "slow variant inspecting all blocks");
 
     ShowProgress(strprintf("[%s] %s", DisplayName(), _("Rescanning…")), 0); // show rescan progress in GUI as dialog or on splashscreen, if rescan required on startup (e.g. due to corruption)
-    uint256 tip_hash = WITH_LOCK(cs_wallet, return GetLastBlockHash());
     uint256 end_hash = tip_hash;
     if (max_height) chain().findAncestorByHeight(tip_hash, *max_height, FoundBlock().hash(end_hash));
     double progress_begin = chain().guessVerificationProgress(block_hash);
@@ -1935,6 +1944,11 @@ CWallet::ScanResult CWallet::ScanForWalletTransactions(const uint256& start_bloc
                 }
             } else {
                 LogDebug(BCLog::SCAN, "Fast rescan: inspect block %d [%s] (WARNING: block filter not found!)\n", block_height, block_hash.ToString());
+                if (!chain().hasBlocks(block_hash, block_height, block_height, /*allow_fetch=*/false)) {
+                    result.last_failed_block = block_hash;
+                    result.status = ScanResult::FAILURE;
+                    break;
+                }
             }
         }
 
@@ -3277,34 +3291,36 @@ bool CWallet::AttachChain(const std::shared_ptr<CWallet>& walletInstance, interf
             }
         }
 
-        // Technically we could execute the code below in any case, but performing the
-        // `while` loop below can make startup very slow, so only check blocks on disk
-        // if necessary.
+        // Technically we could execute the code below in any case, but checking
+        // block availability can make startup slow, so only do it if necessary.
         if (chain.havePruned() || chain.hasAssumedValidChain()) {
-            int block_height = *tip_height;
-            while (block_height > 0 && chain.haveBlockOnDisk(block_height - 1) && rescan_height != block_height) {
-                --block_height;
-            }
+            // Wallet loading runs before peers are available, so remote
+            // fetchability cannot satisfy this startup rescan.
+            if (!chain.hasBlocks(chain.getBlockHash(*tip_height), rescan_height, *tip_height, /*allow_fetch=*/false)) {
+                int block_height = *tip_height;
+                while (block_height > 0 && chain.haveBlockOnDisk(block_height - 1) && rescan_height != block_height) {
+                    --block_height;
+                }
+                if (rescan_height != block_height) {
+                    // We can't rescan beyond blocks we don't have data for, stop and throw an error.
+                    // This might happen if a user uses an old wallet within a pruned node
+                    // or if they ran -disablewallet for a longer time, then decided to re-enable
+                    // Exit early and print an error.
+                    // It also may happen if an assumed-valid chain is in use and therefore not
+                    // all block data is available.
+                    // If a block is pruned after this check, we will load the wallet,
+                    // but fail the rescan with a generic error.
 
-            if (rescan_height != block_height) {
-                // We can't rescan beyond blocks we don't have data for, stop and throw an error.
-                // This might happen if a user uses an old wallet within a pruned node
-                // or if they ran -disablewallet for a longer time, then decided to re-enable
-                // Exit early and print an error.
-                // It also may happen if an assumed-valid chain is in use and therefore not
-                // all block data is available.
-                // If a block is pruned after this check, we will load the wallet,
-                // but fail the rescan with a generic error.
-
-                error = chain.havePruned() ?
-                     _("Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of a pruned node)") :
-                     strprintf(_(
-                        "Error loading wallet. Wallet requires blocks to be downloaded, "
-                        "and software does not currently support loading wallets while "
-                        "blocks are being downloaded out of order when using assumeutxo "
-                        "snapshots. Wallet should be able to load successfully after "
-                        "node sync reaches height %s"), block_height);
-                return false;
+                    error = chain.havePruned() ?
+                         _("Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of a pruned node)") :
+                         strprintf(_(
+                            "Error loading wallet. Wallet requires blocks to be downloaded, "
+                            "and software does not currently support loading wallets while "
+                            "blocks are being downloaded out of order when using assumeutxo "
+                            "snapshots. Wallet should be able to load successfully after "
+                            "node sync reaches height %s"), block_height);
+                    return false;
+                }
             }
         }
 

--- a/test/functional/feature_blockfetchproxy.py
+++ b/test/functional/feature_blockfetchproxy.py
@@ -23,6 +23,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
+    sync_txindex,
 )
 
 
@@ -30,7 +31,7 @@ class BlockFetchProxyTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
         self.extra_args = [
-            ["-fastprune", "-prune=1", "-blockfetchproxy", "-rest", "-whitelist=noban@127.0.0.1"],
+            ["-fastprune", "-prune=1", "-blockfetchproxy", "-rest", "-txindex", "-whitelist=noban@127.0.0.1"],
             [],
         ]
 
@@ -50,8 +51,11 @@ class BlockFetchProxyTest(BitcoinTestFramework):
 
         self.log.info("Build enough history to prune an old block")
         self.generate(self.nodes[1], 400)
-        block_hashes = [self.nodes[1].getblockhash(height) for height in range(2, 4)]
+        block_hashes = [self.nodes[1].getblockhash(height) for height in range(2, 5)]
         raw_blocks = [self.nodes[1].getblock(block_hash, 0) for block_hash in block_hashes]
+        txids = [self.nodes[1].getblock(block_hash)["tx"][0] for block_hash in block_hashes]
+        raw_txs = [self.nodes[1].getrawtransaction(txid, 0, block_hash) for txid, block_hash in zip(txids, block_hashes)]
+        sync_txindex(self, self.nodes[0])
         assert_equal(self.nodes[0].pruneblockchain(300), 249)
 
         self.log.info("Do not fetch when requested verbosity requires undo data")
@@ -65,11 +69,16 @@ class BlockFetchProxyTest(BitcoinTestFramework):
         with self.nodes[0].assert_debug_log(expected_msgs=[], unexpected_msgs=[f"Requesting block {block_hashes[0]} from peer="]):
             assert_equal(self.nodes[0].getblock(block_hashes[0], 0), raw_blocks[0])
 
+        self.log.info("Use txindex to locate and read a transaction in a pruned block")
+        with self.nodes[0].assert_debug_log([f"Requesting block {block_hashes[1]} from peer="]):
+            assert_equal(self.nodes[0].getrawtransaction(txids[1]), raw_txs[1])
+
         self.log.info("Do not serve retained local-only blocks to peers")
         peer = self.nodes[0].add_p2p_connection(P2PInterface())
         peer.send_and_ping(msg_getdata([CInv(MSG_BLOCK, int(block_hashes[0], 16))]))
         assert "block" not in peer.last_message
         assert_equal(rest_status(f"/rest/block/{block_hashes[0]}.bin"), 404)
+        assert_equal(rest_status(f"/rest/tx/{txids[1]}.bin"), 404)
 
         self.log.info("Read the retained block without a peer and after restart")
         self.disconnect_nodes(0, 1)
@@ -79,13 +88,17 @@ class BlockFetchProxyTest(BitcoinTestFramework):
         peer = self.nodes[0].add_p2p_connection(P2PInterface())
         peer.send_and_ping(msg_getdata([CInv(MSG_BLOCK, int(block_hashes[0], 16))]))
         assert "block" not in peer.last_message
-        assert_raises_rpc_error(-1, "No outbound full-history peer has the requested block", self.nodes[0].getblock, block_hashes[1], 0)
+        assert_raises_rpc_error(-1, "No outbound full-history peer has the requested block", self.nodes[0].getblock, block_hashes[2], 0)
 
         self.log.info("Require prune mode for the opt-in proxy")
         self.stop_node(1)
         self.nodes[1].assert_start_raises_init_error(
             extra_args=["-blockfetchproxy"],
             expected_msg="Error: -blockfetchproxy requires prune mode.",
+        )
+        self.nodes[1].assert_start_raises_init_error(
+            extra_args=["-prune=1", "-txindex"],
+            expected_msg="Error: Prune mode with -txindex requires -blockfetchproxy.",
         )
         self.log.info("Interrupt a stalled local fetch promptly during shutdown")
         staller = self.nodes[0].add_outbound_p2p_connection(P2PInterface(), p2p_idx=0)

--- a/test/functional/feature_blockfetchproxy.py
+++ b/test/functional/feature_blockfetchproxy.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test persistent local-only reads of pruned blocks."""
+
+import http.client
+import time
+import urllib.parse
+from concurrent.futures import ThreadPoolExecutor
+
+from test_framework.messages import (
+    CBlock,
+    CBlockHeader,
+    CInv,
+    MSG_BLOCK,
+    from_hex,
+    msg_getdata,
+    msg_headers,
+)
+from test_framework.p2p import P2PInterface
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+)
+
+
+class BlockFetchProxyTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.extra_args = [
+            ["-fastprune", "-prune=1", "-blockfetchproxy", "-rest", "-whitelist=noban@127.0.0.1"],
+            [],
+        ]
+
+    def setup_network(self):
+        self.setup_nodes()
+        self.connect_nodes(0, 1)
+
+    def run_test(self):
+        node_url = urllib.parse.urlparse(self.nodes[0].url)
+
+        def rest_status(path):
+            connection = http.client.HTTPConnection(node_url.hostname, node_url.port)
+            connection.request("GET", path)
+            response = connection.getresponse()
+            response.read()
+            return response.status
+
+        self.log.info("Build enough history to prune an old block")
+        self.generate(self.nodes[1], 400)
+        block_hashes = [self.nodes[1].getblockhash(height) for height in range(2, 4)]
+        raw_blocks = [self.nodes[1].getblock(block_hash, 0) for block_hash in block_hashes]
+        assert_equal(self.nodes[0].pruneblockchain(300), 249)
+
+        self.log.info("Do not fetch when requested verbosity requires undo data")
+        with self.nodes[0].assert_debug_log(expected_msgs=[], unexpected_msgs=[f"Requesting block {block_hashes[1]} from peer="]):
+            assert_raises_rpc_error(-1, "Undo data not available", self.nodes[0].getblock, block_hashes[1], 3)
+
+        self.log.info("Fetch a pruned block for a local RPC and retain it on disk")
+        with self.nodes[0].assert_debug_log([f"Requesting block {block_hashes[0]} from peer="]):
+            assert_equal(self.nodes[0].getblock(block_hashes[0], 0), raw_blocks[0])
+        self.nodes[0].pruneblockchain(300)
+        with self.nodes[0].assert_debug_log(expected_msgs=[], unexpected_msgs=[f"Requesting block {block_hashes[0]} from peer="]):
+            assert_equal(self.nodes[0].getblock(block_hashes[0], 0), raw_blocks[0])
+
+        self.log.info("Do not serve retained local-only blocks to peers")
+        peer = self.nodes[0].add_p2p_connection(P2PInterface())
+        peer.send_and_ping(msg_getdata([CInv(MSG_BLOCK, int(block_hashes[0], 16))]))
+        assert "block" not in peer.last_message
+        assert_equal(rest_status(f"/rest/block/{block_hashes[0]}.bin"), 404)
+
+        self.log.info("Read the retained block without a peer and after restart")
+        self.disconnect_nodes(0, 1)
+        assert_equal(self.nodes[0].getblock(block_hashes[0], 0), raw_blocks[0])
+        self.restart_node(0)
+        assert_equal(self.nodes[0].getblock(block_hashes[0], 0), raw_blocks[0])
+        peer = self.nodes[0].add_p2p_connection(P2PInterface())
+        peer.send_and_ping(msg_getdata([CInv(MSG_BLOCK, int(block_hashes[0], 16))]))
+        assert "block" not in peer.last_message
+        assert_raises_rpc_error(-1, "No outbound full-history peer has the requested block", self.nodes[0].getblock, block_hashes[1], 0)
+
+        self.log.info("Require prune mode for the opt-in proxy")
+        self.stop_node(1)
+        self.nodes[1].assert_start_raises_init_error(
+            extra_args=["-blockfetchproxy"],
+            expected_msg="Error: -blockfetchproxy requires prune mode.",
+        )
+        self.log.info("Interrupt a stalled local fetch promptly during shutdown")
+        staller = self.nodes[0].add_outbound_p2p_connection(P2PInterface(), p2p_idx=0)
+        staller_id = self.nodes[0].getpeerinfo()[-1]["id"]
+        stalled_hash = block_hashes[-1]
+        old_header = CBlockHeader(from_hex(CBlock(), raw_blocks[-1]))
+        staller.send_and_ping(msg_headers([old_header]))
+        fetch_rpc = self.nodes[0].create_new_rpc_connection(mode="AUTHPROXY", client_timeout=60)
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            request = executor.submit(fetch_rpc.getblock, stalled_hash, 0)
+            staller.wait_until(lambda: any(inv.hash == int(stalled_hash, 16) for inv in staller.last_message.get("getdata", msg_getdata()).inv))
+            assert_raises_rpc_error(
+                -1,
+                "Block is already requested for local use",
+                self.nodes[0].getblockfrompeer,
+                stalled_hash,
+                staller_id,
+            )
+            start = time.monotonic()
+            self.stop_node(0)
+            assert time.monotonic() - start < 10
+            assert request.exception(timeout=5) is not None
+
+
+if __name__ == "__main__":
+    BlockFetchProxyTest(__file__).main()

--- a/test/functional/feature_blockfetchproxy.py
+++ b/test/functional/feature_blockfetchproxy.py
@@ -51,7 +51,7 @@ class BlockFetchProxyTest(BitcoinTestFramework):
 
         self.log.info("Build enough history to prune an old block")
         self.generate(self.nodes[1], 400)
-        block_hashes = [self.nodes[1].getblockhash(height) for height in range(2, 5)]
+        block_hashes = [self.nodes[1].getblockhash(height) for height in range(2, 6)]
         raw_blocks = [self.nodes[1].getblock(block_hash, 0) for block_hash in block_hashes]
         txids = [self.nodes[1].getblock(block_hash)["tx"][0] for block_hash in block_hashes]
         raw_txs = [self.nodes[1].getrawtransaction(txid, 0, block_hash) for txid, block_hash in zip(txids, block_hashes)]
@@ -73,6 +73,14 @@ class BlockFetchProxyTest(BitcoinTestFramework):
         with self.nodes[0].assert_debug_log([f"Requesting block {block_hashes[1]} from peer="]):
             assert_equal(self.nodes[0].getrawtransaction(txids[1]), raw_txs[1])
 
+        self.log.info("Build a transaction proof without fetching its block twice")
+        request_log = f"Requesting block {block_hashes[2]} from peer="
+        requests_before = self.nodes[0].debug_log_path.read_text(encoding="utf-8").count(request_log)
+        with self.nodes[0].assert_debug_log([request_log]):
+            assert_equal(self.nodes[0].gettxoutproof([txids[2]]), self.nodes[1].gettxoutproof([txids[2]], block_hashes[2]))
+        requests_after = self.nodes[0].debug_log_path.read_text(encoding="utf-8").count(request_log)
+        assert_equal(requests_after - requests_before, 1)
+
         self.log.info("Do not serve retained local-only blocks to peers")
         peer = self.nodes[0].add_p2p_connection(P2PInterface())
         peer.send_and_ping(msg_getdata([CInv(MSG_BLOCK, int(block_hashes[0], 16))]))
@@ -88,7 +96,7 @@ class BlockFetchProxyTest(BitcoinTestFramework):
         peer = self.nodes[0].add_p2p_connection(P2PInterface())
         peer.send_and_ping(msg_getdata([CInv(MSG_BLOCK, int(block_hashes[0], 16))]))
         assert "block" not in peer.last_message
-        assert_raises_rpc_error(-1, "No outbound full-history peer has the requested block", self.nodes[0].getblock, block_hashes[2], 0)
+        assert_raises_rpc_error(-1, "No outbound full-history peer has the requested block", self.nodes[0].getblock, block_hashes[3], 0)
 
         self.log.info("Require prune mode for the opt-in proxy")
         self.stop_node(1)

--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -124,7 +124,7 @@ class PruneTest(BitcoinTestFramework):
             extra_args=['-prune=549'],
         )
         self.nodes[0].assert_start_raises_init_error(
-            expected_msg='Error: Prune mode is incompatible with -txindex.',
+            expected_msg='Error: Prune mode with -txindex requires -blockfetchproxy.',
             extra_args=['-prune=550', '-txindex'],
         )
         self.nodes[0].assert_start_raises_init_error(

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -88,6 +88,7 @@ EXTENDED_SCRIPTS = [
     # These tests are not run by default.
     # Longest test should go first, to favor running tests in parallel
     'feature_pruning.py',
+    'feature_blockfetchproxy.py',
     'feature_dbcrash.py',
     'feature_index_prune.py',
 ]

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -172,6 +172,7 @@ BASE_SCRIPTS = [
     'p2p_compactblocks_blocksonly.py',
     'wallet_hd.py',
     'wallet_blank.py',
+    'wallet_blockfetchproxy.py',
     'wallet_keypool_topup.py',
     'wallet_fast_rescan.py',
     'wallet_gethdkeys.py',

--- a/test/functional/wallet_blockfetchproxy.py
+++ b/test/functional/wallet_blockfetchproxy.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test restoring a known descriptor by fetching matching pruned blocks."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than,
+    assert_raises_rpc_error,
+)
+
+
+class WalletBlockFetchProxyTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.extra_args = [
+            ["-fastprune", "-prune=1", "-blockfetchproxy", "-blockfilterindex=1", "-txindex"],
+            ["-fastprune"],
+        ]
+
+    def setup_network(self):
+        self.setup_nodes()
+        self.connect_nodes(0, 1)
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        source_wallet = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
+        funding_wallet = self.nodes[1].get_wallet_rpc(self.default_wallet_name)
+
+        address = source_wallet.getnewaddress()
+        descriptor = source_wallet.getaddressinfo(address)["desc"]
+        payment_txid = funding_wallet.sendtoaddress(address, 1)
+        payment_hash = self.generate(self.nodes[1], 1)[0]
+        payment_block = self.nodes[1].getblock(payment_hash)
+        payment_height = payment_block["height"]
+        payment_time = payment_block["time"]
+        spend_txid = source_wallet.sendall([funding_wallet.getnewaddress()])["txid"]
+        self.sync_mempools()
+        self.generate(self.nodes[1], 1)
+        spend_hash = source_wallet.gettransaction(spend_txid)["blockhash"]
+
+        self.log.info("Build enough history to prune the payment block")
+        self.generate(self.nodes[1], 398)
+        self.wait_until(lambda: all(index["synced"] for index in self.nodes[0].getindexinfo().values()))
+        assert_greater_than(self.nodes[0].pruneblockchain(300), payment_height)
+
+        self.log.info("Restore fully spent history for a known descriptor")
+        self.nodes[0].createwallet("restored", disable_private_keys=True, blank=True)
+        restored_wallet = self.nodes[0].get_wallet_rpc("restored")
+        request_log = "Requesting block "
+        requests_before = self.nodes[0].debug_log_path.read_text(encoding="utf-8").count(request_log)
+        with self.nodes[0].assert_debug_log([
+            f"Requesting block {payment_hash} from peer=",
+            f"Requesting block {spend_hash} from peer=",
+        ]):
+            result = restored_wallet.importdescriptors([{"desc": descriptor, "timestamp": payment_time}])
+        requests_after = self.nodes[0].debug_log_path.read_text(encoding="utf-8").count(request_log)
+        assert_equal(result[0]["success"], True)
+        assert_equal(requests_after - requests_before, 2)
+        assert_equal(restored_wallet.gettransaction(payment_txid)["txid"], payment_txid)
+        assert_equal(restored_wallet.gettransaction(spend_txid)["txid"], spend_txid)
+        assert_equal(restored_wallet.getbalance(), 0)
+
+        self.log.info("Require compact filters for fetch-backed wallet rescans")
+        self.restart_node(1, extra_args=["-fastprune", "-prune=1", "-blockfetchproxy"])
+        funding_wallet = self.nodes[1].get_wallet_rpc(self.default_wallet_name)
+        assert_greater_than(self.nodes[1].pruneblockchain(300), payment_height)
+        assert_raises_rpc_error(
+            -1,
+            "Block fetch proxy wallet rescans require -blockfilterindex=1",
+            funding_wallet.rescanblockchain,
+            0,
+            payment_height,
+        )
+
+
+if __name__ == "__main__":
+    WalletBlockFetchProxyTest(__file__).main()


### PR DESCRIPTION
**Problem:** Pruned nodes cannot use `-txindex`, and authenticated RPC and wallet operations cannot directly read historical blocks after their files are deleted.
The height-based txindex layout in #35531 can identify the containing active-chain block independently of its old file position, but txindex still cannot retrieve missing block data for the lookup.
Similarly, compact filters can identify blocks matching known wallet descriptors, but a rescan cannot inspect a matching block once it has been pruned.

**Fix:** Add the opt-in `-blockfetchproxy` option for pruned nodes.
When a trusted local RPC, txindex lookup, or wallet rescan needs a previously processed active-chain block that is no longer on disk, request it from an outbound full-history peer and store it through the normal block-file path.
Requests for the same hash are coalesced and at most four distinct historical blocks can be requested concurrently.
`getblock`, `getrawtransaction`, `gettxoutproof`, txindex lookups, and wallet reads use retained data first and fetch only when needed.

**Privacy and storage:** Fetched blocks carry a persistent local-only marker and are excluded from P2P block serving, inventory, compact-block transaction serving, recent-block caches, and unauthenticated REST reads.
They are appended to the current block file so repeated reads and restarts do not fetch them again; once that file rolls over, normal pruning can remove it.
The selected peer can observe the requested block hash, so the option is disabled by default and only outbound full-relay peers are used.
Older releases and `-reindex` do not preserve the local-only marker and may make retained blocks servable.

**Wallet recovery:** Fetch-backed wallet rescans require an available basic block filter for each block that must be downloaded, so only blocks matching known wallet scripts are fetched.
This can recover receives and fully spent history for known descriptors and derivation ranges, but it cannot discover transactions involving scripts the wallet does not know.
Functional coverage restores both a receive and its full spend, and checks that retained blocks survive restart without becoming available over P2P or REST.

**Stack:** This branch is stacked on #35531 and five `suggestion:` commits for that PR.
The change proposed here starts with `blockstorage: keep cursor files from pruning`; the earlier commits are included only so the proxy can be prototyped and reviewed against the txindex format it uses.
