### PR TITLE
ci: verify downloaded CI dependencies

### DIFF
--- a/ci/lint/01_install.sh
+++ b/ci/lint/01_install.sh
@@ -31,13 +31,22 @@ python3 --version
 
 uv pip install --python /python_env --requirements /ci/lint/requirements.txt
 
+case "$(uname --machine)" in
+  x86_64)  SHELLCHECK_SHA256="8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198" MLC_SHA256="7a72a93d5b3ee8a554cb840abdfe90aefb709418f225461b52021e3a058238a2" ;;
+  aarch64) SHELLCHECK_SHA256="12b331c1d2db6b9eb13cfca64306b1b157a86eb69db83023e261eaa7e7c14588" MLC_SHA256="01ec8e086f3b625616d461b63451be9175a02557de6b591bac7cde6791ab074b" ;;
+esac
+
 SHELLCHECK_VERSION=v0.11.0
-curl --fail -L "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.$(uname --machine).tar.xz" | \
-    tar --xz -xf - --directory /tmp/
+SHELLCHECK_ARCHIVE=/tmp/shellcheck.tar.xz
+curl --fail -L "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.$(uname --machine).tar.xz" -o "${SHELLCHECK_ARCHIVE}"
+sha256sum -c <<<"${SHELLCHECK_SHA256} ${SHELLCHECK_ARCHIVE}"
+tar --xz -xf "${SHELLCHECK_ARCHIVE}" --directory /tmp/
 mv "/tmp/shellcheck-${SHELLCHECK_VERSION}/shellcheck" /usr/bin/
 
 MLC_VERSION=v1.2.0
-curl --fail -L "https://github.com/becheran/mlc/releases/download/${MLC_VERSION}/mlc-$(uname --machine)-linux" -o "/usr/bin/mlc"
-chmod +x /usr/bin/mlc
+MLC_PATH=/usr/bin/mlc
+curl --fail -L "https://github.com/becheran/mlc/releases/download/${MLC_VERSION}/mlc-$(uname --machine)-linux" -o "${MLC_PATH}"
+sha256sum -c <<<"${MLC_SHA256} ${MLC_PATH}"
+chmod +x "${MLC_PATH}"
 
 popd || exit

--- a/ci/test/01_base_install.sh
+++ b/ci/test/01_base_install.sh
@@ -116,6 +116,7 @@ if [ -n "$XCODE_VERSION" ] && [ ! -d "${DEPENDS_DIR}/SDKs/${OSX_SDK_BASENAME}" ]
   if [ ! -f "$OSX_SDK_PATH" ]; then
     ${CI_RETRY_EXE} curl --location --fail "${SDK_URL}/${OSX_SDK_FILENAME}" -o "$OSX_SDK_PATH"
   fi
+  sha256sum -c <<<"9600fa93644df674ee916b5e2c8a6ba8dacf631996a65dc922d003b98b5ea3b1 ${OSX_SDK_PATH}"
   tar -C "${DEPENDS_DIR}/SDKs" -xf "$OSX_SDK_PATH"
 fi
 
@@ -136,6 +137,7 @@ if [ -n "$FREEBSD_VERSION" ] && [ ! -d "${DEPENDS_DIR}/SDKs/${FREEBSD_SDK_BASENA
   if [ ! -f "$FREEBSD_SDK_PATH" ]; then
     ${CI_RETRY_EXE} curl --location --fail "https://download.freebsd.org/releases/amd64/${FREEBSD_VERSION}-RELEASE/base.txz" -o "$FREEBSD_SDK_PATH"
   fi
+  sha256sum -c <<<"3768988b151c20f965679062b065c63a977d6bbb9f47fd83695ec2c40790c18f ${FREEBSD_SDK_PATH}"
   mkdir -p "${DEPENDS_DIR}/SDKs/${FREEBSD_SDK_BASENAME}"
   tar -C "${DEPENDS_DIR}/SDKs/${FREEBSD_SDK_BASENAME}" -xf "$FREEBSD_SDK_PATH"
 fi

--- a/ci/test/01_base_install.sh
+++ b/ci/test/01_base_install.sh
@@ -30,6 +30,7 @@ if [ -n "${APT_LLVM_V}" ]; then
   ${CI_RETRY_EXE} apt-get update
   ${CI_RETRY_EXE} apt-get install curl -y
   curl "https://apt.llvm.org/llvm-snapshot.gpg.key" | tee "/etc/apt/trusted.gpg.d/apt.llvm.org.asc"
+  sha256sum -c <<<"8b2a587ffd672c4687e7581dad4b2f6c1bb2ad6b480cd9771ba2ff48e0b8c75d /etc/apt/trusted.gpg.d/apt.llvm.org.asc"
   (
     # shellcheck disable=SC2034
     source /etc/os-release

--- a/ci/test/01_base_install.sh
+++ b/ci/test/01_base_install.sh
@@ -63,7 +63,7 @@ if [ -n "$PIP_PACKAGES" ]; then
 fi
 
 if [[ -n "${USE_INSTRUMENTED_LIBCPP}" ]]; then
-  ${CI_RETRY_EXE} git clone --depth=1 https://github.com/llvm/llvm-project -b "llvmorg-22.1.7" /llvm-project
+  ${CI_RETRY_EXE} git clone --depth=1 --revision=a255c1ed36a1d06f79bd2633ba9f8d900153007c https://github.com/llvm/llvm-project /llvm-project # llvmorg-22.1.7
 
 # LLVM is configured with LIBCXXABI_USE_LLVM_UNWINDER=OFF,
 # because libunwind doesn't handle exceptions under MSAN.
@@ -89,7 +89,7 @@ if [[ -n "${USE_INSTRUMENTED_LIBCPP}" ]]; then
 fi
 
 if [[ ${BARE_METAL_RISCV} == "true" ]]; then
-    ${CI_RETRY_EXE} git clone --depth=1 https://github.com/riscv-collab/riscv-gnu-toolchain -b 2026.06.06 /riscv/gcc
+    ${CI_RETRY_EXE} git clone --depth=1 --revision=81bb1f89664aad156df3d2773195177c92dedc3a https://github.com/riscv-collab/riscv-gnu-toolchain /riscv/gcc # 2026.06.06
     ( cd /riscv/gcc;
       ./configure --prefix=/opt/riscv-ilp32 --with-arch=rv32gc --with-abi=ilp32 --disable-gdb;
       make "$MAKEJOBS"; )
@@ -97,7 +97,7 @@ if [[ ${BARE_METAL_RISCV} == "true" ]]; then
 fi
 
 if [[ "${RUN_IWYU}" == true ]]; then
-  ${CI_RETRY_EXE} git clone --depth=1 https://github.com/include-what-you-use/include-what-you-use -b clang_"${IWYU_LLVM_V}" /include-what-you-use
+  ${CI_RETRY_EXE} git clone --depth=1 --revision=01a091d16b3dedb808db21f32ed3e761737a3691 https://github.com/include-what-you-use/include-what-you-use /include-what-you-use # clang_22
   pushd /include-what-you-use
   patch -p1 < /ci_container_base/ci/test/01_iwyu.patch
   patch -p1 < /ci_container_base/ci/test/02_iwyu_hash.patch


### PR DESCRIPTION
**Problem:** CI downloads and executes lint binaries, cross-build SDK archives, LLVM and IWYU source trees, and the LLVM APT signing key.
Version labels and branch names do not bind those inputs to reviewed bytes or commits.

**Fix:** Pin the downloaded artifacts and resolved Git commits, verify them before extraction, execution, or configuration, and scope the verified LLVM key to its APT source.
