### PR TITLE
index: fix reader races during restart

### DIFF
--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -448,7 +448,11 @@ bool BaseIndex::BlockUntilSyncedToCurrentChain() const
         LOCK(cs_main);
         const CBlockIndex* chain_tip = m_chainstate->m_chain.Tip();
         const CBlockIndex* best_block_index = m_best_block_index.load();
-        if (best_block_index->GetAncestor(chain_tip->nHeight) == chain_tip) {
+        if (!chain_tip) {
+            Assume(!best_block_index);
+        } else if (!best_block_index) {
+            return false;
+        } else if (best_block_index->GetAncestor(chain_tip->nHeight) == chain_tip) {
             return true;
         }
     }

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -109,10 +109,7 @@ bool BaseIndex::Init()
     // May need reset if index is being restarted.
     m_interrupt.reset();
 
-    // m_chainstate member gives indexing code access to node internals. It is
-    // removed in followup https://github.com/bitcoin/bitcoin/pull/24230
-    m_chainstate = WITH_LOCK(::cs_main,
-                             return &m_chain->context()->chainman->ValidatedChainstate());
+    WITH_LOCK(::cs_main, m_chainstate = &m_chain->context()->chainman->ValidatedChainstate());
     // Register to validation interface before setting the 'm_synced' flag, so that
     // callbacks are not missed once m_synced is true.
     m_chain->context()->validation_signals->RegisterValidationInterface(this);

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -111,6 +111,9 @@ private:
 
 protected:
     std::unique_ptr<interfaces::Chain> m_chain;
+    /// Gives indexing code access to node internals. Assigned under ::cs_main in Init() on every
+    /// index (re)start, so readers outside the sync/callback threads must hold ::cs_main.
+    /// Will be removed in followup https://github.com/bitcoin/bitcoin/pull/24230.
     Chainstate* m_chainstate{nullptr};
     const std::string m_name;
     const std::string m_thread_name;

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -112,7 +112,8 @@ private:
 protected:
     std::unique_ptr<interfaces::Chain> m_chain;
     /// Gives indexing code access to node internals. Assigned under ::cs_main in Init() on every
-    /// index (re)start, so readers outside the sync/callback threads must hold ::cs_main.
+    /// index (re)start, so readers outside the sync/callback threads must hold ::cs_main. For block
+    /// file access, prefer the never-reassigned m_chain->context()->chainman->m_blockman.
     /// Will be removed in followup https://github.com/bitcoin/bitcoin/pull/24230.
     Chainstate* m_chainstate{nullptr};
     const std::string m_name;

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -11,6 +11,7 @@
 #include <index/disktxpos.h>
 #include <interfaces/chain.h>
 #include <node/blockstorage.h>
+#include <node/context.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <serialize.h>
@@ -97,7 +98,8 @@ bool TxIndex::FindTx(const Txid& tx_hash, uint256& block_hash, CTransactionRef& 
         return false;
     }
 
-    AutoFile file{m_chainstate->m_blockman.OpenBlockFile(postx, true)};
+    // Unlike m_chainstate, chainman->m_blockman is never reassigned on index restart.
+    AutoFile file{m_chain->context()->chainman->m_blockman.OpenBlockFile(postx, /*fReadOnly=*/true)};
     if (file.IsNull()) {
         LogError("OpenBlockFile failed");
         return false;

--- a/src/index/txospenderindex.cpp
+++ b/src/index/txospenderindex.cpp
@@ -13,6 +13,7 @@
 #include <interfaces/chain.h>
 #include <logging.h>
 #include <node/blockstorage.h>
+#include <node/context.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <random.h>
@@ -143,7 +144,8 @@ bool TxoSpenderIndex::CustomRemove(const interfaces::BlockInfo& block)
 
 util::Expected<TxoSpender, std::string> TxoSpenderIndex::ReadTransaction(const CDiskTxPos& tx_pos) const
 {
-    AutoFile file{m_chainstate->m_blockman.OpenBlockFile(tx_pos, /*fReadOnly=*/true)};
+    // Unlike m_chainstate, chainman->m_blockman is never reassigned on index restart.
+    AutoFile file{m_chain->context()->chainman->m_blockman.OpenBlockFile(tx_pos, /*fReadOnly=*/true)};
     if (file.IsNull()) {
         return util::Unexpected("cannot open block");
     }

--- a/src/test/baseindex_tests.cpp
+++ b/src/test/baseindex_tests.cpp
@@ -13,6 +13,10 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <atomic>
+#include <latch>
+#include <thread>
+
 // Tests of generic BaseIndex functionality that is independent of which
 // concrete index is being used. Concrete indexes are used here merely as
 // convenient instantiations of BaseIndex.
@@ -60,25 +64,37 @@ BOOST_FIXTURE_TEST_CASE(baseindex_no_commit_ahead_of_flush, TestChain100Setup)
     sync_index(false, 101, 100);
 }
 
-BOOST_FIXTURE_TEST_CASE(baseindex_restart_reads, TestChain100Setup)
+// Test that BlockUntilSyncedToCurrentChain() can run concurrently with the
+// index being stopped and restarted. TxIndex is used as a representative
+// BaseIndex implementation.
+BOOST_FIXTURE_TEST_CASE(baseindex_restart_block_until, TestChain100Setup)
 {
     TxIndex index{interfaces::MakeChain(m_node), /*n_cache_size=*/1_MiB, /*f_memory=*/true};
     BOOST_REQUIRE(index.Init());
     index.Sync();
 
-    const Txid txid{m_coinbase_txns[1]->GetHash()};
-    for (int i{0}; i < 2; ++i) {
-        index.Stop();
-        BOOST_REQUIRE(index.Init());
-        index.Sync();
+    std::latch reader_started{1};
+    std::atomic_bool run{true};
+    std::thread reader{[&] {
+        reader_started.count_down();
+        while (run.load(std::memory_order_relaxed)) {
+            // This read overlaps Stop()/Init() and exposes the transient state.
+            index.BlockUntilSyncedToCurrentChain();
+        }
+    }};
+    reader_started.wait();
 
-        CTransactionRef tx;
-        uint256 block_hash;
-        BOOST_REQUIRE(index.BlockUntilSyncedToCurrentChain());
-        BOOST_REQUIRE(index.FindTx(txid, block_hash, tx));
+    bool init_ok{true};
+    for (int i{0}; init_ok && i < 1000; ++i) {
+        index.Stop();
+        init_ok = index.Init();
+        std::this_thread::yield();
     }
 
+    run = false;
+    reader.join();
     index.Stop();
+    BOOST_REQUIRE(init_ok);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/baseindex_tests.cpp
+++ b/src/test/baseindex_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <index/coinstatsindex.h>
+#include <index/txindex.h>
 #include <interfaces/chain.h>
 #include <script/script.h>
 #include <test/util/setup_common.h>
@@ -13,8 +14,8 @@
 #include <boost/test/unit_test.hpp>
 
 // Tests of generic BaseIndex functionality that is independent of which
-// concrete index is being used. CoinStatsIndex is used here merely as a
-// convenient instantiation of BaseIndex.
+// concrete index is being used. Concrete indexes are used here merely as
+// convenient instantiations of BaseIndex.
 BOOST_AUTO_TEST_SUITE(baseindex_tests)
 
 // Test that the index does not commit ahead of the chainstate's last
@@ -57,6 +58,27 @@ BOOST_FIXTURE_TEST_CASE(baseindex_no_commit_ahead_of_flush, TestChain100Setup)
     // state deterministic.
     CreateAndProcessBlock({}, CScript() << OP_TRUE);
     sync_index(false, 101, 100);
+}
+
+BOOST_FIXTURE_TEST_CASE(baseindex_restart_reads, TestChain100Setup)
+{
+    TxIndex index{interfaces::MakeChain(m_node), /*n_cache_size=*/1_MiB, /*f_memory=*/true};
+    BOOST_REQUIRE(index.Init());
+    index.Sync();
+
+    const Txid txid{m_coinbase_txns[1]->GetHash()};
+    for (int i{0}; i < 2; ++i) {
+        index.Stop();
+        BOOST_REQUIRE(index.Init());
+        index.Sync();
+
+        CTransactionRef tx;
+        uint256 block_hash;
+        BOOST_REQUIRE(index.BlockUntilSyncedToCurrentChain());
+        BOOST_REQUIRE(index.FindTx(txid, block_hash, tx));
+    }
+
+    index.Stop();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/baseindex_tests.cpp
+++ b/src/test/baseindex_tests.cpp
@@ -64,22 +64,26 @@ BOOST_FIXTURE_TEST_CASE(baseindex_no_commit_ahead_of_flush, TestChain100Setup)
     sync_index(false, 101, 100);
 }
 
-// Test that BlockUntilSyncedToCurrentChain() can run concurrently with the
-// index being stopped and restarted. TxIndex is used as a representative
-// BaseIndex implementation.
-BOOST_FIXTURE_TEST_CASE(baseindex_restart_block_until, TestChain100Setup)
+// Test that index readers can run concurrently with the index being stopped
+// and restarted. TxIndex is used because its FindTx reader runs off the sync
+// thread without synchronization.
+BOOST_FIXTURE_TEST_CASE(baseindex_restart_concurrent_reads, TestChain100Setup)
 {
     TxIndex index{interfaces::MakeChain(m_node), /*n_cache_size=*/1_MiB, /*f_memory=*/true};
     BOOST_REQUIRE(index.Init());
     index.Sync();
 
+    const Txid txid{m_coinbase_txns[1]->GetHash()};
     std::latch reader_started{1};
     std::atomic_bool run{true};
     std::thread reader{[&] {
         reader_started.count_down();
         while (run.load(std::memory_order_relaxed)) {
-            // This read overlaps Stop()/Init() and exposes the transient state.
+            CTransactionRef tx;
+            uint256 block_hash;
+            // These reads overlap Stop()/Init() and exercise the unsynchronized reader paths.
             index.BlockUntilSyncedToCurrentChain();
+            index.FindTx(txid, block_hash, tx);
         }
     }};
     reader_started.wait();


### PR DESCRIPTION
**Problem:** RPC and REST index reads remain available while AssumeUTXO completion restarts indexes with `Stop()`, `Init()`, and `StartBackgroundSync()`.
`BaseIndex::Init()` assigned `m_chainstate` after releasing `cs_main`, while `TxIndex::FindTx()` and `TxoSpenderIndex::ReadTransaction()` dereferenced it without holding `cs_main`.
`BlockUntilSyncedToCurrentChain()` could also dereference a null `m_best_block_index` during the restart.

**Fix:** Publish `m_chainstate` while holding `cs_main`, return `false` until the restarted index has a best block, and use the never-reassigned `ChainstateManager::m_blockman` for block-file reads.