### PR TITLE
p2p: select another peer after empty headers

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -99,6 +99,9 @@ static constexpr auto HEADERS_DOWNLOAD_TIMEOUT_BASE = 15min;
 static constexpr auto HEADERS_DOWNLOAD_TIMEOUT_PER_HEADER = 1ms;
 /** How long to wait for a peer to respond to a getheaders request */
 static constexpr auto HEADERS_RESPONSE_TIME{2min};
+/** Age threshold for considering ourselves far behind: initial headers sync is then
+ *  limited to one peer at a time, and a stalling peer's slot is released. */
+static constexpr auto BEST_HEADER_STALE_AGE{24h};
 /** Protect at least this many outbound peers from disconnection due to slow/
  * behind headers chain.
  */
@@ -996,6 +999,8 @@ private:
 
     bool TipMayBeStale() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
+    bool IsBestHeaderStale() const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
     /** Update pindexLastCommonBlock and add not-in-flight missing successors to vBlocks, until it has
      *  at most count entries.
      */
@@ -1434,6 +1439,12 @@ bool PeerManagerImpl::TipMayBeStale()
         m_last_tip_update = GetTime<std::chrono::seconds>();
     }
     return m_last_tip_update.load() < GetTime<std::chrono::seconds>() - std::chrono::seconds{consensusParams.nPowTargetSpacing * 3} && mapBlocksInFlight.empty();
+}
+
+bool PeerManagerImpl::IsBestHeaderStale() const
+{
+    AssertLockHeld(cs_main);
+    return m_chainman.m_best_header->Time() <= NodeClock::now() - BEST_HEADER_STALE_AGE;
 }
 
 int64_t PeerManagerImpl::ApproximateBestBlockDepth() const
@@ -6106,7 +6117,7 @@ bool PeerManagerImpl::SendMessages(CNode& node)
 
         if (!state.fSyncStarted && CanServeBlocks(peer) && !m_chainman.m_blockman.LoadingBlocks()) {
             // Only actively request headers from a single peer, unless we're close to today.
-            if ((nSyncStarted == 0 && sync_blocks_and_headers_from_peer) || m_chainman.m_best_header->Time() > NodeClock::now() - 24h) {
+            if ((nSyncStarted == 0 && sync_blocks_and_headers_from_peer) || !IsBestHeaderStale()) {
                 const CBlockIndex* pindexStart = m_chainman.m_best_header;
                 /* If possible, start at the block preceding the currently
                    best known header.  This ensures that we always get a
@@ -6431,7 +6442,7 @@ bool PeerManagerImpl::SendMessages(CNode& node)
         // Check for headers sync timeouts
         if (state.fSyncStarted && peer.m_headers_sync_timeout < std::chrono::microseconds::max()) {
             // Detect whether this is a stalling initial-headers-sync peer
-            if (m_chainman.m_best_header->Time() <= NodeClock::now() - 24h) {
+            if (IsBestHeaderStale()) {
                 if (current_time > peer.m_headers_sync_timeout && nSyncStarted == 1 && (m_num_preferred_download_peers - state.fPreferredDownload >= 1)) {
                     // Disconnect a peer (without NetPermissionFlags::NoBan permission) if it is our only sync peer,
                     // and we have others we could be using instead.

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1001,6 +1001,8 @@ private:
 
     bool IsBestHeaderStale() const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
+    void ReleaseHeadersSyncSlot(CNodeState& state, Peer& peer) EXCLUSIVE_LOCKS_REQUIRED(cs_main, g_msgproc_mutex);
+
     /** Update pindexLastCommonBlock and add not-in-flight missing successors to vBlocks, until it has
      *  at most count entries.
      */
@@ -1445,6 +1447,15 @@ bool PeerManagerImpl::IsBestHeaderStale() const
 {
     AssertLockHeld(cs_main);
     return m_chainman.m_best_header->Time() <= NodeClock::now() - BEST_HEADER_STALE_AGE;
+}
+
+void PeerManagerImpl::ReleaseHeadersSyncSlot(CNodeState& state, Peer& peer)
+{
+    AssertLockHeld(cs_main);
+    Assume(state.fSyncStarted);
+    state.fSyncStarted = false;
+    nSyncStarted--;
+    peer.m_headers_sync_timeout = 0us;
 }
 
 int64_t PeerManagerImpl::ApproximateBestBlockDepth() const
@@ -6460,9 +6471,7 @@ bool PeerManagerImpl::SendMessages(CNode& node)
                         // Note: this will also result in at least one more
                         // getheaders message to be sent to
                         // this peer (eventually).
-                        state.fSyncStarted = false;
-                        nSyncStarted--;
-                        peer.m_headers_sync_timeout = 0us;
+                        ReleaseHeadersSyncSlot(state, peer);
                     }
                 }
             } else {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -5496,7 +5496,9 @@ void PeerManagerImpl::ConsiderEviction(CNode& pto, Peer& peer, std::chrono::seco
 
     CNodeState &state = *State(pto.GetId());
 
-    if (!state.m_chain_sync.m_protect && pto.IsOutboundOrBlockRelayConn() && state.fSyncStarted) {
+    // Syncing headers from this peer arms the check; once a timeout is set it stays
+    // armed until cleared below, so releasing the sync slot does not disarm it.
+    if (!state.m_chain_sync.m_protect && pto.IsOutboundOrBlockRelayConn() && (state.fSyncStarted || state.m_chain_sync.m_timeout != 0s)) {
         // This is an outbound peer subject to disconnection if they don't
         // announce a block with as much work as the current tip within
         // CHAIN_SYNC_TIMEOUT + HEADERS_RESPONSE_TIME seconds (note: if

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3219,15 +3219,24 @@ void PeerManagerImpl::ProcessHeadersMessage(CNode& pfrom, Peer& peer,
         // If we were in the middle of headers sync, receiving an empty headers
         // message suggests that the peer suddenly has nothing to give us
         // (perhaps it reorged to our chain). Clear download state for this peer.
-        LOCK(peer.m_headers_sync_mutex);
-        if (peer.m_headers_sync) {
-            peer.m_headers_sync.reset(nullptr);
-            LOCK(m_headers_presync_mutex);
-            m_headers_presync_stats.erase(pfrom.GetId());
+        {
+            LOCK(peer.m_headers_sync_mutex);
+            if (peer.m_headers_sync) {
+                peer.m_headers_sync.reset(nullptr);
+                LOCK(m_headers_presync_mutex);
+                m_headers_presync_stats.erase(pfrom.GetId());
+            }
         }
-        // A headers message with no headers cannot be an announcement, so assume
-        // it is a response to our last getheaders request, if there is one.
-        peer.m_last_getheaders_timestamp = {};
+
+        LOCK(cs_main);
+        CNodeState& state{*Assert(State(pfrom.GetId()))};
+        if (state.fSyncStarted && IsBestHeaderStale()) {
+            ReleaseHeadersSyncSlot(state, peer);
+        } else {
+            // A headers message with no headers cannot be an announcement, so assume
+            // it is a response to our last getheaders request, if there is one.
+            peer.m_last_getheaders_timestamp = {};
+        }
         return;
     }
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -398,6 +398,8 @@ struct Peer {
 
     /** Time of the last getheaders message to this peer */
     NodeClock::time_point m_last_getheaders_timestamp GUARDED_BY(NetEventsInterface::g_msgproc_mutex){};
+    /** Whether empty headers released this peer's initial sync slot. */
+    bool m_initial_headers_sync_released GUARDED_BY(NetEventsInterface::g_msgproc_mutex){false};
 
     /** Protects m_headers_sync **/
     Mutex m_headers_sync_mutex;
@@ -3232,9 +3234,12 @@ void PeerManagerImpl::ProcessHeadersMessage(CNode& pfrom, Peer& peer,
         CNodeState& state{*Assert(State(pfrom.GetId()))};
         if (state.fSyncStarted && IsBestHeaderStale()) {
             ReleaseHeadersSyncSlot(state, peer);
-        } else {
+            peer.m_initial_headers_sync_released = true;
+        } else if (!peer.m_initial_headers_sync_released) {
             // A headers message with no headers cannot be an announcement, so assume
             // it is a response to our last getheaders request, if there is one.
+            // A peer that released its slot keeps its request timestamp as a backoff
+            // instead, so the scheduler does not hand the slot straight back to it.
             peer.m_last_getheaders_timestamp = {};
         }
         return;
@@ -3299,8 +3304,10 @@ void PeerManagerImpl::ProcessHeadersMessage(CNode& pfrom, Peer& peer,
 
     // If headers connect, assume that this is in response to any outstanding getheaders
     // request we may have sent, and clear out the time of our last request. Non-connecting
-    // headers cannot be a response to a getheaders request.
+    // headers cannot be a response to a getheaders request. A connecting response also
+    // ends any released-slot backoff.
     peer.m_last_getheaders_timestamp = {};
+    peer.m_initial_headers_sync_released = false;
 
     // If the headers we received are already in memory and an ancestor of
     // m_best_header or our tip, skip anti-DoS checks. These headers will not
@@ -4423,6 +4430,10 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
             // use if we turned on sync with all peers).
             CNodeState& state{*Assert(State(pfrom.GetId()))};
             if (state.fSyncStarted || (!peer.m_inv_triggered_getheaders_before_sync && *best_block != m_last_block_inv_triggering_headers_sync)) {
+                // This peer's backoff was deliberately left armed when it released its
+                // slot; a new block announcement is fresh evidence, so let one request
+                // through rather than waiting for the backoff to expire.
+                if (peer.m_initial_headers_sync_released) peer.m_last_getheaders_timestamp = {};
                 if (MaybeSendGetHeaders(pfrom, GetLocator(m_chainman.m_best_header), peer)) {
                     LogDebug(BCLog::NET, "getheaders (%d) %s to peer=%d\n",
                             m_chainman.m_best_header->nHeight, best_block->ToString(),
@@ -6153,6 +6164,7 @@ bool PeerManagerImpl::SendMessages(CNode& node)
                 if (MaybeSendGetHeaders(node, GetLocator(pindexStart), peer)) {
                     LogDebug(BCLog::NET, "initial getheaders (%d) to peer=%d", pindexStart->nHeight, node.GetId());
 
+                    peer.m_initial_headers_sync_released = false;
                     state.fSyncStarted = true;
                     peer.m_headers_sync_timeout = current_time + HEADERS_DOWNLOAD_TIMEOUT_BASE +
                         (

--- a/test/functional/p2p_initial_headers_sync.py
+++ b/test/functional/p2p_initial_headers_sync.py
@@ -2,18 +2,19 @@
 # Copyright (c) 2022-present The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test initial headers download and timeout behavior
+"""Test initial headers download, empty responses, and timeout behavior
 
-Test that we only try to initially sync headers from one peer (until our chain
-is close to caught up), and that each block announcement results in only one
-additional peer receiving a getheaders message.
+Test that only one peer at a time initially syncs headers and each block
+announcement triggers one additional getheaders.
 
 Also test peer timeout during initial headers sync, including normal peer
 disconnection vs noban peer behavior.
 """
 
 from test_framework.test_framework import BitcoinTestFramework
+from test_framework.blocktools import REGTEST_N_BITS
 from test_framework.messages import (
+    CBlock,
     CInv,
     MSG_BLOCK,
     msg_headers,
@@ -55,19 +56,59 @@ class HeadersSyncTest(BitcoinTestFramework):
         for p in peers:
             p.send_and_ping(new_block_announcement)
 
-    def assert_single_getheaders_recipient(self, peers):
-        count = 0
-        receiving_peer = None
+    def getheaders_recipients(self, peers):
+        with p2p_lock:
+            return [p for p in peers if "getheaders" in p.last_message]
+
+    def wait_for_single_getheaders(self, peers, block_hash):
+        self.wait_until(lambda: self.getheaders_recipients(peers))
         for p in peers:
-            with p2p_lock:
-                if "getheaders" in p.last_message:
-                    count += 1
-                    receiving_peer = p
-        assert_equal(count, 1)
-        return receiving_peer
+            p.sync_with_ping()
+        recipients = self.getheaders_recipients(peers)
+        assert_equal(len(recipients), 1)
+        recipients[0].wait_for_getheaders(block_hash=block_hash)
+        return recipients[0]
+
+    def test_empty_headers_sync_slot(self):
+        self.log.info("Test empty headers response during initial sync")
+        peer1 = self.nodes[0].add_p2p_connection(P2PInterface())
+        best_block_hash = int(self.nodes[0].getbestblockhash(), 16)
+        peer1.wait_for_getheaders(block_hash=best_block_hash)
+        peer1.send_and_ping(msg_headers())
+
+        # An unconnecting header is not a getheaders response, so it only draws a new
+        # request if the backoff has been cleared.
+        unconnecting_header = CBlock()
+        unconnecting_header.hashPrevBlock = 1
+        unconnecting_header.nBits = REGTEST_N_BITS
+        unconnecting_header.solve()
+        peer1.send_and_ping(msg_headers([unconnecting_header]))
+        with p2p_lock:
+            assert_equal("getheaders" in peer1.last_message, True)  # TODO: Retain the request timestamp after an empty response.
+            peer1.last_message.pop("getheaders", None)
+
+        peer2 = self.nodes[0].add_p2p_connection(P2PInterface())
+        peer3 = self.nodes[0].add_p2p_connection(P2PInterface())
+        for peer in [peer1, peer2, peer3]:
+            peer.sync_with_ping()
+
+        assert_equal(len(self.getheaders_recipients([peer2, peer3])), 0)  # TODO: Empty headers should release the sync slot.
+
+        peer1.send_and_ping(msg_headers())
+        unconnecting_header.hashPrevBlock = 2
+        unconnecting_header.solve()
+        peer1.send_and_ping(msg_headers([unconnecting_header]))
+        with p2p_lock:
+            assert_equal("getheaders" in peer1.last_message, True)  # TODO: Retain the request timestamp after a repeated empty response.
+            peer1.last_message.pop("getheaders", None)
+
+        self.announce_random_block([peer1])
+        with p2p_lock:
+            assert_equal("getheaders" in peer1.last_message, False)  # TODO: Let a block announcement retry a peer after its sync slot was released.
 
     def test_initial_headers_sync(self):
         self.log.info("Test initial headers sync")
+        self.restart_node(0)
 
         self.log.info("Adding a peer to node0")
         peer1 = self.nodes[0].add_p2p_connection(P2PInterface())
@@ -102,7 +143,7 @@ class HeadersSyncTest(BitcoinTestFramework):
         peer1.send_without_ping(msg_headers()) # Send empty response, see above
 
         self.log.info("Check that exactly 1 of {peer2, peer3} received a getheaders in response")
-        peer_receiving_getheaders = self.assert_single_getheaders_recipient([peer2, peer3])
+        peer_receiving_getheaders = self.wait_for_single_getheaders([peer2, peer3], best_block_hash)
         peer_receiving_getheaders.send_without_ping(msg_headers()) # Send empty response, see above
 
         self.log.info("Announce another new block, from all peers")
@@ -174,9 +215,10 @@ class HeadersSyncTest(BitcoinTestFramework):
             assert_equal(self.nodes[0].num_test_p2p_connections(), 2)
 
         self.log.info("Check that exactly 1 of {peer1, peer2} receives a getheaders")
-        self.assert_single_getheaders_recipient([peer1, peer2])
+        self.wait_for_single_getheaders([peer1, peer2], int(self.nodes[0].getbestblockhash(), 16))
 
     def run_test(self):
+        self.test_empty_headers_sync_slot()
         self.test_initial_headers_sync()
         self.test_normal_peer_timeout()
         self.test_noban_peer_timeout()

--- a/test/functional/p2p_initial_headers_sync.py
+++ b/test/functional/p2p_initial_headers_sync.py
@@ -34,6 +34,7 @@ import time
 # Constants from net_processing
 HEADERS_DOWNLOAD_TIMEOUT_BASE_SEC = 15 * 60
 HEADERS_DOWNLOAD_TIMEOUT_PER_HEADER_MS = 1
+HEADERS_RESPONSE_TIME_SEC = 2 * 60
 POW_TARGET_SPACING_SEC = 10 * 60
 
 
@@ -109,6 +110,7 @@ class HeadersSyncTest(BitcoinTestFramework):
     def test_initial_headers_sync(self):
         self.log.info("Test initial headers sync")
         self.restart_node(0)
+        self.nodes[0].setmocktime(int(time.time()))
 
         self.log.info("Adding a peer to node0")
         peer1 = self.nodes[0].add_p2p_connection(P2PInterface())
@@ -116,10 +118,6 @@ class HeadersSyncTest(BitcoinTestFramework):
 
         # Wait for peer1 to receive a getheaders
         peer1.wait_for_getheaders(block_hash=best_block_hash)
-        # An empty reply will clear the outstanding getheaders request,
-        # allowing additional getheaders requests to be sent to this peer in
-        # the future.
-        peer1.send_without_ping(msg_headers())
 
         self.log.info("Connecting two more peers to node0")
         # Connect 2 more peers; they should not receive a getheaders yet
@@ -135,17 +133,17 @@ class HeadersSyncTest(BitcoinTestFramework):
             assert "getheaders" not in peer2.last_message
             assert "getheaders" not in peer3.last_message
 
+        self.nodes[0].bumpmocktime(HEADERS_RESPONSE_TIME_SEC + 1)
         self.log.info("Have all peers announce a new block")
         self.announce_random_block(all_peers)
 
         self.log.info("Check that peer1 receives a getheaders in response")
         peer1.wait_for_getheaders(block_hash=best_block_hash)
-        peer1.send_without_ping(msg_headers()) # Send empty response, see above
 
         self.log.info("Check that exactly 1 of {peer2, peer3} received a getheaders in response")
         peer_receiving_getheaders = self.wait_for_single_getheaders([peer2, peer3], best_block_hash)
-        peer_receiving_getheaders.send_without_ping(msg_headers()) # Send empty response, see above
 
+        self.nodes[0].bumpmocktime(HEADERS_RESPONSE_TIME_SEC + 1)
         self.log.info("Announce another new block, from all peers")
         self.announce_random_block(all_peers)
 

--- a/test/functional/p2p_initial_headers_sync.py
+++ b/test/functional/p2p_initial_headers_sync.py
@@ -130,12 +130,12 @@ class HeadersSyncTest(BitcoinTestFramework):
         node.bumpmocktime(CHAIN_SYNC_TIMEOUT_SEC + 1)
         peer.sync_with_ping()
         with p2p_lock:
-            assert_equal("getheaders" in peer.last_message, False)  # TODO: Continue an armed old-chain eviction after releasing the sync slot.
+            assert_equal("getheaders" in peer.last_message, True)
 
         peer.send_and_ping(msg_headers([old_header]))
-        with node.assert_debug_log(expected_msgs=[], unexpected_msgs=["Outbound peer has old chain"]):  # TODO: Log old-chain eviction after the released slot expires.
+        with node.assert_debug_log(["Outbound peer has old chain"]):
             node.bumpmocktime(HEADERS_RESPONSE_TIME_SEC + 1)
-            peer.sync_with_ping()  # TODO: Disconnect the peer when the armed old-chain eviction expires.
+            peer.wait_for_disconnect()
 
     def test_initial_headers_sync(self):
         self.log.info("Test initial headers sync")

--- a/test/functional/p2p_initial_headers_sync.py
+++ b/test/functional/p2p_initial_headers_sync.py
@@ -8,15 +8,17 @@ Test that only one peer at a time initially syncs headers and each block
 announcement triggers one additional getheaders.
 
 Also test peer timeout during initial headers sync, including normal peer
-disconnection vs noban peer behavior.
+disconnection vs noban behavior, and old-chain eviction after releasing a sync slot.
 """
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.blocktools import REGTEST_N_BITS
 from test_framework.messages import (
     CBlock,
+    CBlockHeader,
     CInv,
     MSG_BLOCK,
+    from_hex,
     msg_headers,
     msg_inv,
 )
@@ -32,6 +34,7 @@ import random
 import time
 
 # Constants from net_processing
+CHAIN_SYNC_TIMEOUT_SEC = 20 * 60
 HEADERS_DOWNLOAD_TIMEOUT_BASE_SEC = 15 * 60
 HEADERS_DOWNLOAD_TIMEOUT_PER_HEADER_MS = 1
 HEADERS_RESPONSE_TIME_SEC = 2 * 60
@@ -105,6 +108,34 @@ class HeadersSyncTest(BitcoinTestFramework):
         self.announce_random_block([peer1])
         with p2p_lock:
             assert_equal("getheaders" in peer1.last_message, False)  # TODO: Let a block announcement retry a peer after its sync slot was released.
+
+    def test_released_slot_outbound_eviction(self):
+        self.log.info("Test outbound eviction after releasing a headers sync slot")
+        self.restart_node(0)
+        node = self.nodes[0]
+        node.setmocktime(node.getblockchaininfo()["time"] + 1)
+        self.generate(node, 2)
+        old_header = from_hex(CBlockHeader(), node.getblockheader(node.getblockhash(1), False))
+        node.setmocktime(int(time.time()))
+
+        peer = node.add_outbound_p2p_connection(P2PInterface(), p2p_idx=0, connection_type="outbound-full-relay")
+        peer.wait_for_getheaders()
+        peer.send_and_ping(msg_headers())
+
+        # Occupy the released slot so `peer` stays released; its eviction timeout then
+        # has to keep running on m_chain_sync.m_timeout alone.
+        sync_peer = node.add_p2p_connection(P2PInterface())
+        sync_peer.wait_for_getheaders()
+
+        node.bumpmocktime(CHAIN_SYNC_TIMEOUT_SEC + 1)
+        peer.sync_with_ping()
+        with p2p_lock:
+            assert_equal("getheaders" in peer.last_message, False)  # TODO: Continue an armed old-chain eviction after releasing the sync slot.
+
+        peer.send_and_ping(msg_headers([old_header]))
+        with node.assert_debug_log(expected_msgs=[], unexpected_msgs=["Outbound peer has old chain"]):  # TODO: Log old-chain eviction after the released slot expires.
+            node.bumpmocktime(HEADERS_RESPONSE_TIME_SEC + 1)
+            peer.sync_with_ping()  # TODO: Disconnect the peer when the armed old-chain eviction expires.
 
     def test_initial_headers_sync(self):
         self.log.info("Test initial headers sync")
@@ -219,6 +250,7 @@ class HeadersSyncTest(BitcoinTestFramework):
         self.test_initial_headers_sync()
         self.test_normal_peer_timeout()
         self.test_noban_peer_timeout()
+        self.test_released_slot_outbound_eviction()
 
 
 if __name__ == '__main__':

--- a/test/functional/p2p_initial_headers_sync.py
+++ b/test/functional/p2p_initial_headers_sync.py
@@ -102,12 +102,11 @@ class HeadersSyncTest(BitcoinTestFramework):
         unconnecting_header.solve()
         peer1.send_and_ping(msg_headers([unconnecting_header]))
         with p2p_lock:
-            assert_equal("getheaders" in peer1.last_message, True)  # TODO: Retain the request timestamp after a repeated empty response.
-            peer1.last_message.pop("getheaders", None)
+            assert_equal("getheaders" in peer1.last_message, False)
 
         self.announce_random_block([peer1])
         with p2p_lock:
-            assert_equal("getheaders" in peer1.last_message, False)  # TODO: Let a block announcement retry a peer after its sync slot was released.
+            assert_equal("getheaders" in peer1.last_message, True)
 
     def test_released_slot_outbound_eviction(self):
         self.log.info("Test outbound eviction after releasing a headers sync slot")

--- a/test/functional/p2p_initial_headers_sync.py
+++ b/test/functional/p2p_initial_headers_sync.py
@@ -85,15 +85,14 @@ class HeadersSyncTest(BitcoinTestFramework):
         unconnecting_header.solve()
         peer1.send_and_ping(msg_headers([unconnecting_header]))
         with p2p_lock:
-            assert_equal("getheaders" in peer1.last_message, True)  # TODO: Retain the request timestamp after an empty response.
-            peer1.last_message.pop("getheaders", None)
+            assert_equal("getheaders" in peer1.last_message, False)
 
         peer2 = self.nodes[0].add_p2p_connection(P2PInterface())
         peer3 = self.nodes[0].add_p2p_connection(P2PInterface())
         for peer in [peer1, peer2, peer3]:
             peer.sync_with_ping()
 
-        assert_equal(len(self.getheaders_recipients([peer2, peer3])), 0)  # TODO: Empty headers should release the sync slot.
+        assert_equal(len(self.getheaders_recipients([peer2, peer3])), 1)
 
         peer1.send_and_ping(msg_headers())
         unconnecting_header.hashPrevBlock = 2


### PR DESCRIPTION
**Problem:** During IBD, the node asks one peer at a time for the headers needed to catch up.
That peer can send valid empty `headers`, which the node accepts while still treating the peer as active, so no replacement is selected.
When all peers are inbound, the headers timeout cannot release that peer either.

**Fix:** Stop treating the peer as active after an empty response while the best header is at least a day old, and clear its headers timeout.
Keep the time of the recent `getheaders` request so the same peer is not selected again immediately, while a later block announcement can still retry it.
If an outbound peer is already waiting to be disconnected because its chain is old, keep that check running after another peer takes over headers sync.

<details><summary>Manual reproducer</summary>

Both runs use the checked-out `build/bin/bitcoind`; [Python](https://gist.github.com/l0rinc/39e471dd6835fe332205d3812ebb9e92) only supplies two inbound P2P peers.

```bash
DATADIR="$(mktemp -d /tmp/bitcoin-empty-headers.XXXXXX)"
trap 'build/bin/bitcoin-cli -regtest -datadir="$DATADIR" -rpcport=18454 stop >/dev/null 2>&1; rm -rf "$DATADIR"' EXIT

{ cmake -B build && cmake --build build -j --target bitcoind bitcoin-cli; } >/dev/null 2>&1
build/bin/bitcoind -regtest -daemonwait -datadir="$DATADIR" -connect=0 -listen=1 -port=18455 -rpcport=18454
time python3 '/Users/lorinc/Library/Application Support/JetBrains/CLion2026.1/scratches/scratch_758.py'
killall bitcoind
```

The fixed node returns as soon as the replacement peer receives `getheaders`.
On the old node, that wait times out after 10 seconds because the initial peer is still treated as active.
</details>
