### PR TITLE
psbt: avoid aborting when updating zero-input PSBTs

### DIFF
--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -87,6 +87,8 @@ std::optional<uint256> MutableTransactionSignatureCreator::ComputeSchnorrSignatu
 {
     assert(sigversion == SigVersion::TAPROOT || sigversion == SigVersion::TAPSCRIPT);
 
+    if (!HasInput()) return std::nullopt;
+
     // BIP341/BIP342 signing needs lots of precomputed transaction data. While some
     // (non-SIGHASH_DEFAULT) sighash modes exist that can work with just some subset
     // of data present, for now, only support signing when everything is provided.

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -50,6 +50,12 @@ MutableTransactionSignatureCreator::MutableTransactionSignatureCreator(const CMu
 {
 }
 
+const BaseSignatureChecker& MutableTransactionSignatureCreator::Checker() const
+{
+    static const BaseSignatureChecker REJECT_ALL;
+    return HasInput() ? checker : REJECT_ALL;
+}
+
 bool MutableTransactionSignatureCreator::CreateSig(const SigningProvider& provider, std::vector<unsigned char>& vchSig, const CKeyID& address, const CScript& scriptCode, SigVersion sigversion) const
 {
     assert(sigversion == SigVersion::BASE || sigversion == SigVersion::WITNESS_V0);

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -54,6 +54,8 @@ bool MutableTransactionSignatureCreator::CreateSig(const SigningProvider& provid
 {
     assert(sigversion == SigVersion::BASE || sigversion == SigVersion::WITNESS_V0);
 
+    if (!HasInput()) return false;
+
     CKey key;
     if (!provider.GetKey(address, key))
         return false;

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -8,6 +8,7 @@
 
 #include <attributes.h>
 #include <consensus/amount.h>
+#include <primitives/transaction.h>
 #include <pubkey.h>
 #include <script/interpreter.h>
 #include <script/keyorigin.h>
@@ -22,13 +23,9 @@
 #include <utility>
 #include <vector>
 
-class COutPoint;
-class CTxIn;
-class CTxOut;
 class Coin;
 
 struct bilingual_str;
-struct CMutableTransaction;
 struct SignatureData;
 
 struct SignOptions {
@@ -59,6 +56,7 @@ class MutableTransactionSignatureCreator : public BaseSignatureCreator
     const MutableTransactionSignatureChecker checker;
     const PrecomputedTransactionData* m_txdata;
 
+    bool HasInput() const { return nIn < m_txto.vin.size(); }
     std::optional<uint256> ComputeSchnorrSignatureHash(const uint256* leaf_hash, SigVersion sigversion) const;
 
 public:

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -62,7 +62,8 @@ class MutableTransactionSignatureCreator : public BaseSignatureCreator
 public:
     MutableTransactionSignatureCreator(const CMutableTransaction& tx LIFETIMEBOUND, unsigned int input_idx, const CAmount& amount, const SignOptions& options);
     MutableTransactionSignatureCreator(const CMutableTransaction& tx LIFETIMEBOUND, unsigned int input_idx, const CAmount& amount, const PrecomputedTransactionData* txdata, const SignOptions& options);
-    const BaseSignatureChecker& Checker() const override { return checker; }
+    /** Returns the transaction checker, or a rejecting checker when input_idx has no corresponding input. */
+    const BaseSignatureChecker& Checker() const override;
     bool CreateSig(const SigningProvider& provider, std::vector<unsigned char>& vchSig, const CKeyID& keyid, const CScript& scriptCode, SigVersion sigversion) const override;
     bool CreateSchnorrSig(const SigningProvider& provider, std::vector<unsigned char>& sig, const XOnlyPubKey& pubkey, const uint256* leaf_hash, const uint256* merkle_root, SigVersion sigversion) const override;
     std::vector<uint8_t> CreateMuSig2Nonce(const SigningProvider& provider, const CPubKey& aggregate_pubkey, const CPubKey& script_pubkey, const CPubKey& part_pubkey, const uint256* leaf_hash, const uint256* merkle_root, SigVersion sigversion, const SignatureData& sigdata) const override;

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -46,7 +46,7 @@ public:
     virtual bool CreateMuSig2AggregateSig(const std::vector<CPubKey>& participants, std::vector<uint8_t>& sig, const CPubKey& aggregate_pubkey, const CPubKey& script_pubkey, const uint256* leaf_hash, const std::vector<std::pair<uint256, bool>>& tweaks, SigVersion sigversion, const SignatureData& sigdata) const =0;
 };
 
-/** A signature creator for transactions. */
+/** A signature creator for transactions. Signing fails when input_idx has no corresponding input. */
 class MutableTransactionSignatureCreator : public BaseSignatureCreator
 {
     const CMutableTransaction& m_txto;

--- a/src/test/fuzz/script_sign.cpp
+++ b/src/test/fuzz/script_sign.cpp
@@ -130,6 +130,8 @@ FUZZ_TARGET(script_sign, .init = initialize_script_sign)
             auto script_code = ConsumeScript(fuzzed_data_provider);
             auto sigversion = fuzzed_data_provider.PickValueInArray({SigVersion::BASE, SigVersion::WITNESS_V0});
             (void)signature_creator.CreateSig(provider, vch_sig, address, script_code, sigversion);
+            SignatureData sigdata;
+            (void)ProduceSignature(provider, signature_creator, script_code, sigdata);
             std::map<COutPoint, Coin> coins{ConsumeCoins(fuzzed_data_provider)};
             std::map<int, bilingual_str> input_errors;
             (void)SignTransaction(sign_transaction_tx_to, &provider, coins, {.sighash_type = fuzzed_data_provider.ConsumeIntegral<int>()}, input_errors);

--- a/src/test/fuzz/script_sign.cpp
+++ b/src/test/fuzz/script_sign.cpp
@@ -116,20 +116,20 @@ FUZZ_TARGET(script_sign, .init = initialize_script_sign)
                 auto amount = ConsumeMoney(fuzzed_data_provider);
                 auto n_hash_type = fuzzed_data_provider.ConsumeIntegral<int>();
                 (void)SignSignature(provider, from_pub_key, script_tx_to, n_in, amount, n_hash_type, empty);
-                MutableTransactionSignatureCreator signature_creator{tx_to, n_in, ConsumeMoney(fuzzed_data_provider), {.sighash_type = fuzzed_data_provider.ConsumeIntegral<int>()}};
-                std::vector<unsigned char> vch_sig;
-                CKeyID address;
-                if (fuzzed_data_provider.ConsumeBool()) {
-                    if (k.IsValid()) {
-                        address = k.GetPubKey().GetID();
-                    }
-                } else {
-                    address = CKeyID{ConsumeUInt160(fuzzed_data_provider)};
-                }
-                auto script_code = ConsumeScript(fuzzed_data_provider);
-                auto sigversion = fuzzed_data_provider.PickValueInArray({SigVersion::BASE, SigVersion::WITNESS_V0});
-                (void)signature_creator.CreateSig(provider, vch_sig, address, script_code, sigversion);
             }
+            MutableTransactionSignatureCreator signature_creator{tx_to, n_in, ConsumeMoney(fuzzed_data_provider), {.sighash_type = fuzzed_data_provider.ConsumeIntegral<int>()}};
+            std::vector<uint8_t> vch_sig;
+            CKeyID address;
+            if (fuzzed_data_provider.ConsumeBool()) {
+                if (k.IsValid()) {
+                    address = k.GetPubKey().GetID();
+                }
+            } else {
+                address = CKeyID{ConsumeUInt160(fuzzed_data_provider)};
+            }
+            auto script_code = ConsumeScript(fuzzed_data_provider);
+            auto sigversion = fuzzed_data_provider.PickValueInArray({SigVersion::BASE, SigVersion::WITNESS_V0});
+            (void)signature_creator.CreateSig(provider, vch_sig, address, script_code, sigversion);
             std::map<COutPoint, Coin> coins{ConsumeCoins(fuzzed_data_provider)};
             std::map<int, bilingual_str> input_errors;
             (void)SignTransaction(sign_transaction_tx_to, &provider, coins, {.sighash_type = fuzzed_data_provider.ConsumeIntegral<int>()}, input_errors);

--- a/src/test/fuzz/script_sign.cpp
+++ b/src/test/fuzz/script_sign.cpp
@@ -23,6 +23,7 @@
 #include <map>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 void initialize_script_sign()
@@ -132,6 +133,15 @@ FUZZ_TARGET(script_sign, .init = initialize_script_sign)
             (void)signature_creator.CreateSig(provider, vch_sig, address, script_code, sigversion);
             SignatureData sigdata;
             (void)ProduceSignature(provider, signature_creator, script_code, sigdata);
+            if (k.IsValid() && k.IsCompressed()) { // X-only lookup probes compressed key IDs
+                std::vector<CTxOut> spent_outputs(tx_to.vin.size(), CTxOut{CAmount{0}, CScript{}});
+                PrecomputedTransactionData txdata;
+                txdata.Init(tx_to, std::move(spent_outputs), /*force=*/true);
+                MutableTransactionSignatureCreator schnorr_creator{tx_to, n_in, CAmount{0}, &txdata, {.sighash_type = SIGHASH_DEFAULT}};
+                std::vector<uint8_t> schnorr_sig;
+                XOnlyPubKey xonly{k.GetPubKey()};
+                (void)schnorr_creator.CreateSchnorrSig(provider, schnorr_sig, xonly, /*leaf_hash=*/nullptr, /*merkle_root=*/nullptr, SigVersion::TAPROOT);
+            }
             std::map<COutPoint, Coin> coins{ConsumeCoins(fuzzed_data_provider)};
             std::map<int, bilingual_str> input_errors;
             (void)SignTransaction(sign_transaction_tx_to, &provider, coins, {.sighash_type = fuzzed_data_provider.ConsumeIntegral<int>()}, input_errors);

--- a/src/test/psbt_tests.cpp
+++ b/src/test/psbt_tests.cpp
@@ -2,10 +2,21 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
+#include <addresstype.h>
+#include <key.h>
 #include <psbt.h>
+#include <script/descriptor.h>
+#include <script/script.h>
+#include <script/signingprovider.h>
+#include <script/solver.h>
+#include <test/util/setup_common.h>
+#include <util/strencodings.h>
+#include <util/string.h>
 
 #include <boost/test/unit_test.hpp>
-#include <test/util/setup_common.h>
+
+#include <string>
+#include <vector>
 
 BOOST_FIXTURE_TEST_SUITE(psbt_tests, BasicTestingSetup)
 
@@ -214,6 +225,81 @@ BOOST_AUTO_TEST_CASE(merge_proprietary_fields)
     const auto output_it = left.outputs[0].m_proprietary.find(right_prop);
     BOOST_REQUIRE(output_it != left.outputs[0].m_proprietary.end());
     BOOST_CHECK(output_it->value == right_prop.value);
+}
+
+struct PSBTOutputTest {
+    CPubKey pubkey;
+    FlatSigningProvider provider;
+    CScript script_pubkey;
+
+    explicit PSBTOutputTest(std::string descriptor)
+    {
+        CKey key{GenerateRandomKey()};
+        pubkey = key.GetPubKey();
+        provider.keys.emplace(pubkey.GetID(), key);
+
+        util::ReplaceAll(descriptor, "<KEY>", HexStr(pubkey));
+        std::string error;
+        auto descriptors{Parse(descriptor, provider, error, /*require_checksum=*/false)};
+        BOOST_REQUIRE_MESSAGE(!descriptors.empty(), error);
+        std::vector<CScript> output_scripts;
+        BOOST_REQUIRE(descriptors[0]->Expand(/*pos=*/0, provider, output_scripts, provider));
+        BOOST_REQUIRE_EQUAL(output_scripts.size(), 1);
+        script_pubkey = output_scripts[0];
+    }
+
+    PSBTOutput UpdateOutput(bool has_input) const
+    {
+        CMutableTransaction tx;
+        if (has_input) tx.vin.emplace_back();
+        tx.vout.emplace_back(0, script_pubkey);
+        PartiallySignedTransaction psbt{tx};
+        UpdatePSBTOutput(provider, psbt, 0);
+        return psbt.outputs[0];
+    }
+};
+
+BOOST_AUTO_TEST_CASE(update_psbt_output_keypaths)
+{
+    for (bool has_input : {true}) { // TODO: Zero-input updates abort during ECDSA sighash creation.
+        for (const auto& descriptor : {"pkh(<KEY>)", "wpkh(<KEY>)"}) {
+            PSBTOutputTest test{descriptor};
+            auto out{test.UpdateOutput(has_input)};
+            BOOST_CHECK(out.hd_keypaths.contains(test.pubkey));
+            BOOST_CHECK(out.redeem_script.empty());
+            BOOST_CHECK(out.witness_script.empty());
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(update_psbt_output_redeem_script)
+{
+    for (bool has_input : {true}) { // TODO: Zero-input updates abort during ECDSA sighash creation.
+        PSBTOutputTest test{"sh(wpkh(<KEY>))"};
+        auto out{test.UpdateOutput(has_input)};
+        BOOST_CHECK(out.redeem_script == GetScriptForDestination(WitnessV0KeyHash{test.pubkey}));
+        BOOST_CHECK(out.hd_keypaths.contains(test.pubkey));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(update_psbt_output_witness_script)
+{
+    for (bool has_input : {true}) { // TODO: Zero-input updates abort during ECDSA sighash creation.
+        PSBTOutputTest test{"wsh(pk(<KEY>))"};
+        auto out{test.UpdateOutput(has_input)};
+        BOOST_CHECK(out.witness_script == GetScriptForRawPubKey(test.pubkey));
+        BOOST_CHECK(out.hd_keypaths.contains(test.pubkey));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(update_psbt_output_taproot)
+{
+    for (bool has_input : {false, true}) {
+        PSBTOutputTest test{"rawtr(<KEY>)"};
+        auto out{test.UpdateOutput(has_input)};
+        BOOST_CHECK(out.m_tap_bip32_paths.contains(XOnlyPubKey{test.pubkey}));
+        BOOST_CHECK(out.hd_keypaths.empty());
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/psbt_tests.cpp
+++ b/src/test/psbt_tests.cpp
@@ -292,6 +292,16 @@ BOOST_AUTO_TEST_CASE(update_psbt_output_witness_script)
     }
 }
 
+BOOST_AUTO_TEST_CASE(update_psbt_output_miniscript_timelock)
+{
+    for (bool has_input : {true}) { // TODO: Zero-input updates read a missing input through the checker.
+        PSBTOutputTest test{"wsh(and_v(v:pk(<KEY>),older(144)))"};
+        auto out{test.UpdateOutput(has_input)};
+        BOOST_CHECK(GetScriptForDestination(WitnessV0ScriptHash{out.witness_script}) == test.script_pubkey);
+        BOOST_CHECK(out.hd_keypaths.contains(test.pubkey));
+    }
+}
+
 BOOST_AUTO_TEST_CASE(update_psbt_output_taproot)
 {
     for (bool has_input : {false, true}) {

--- a/src/test/psbt_tests.cpp
+++ b/src/test/psbt_tests.cpp
@@ -261,7 +261,7 @@ struct PSBTOutputTest {
 
 BOOST_AUTO_TEST_CASE(update_psbt_output_keypaths)
 {
-    for (bool has_input : {true}) { // TODO: Zero-input updates abort during ECDSA sighash creation.
+    for (bool has_input : {false, true}) {
         for (const auto& descriptor : {"pkh(<KEY>)", "wpkh(<KEY>)"}) {
             PSBTOutputTest test{descriptor};
             auto out{test.UpdateOutput(has_input)};
@@ -274,7 +274,7 @@ BOOST_AUTO_TEST_CASE(update_psbt_output_keypaths)
 
 BOOST_AUTO_TEST_CASE(update_psbt_output_redeem_script)
 {
-    for (bool has_input : {true}) { // TODO: Zero-input updates abort during ECDSA sighash creation.
+    for (bool has_input : {false, true}) {
         PSBTOutputTest test{"sh(wpkh(<KEY>))"};
         auto out{test.UpdateOutput(has_input)};
         BOOST_CHECK(out.redeem_script == GetScriptForDestination(WitnessV0KeyHash{test.pubkey}));
@@ -284,7 +284,7 @@ BOOST_AUTO_TEST_CASE(update_psbt_output_redeem_script)
 
 BOOST_AUTO_TEST_CASE(update_psbt_output_witness_script)
 {
-    for (bool has_input : {true}) { // TODO: Zero-input updates abort during ECDSA sighash creation.
+    for (bool has_input : {false, true}) {
         PSBTOutputTest test{"wsh(pk(<KEY>))"};
         auto out{test.UpdateOutput(has_input)};
         BOOST_CHECK(out.witness_script == GetScriptForRawPubKey(test.pubkey));

--- a/src/test/psbt_tests.cpp
+++ b/src/test/psbt_tests.cpp
@@ -7,9 +7,11 @@
 #include <psbt.h>
 #include <script/descriptor.h>
 #include <script/script.h>
+#include <script/sign.h>
 #include <script/signingprovider.h>
 #include <script/solver.h>
 #include <test/util/setup_common.h>
+#include <test/util/transaction_utils.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 
@@ -309,6 +311,23 @@ BOOST_AUTO_TEST_CASE(update_psbt_output_taproot)
         auto out{test.UpdateOutput(has_input)};
         BOOST_CHECK(out.m_tap_bip32_paths.contains(XOnlyPubKey{test.pubkey}));
         BOOST_CHECK(out.hd_keypaths.empty());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(schnorr_signature_creator_inputs)
+{
+    PSBTOutputTest test{"rawtr(<KEY>)"};
+    CTransaction tx_from{BuildCreditingTransaction(test.script_pubkey)};
+    CMutableTransaction tx_to{BuildSpendingTransaction(CScript(), CScriptWitness(), tx_from)};
+    PrecomputedTransactionData txdata;
+    txdata.Init(tx_to, {tx_from.vout[0]}, /*force=*/true);
+
+    for (auto input_idx : {0U}) { // TODO: A missing input aborts during Schnorr sighash creation.
+        MutableTransactionSignatureCreator creator{tx_to, input_idx, CAmount{0}, &txdata, {.sighash_type = SIGHASH_DEFAULT}};
+        std::vector<uint8_t> sig;
+        BOOST_CHECK_EQUAL(
+            creator.CreateSchnorrSig(test.provider, sig, XOnlyPubKey{test.pubkey}, /*leaf_hash=*/nullptr, /*merkle_root=*/nullptr, SigVersion::TAPROOT),
+            input_idx == 0U);
     }
 }
 

--- a/src/test/psbt_tests.cpp
+++ b/src/test/psbt_tests.cpp
@@ -294,7 +294,7 @@ BOOST_AUTO_TEST_CASE(update_psbt_output_witness_script)
 
 BOOST_AUTO_TEST_CASE(update_psbt_output_miniscript_timelock)
 {
-    for (bool has_input : {true}) { // TODO: Zero-input updates read a missing input through the checker.
+    for (bool has_input : {false, true}) {
         PSBTOutputTest test{"wsh(and_v(v:pk(<KEY>),older(144)))"};
         auto out{test.UpdateOutput(has_input)};
         BOOST_CHECK(GetScriptForDestination(WitnessV0ScriptHash{out.witness_script}) == test.script_pubkey);

--- a/src/test/psbt_tests.cpp
+++ b/src/test/psbt_tests.cpp
@@ -322,7 +322,7 @@ BOOST_AUTO_TEST_CASE(schnorr_signature_creator_inputs)
     PrecomputedTransactionData txdata;
     txdata.Init(tx_to, {tx_from.vout[0]}, /*force=*/true);
 
-    for (auto input_idx : {0U}) { // TODO: A missing input aborts during Schnorr sighash creation.
+    for (auto input_idx : {0U, 1U}) {
         MutableTransactionSignatureCreator creator{tx_to, input_idx, CAmount{0}, &txdata, {.sighash_type = SIGHASH_DEFAULT}};
         std::vector<uint8_t> sig;
         BOOST_CHECK_EQUAL(

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -1424,6 +1424,14 @@ class PSBTTest(BitcoinTestFramework):
         utxo = self.create_outpoints(self.nodes[0], outputs=[{address: 1}])[0]
         self.sync_all()
 
+        self.log.info("Test descriptorprocesspsbt updates PSBT outputs")
+        for has_input in [True]:  # TODO: Zero-input updates abort during ECDSA sighash creation.
+            output_psbt = self.nodes[2].createpsbt([utxo] if has_input else [], {address: 1})
+            processed = self.nodes[2].descriptorprocesspsbt(psbt=output_psbt, descriptors=[descriptor], finalize=False)
+            decoded = self.nodes[2].decodepsbt(processed["psbt"])
+            assert_equal(len(decoded["inputs"]), int(has_input))
+            assert_equal(len(decoded["outputs"][0]["bip32_derivs"]), 1)
+
         psbt = self.nodes[2].createpsbt([utxo], {self.nodes[0].getnewaddress(): 0.99999})
         decoded = self.nodes[2].decodepsbt(psbt)
         test_psbt_input_keys(decoded['inputs'][0], [])

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -1425,7 +1425,7 @@ class PSBTTest(BitcoinTestFramework):
         self.sync_all()
 
         self.log.info("Test descriptorprocesspsbt updates PSBT outputs")
-        for has_input in [True]:  # TODO: Zero-input updates abort during ECDSA sighash creation.
+        for has_input in [False, True]:
             output_psbt = self.nodes[2].createpsbt([utxo] if has_input else [], {address: 1})
             processed = self.nodes[2].descriptorprocesspsbt(psbt=output_psbt, descriptors=[descriptor], finalize=False)
             decoded = self.nodes[2].decodepsbt(processed["psbt"])


### PR DESCRIPTION
**Problem:** `UpdatePSBTOutput()` always constructs a `MutableTransactionSignatureCreator` for input 0 to collect output metadata.
A BIP 370 PSBT can contain outputs before any inputs are added, so `descriptorprocesspsbt` can pass a zero-input transaction to the creator.
ECDSA signing or a miniscript timelock check can then use the missing input and abort.

**Fix:** Make `MutableTransactionSignatureCreator` fail ECDSA and Schnorr/MuSig2 signing and return a rejecting checker when `input_idx` does not refer to an existing transaction input.
Output metadata traversal continues normally, preserving scripts and key origins.

<details>
<summary>Additional explanation</summary>

[BIP 370](https://bips.dev/370/) initializes PSBTv2 with no inputs or outputs and permits the Constructor to add them later.
An output can therefore have useful scripts and key origins before an input exists for a sighash or sequence check.

`UpdatePSBTOutput()` reuses `ProduceSignature()` to traverse the output script while discarding signatures.
With a private key, ECDSA signing can reach `SignatureHash()`, while a miniscript `older()` condition can query `Checker().CheckSequence()`.
`ComputeSchnorrSignatureHash()` is guarded separately because callers with initialized transaction data could otherwise pass the same missing index to `SignatureHashSchnorr()`.

The series progresses in three characterization/fix pairs.

* P2PKH, P2WPKH, and P2SH-P2WPKH metadata, followed by the ECDSA sighash guard and separate zero-input P2PKH and P2WPKH regressions.
* P2WSH-P2PK and P2WSH-miniscript metadata, followed by the rejecting checker and a zero-input `older()` regression.
* Taproot key-origin metadata, followed by the Schnorr/MuSig2 sighash guard and a direct creator test that signs with `input_idx=0` before rejecting `input_idx=1`.
</details>
