### PR TITLE
mempool: saturate transaction info fee delta

### DIFF
--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -12,6 +12,7 @@
 #include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
+#include <limits>
 #include <vector>
 
 BOOST_FIXTURE_TEST_SUITE(mempool_tests, TestingSetup)
@@ -48,6 +49,29 @@ BOOST_AUTO_TEST_CASE(MempoolLookupTest)
 
     // Lookup by Wtxid
     BOOST_CHECK(pool.get(CTransaction(tx).GetWitnessHash()));
+}
+
+BOOST_AUTO_TEST_CASE(MempoolInfoSaturatesFeeDelta)
+{
+    auto& pool{*Assert(m_node.mempool)};
+    TestMemPoolEntryHelper entry{};
+    CMutableTransaction tx{};
+    tx.vin.resize(1);
+    tx.vin[0].scriptSig = CScript{} << OP_1;
+    tx.vout.emplace_back(10 * COIN, CScript{} << OP_1 << OP_EQUAL);
+
+    constexpr CAmount base_fee{10'000};
+    constexpr auto minimum{std::numeric_limits<CAmount>::min()};
+    {
+        LOCK2(cs_main, pool.cs);
+        TryAddToMempool(pool, entry.Fee(base_fee).FromTx(tx));
+    }
+
+    pool.PrioritiseTransaction(tx.GetHash(), minimum);
+    pool.PrioritiseTransaction(tx.GetHash(), -base_fee);
+    auto info{pool.info(tx.GetHash())}; // Without the fix, this signed subtraction traps.
+    BOOST_REQUIRE(info.tx);
+    BOOST_CHECK_EQUAL(info.nFeeDelta, minimum);
 }
 
 BOOST_AUTO_TEST_CASE(MempoolRemoveTest)

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -666,12 +666,15 @@ static void TestAddMatrix()
     BOOST_CHECK_EQUAL(MINI, SaturatingAdd(T{-1}, MINI + 1));
     BOOST_CHECK_EQUAL(MINI + 1, SaturatingAdd(T{-1}, MINI + 2));
     BOOST_CHECK_EQUAL(-1, SaturatingAdd(MINI, MAXI));
+    BOOST_CHECK_EQUAL(MINI, SaturatingSubtract(MINI, T{1}));
+    BOOST_CHECK_EQUAL(MAXI, SaturatingSubtract(MAXI, T{-1}));
 }
 
 BOOST_AUTO_TEST_CASE(util_overflow)
 {
     TestAddMatrixOverflow<unsigned>();
     TestAddMatrix<signed>();
+    BOOST_CHECK_EQUAL(0U, SaturatingSubtract(0U, 1U));
 }
 
 template <typename T>

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -22,6 +22,7 @@
 #include <txgraph.h>
 #include <util/feefrac.h>
 #include <util/hasher.h>
+#include <util/overflow.h>
 #include <util/result.h>
 
 #include <boost/multi_index/hashed_index.hpp>
@@ -285,7 +286,7 @@ private:
 
     static TxMempoolInfo GetInfo(CTxMemPool::indexed_transaction_set::const_iterator it)
     {
-        return TxMempoolInfo{it->GetSharedTx(), it->GetTime(), it->GetFee(), it->GetTxSize(), it->GetModifiedFee() - it->GetFee()};
+        return TxMempoolInfo{it->GetSharedTx(), it->GetTime(), it->GetFee(), it->GetTxSize(), SaturatingSubtract(it->GetModifiedFee(), it->GetFee())};
     }
 
     // Helper to remove all transactions that conflict with a given

--- a/src/util/overflow.h
+++ b/src/util/overflow.h
@@ -58,6 +58,22 @@ template <std::integral T>
     return i + j;
 }
 
+template <std::integral T>
+[[nodiscard]] T SaturatingSubtract(const T i, const T j) noexcept
+{
+    if constexpr (std::numeric_limits<T>::is_signed) {
+        if (j > 0 && i < std::numeric_limits<T>::min() + j) {
+            return std::numeric_limits<T>::min();
+        }
+        if (j < 0 && i > std::numeric_limits<T>::max() + j) {
+            return std::numeric_limits<T>::max();
+        }
+    } else if (i < j) {
+        return T{0};
+    }
+    return i - j;
+}
+
 /**
  * @brief Integer ceiling division (for unsigned values).
  *


### PR DESCRIPTION
**Problem:** An authenticated `prioritisetransaction` call can saturate a transaction's modified fee at `INT64_MIN`.
`CTxMemPool::GetInfo()` then subtracts the positive base fee to derive `nFeeDelta`, causing signed-overflow UB when persistence or relay reads the transaction information.
No unauthenticated peer can create this state.

**Fix:** Saturate the derived subtraction.
The focused Debug `-ftrapv` test exits 133 with the raw subtraction and passes with the fix.
