### PR TITLE
coinstats: reduce UTXO statistics scan overhead

### DIFF
--- a/src/coins.h
+++ b/src/coins.h
@@ -100,6 +100,22 @@ public:
     }
 };
 
+//! Serialized coin data needed for un-hashed UTXO statistics.
+struct CoinStatsValue
+{
+    CAmount nValue{0};
+    uint64_t scriptPubKeySize{0};
+
+    template <typename Stream>
+    void Unserialize(Stream& s)
+    {
+        uint32_t code{0};
+        s >> VARINT(code);
+        s >> Using<AmountCompression>(nValue);
+        ScriptCompression{}.UnserSize(s, scriptPubKeySize);
+    }
+};
+
 struct CCoinsCacheEntry;
 using CoinsCachePair = std::pair<const COutPoint, CCoinsCacheEntry>;
 
@@ -245,6 +261,7 @@ public:
 
     virtual bool GetKey(COutPoint &key) const = 0;
     virtual bool GetValue(Coin &coin) const = 0;
+    virtual bool GetValue(CoinStatsValue& coin) const = 0;
 
     virtual bool Valid() const = 0;
     virtual void Next() = 0;

--- a/src/coins.h
+++ b/src/coins.h
@@ -259,7 +259,15 @@ public:
     CCoinsViewCursor(const uint256& in_block_hash) : block_hash(in_block_hash) {}
     virtual ~CCoinsViewCursor() = default;
 
-    virtual bool GetKey(COutPoint &key) const = 0;
+    //! Returned key is valid until Next().
+    virtual const COutPoint* GetKey() const = 0;
+    bool GetKey(COutPoint& key) const
+    {
+        const auto* key_ref{GetKey()};
+        if (!key_ref) return false;
+        key = *key_ref;
+        return true;
+    }
     virtual bool GetValue(Coin &coin) const = 0;
     virtual bool GetValue(CoinStatsValue& coin) const = 0;
 

--- a/src/compressor.h
+++ b/src/compressor.h
@@ -93,6 +93,31 @@ struct ScriptCompression
             s >> std::span{script};
         }
     }
+
+    //! Consume a compressed script and report the size produced by Unser().
+    template<typename Stream>
+    void UnserSize(Stream& s, uint64_t& script_size) {
+        unsigned int nSize{0};
+        s >> VARINT(nSize);
+        if (nSize < nSpecialScripts) {
+            const unsigned int compressed_size{GetSpecialScriptSize(nSize)};
+            if (nSize == 4 || nSize == 5) {
+                CompressedScript vch(compressed_size, 0x00);
+                s >> std::span{vch};
+                CScript script;
+                DecompressScript(script, nSize, vch);
+                script_size = script.size();
+            } else {
+                s.ignore(compressed_size);
+                script_size = nSize == 0 ? 25 : nSize == 1 ? 23 : 35;
+            }
+            return;
+        }
+
+        nSize -= nSpecialScripts;
+        script_size = nSize > MAX_SCRIPT_SIZE ? 1 : nSize;
+        s.ignore(nSize);
+    }
 };
 
 struct AmountCompression

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -152,7 +152,7 @@ bool CoinStatsIndex::CustomAppend(const interfaces::BlockInfo& block)
 
                 ++m_transaction_output_count;
                 m_total_amount += coin.out.nValue;
-                m_bogo_size += GetBogoSize(coin.out.scriptPubKey);
+                m_bogo_size += GetBogoSize(coin.out.scriptPubKey.size());
             }
 
             // The coinbase tx has no undo data since no former output is spent
@@ -169,7 +169,7 @@ bool CoinStatsIndex::CustomAppend(const interfaces::BlockInfo& block)
 
                     --m_transaction_output_count;
                     m_total_amount -= coin.out.nValue;
-                    m_bogo_size -= GetBogoSize(coin.out.scriptPubKey);
+                    m_bogo_size -= GetBogoSize(coin.out.scriptPubKey.size());
                 }
             }
         }

--- a/src/kernel/coinstats.cpp
+++ b/src/kernel/coinstats.cpp
@@ -86,9 +86,7 @@ template <typename T>
 static void ApplyHash(T& hash_obj, const Txid& hash, const std::map<uint32_t, Coin>& outputs)
 {
     for (auto it = outputs.begin(); it != outputs.end(); ++it) {
-        COutPoint outpoint = COutPoint(hash, it->first);
-        Coin coin = it->second;
-        ApplyCoinHash(hash_obj, outpoint, coin);
+        ApplyCoinHash(hash_obj, COutPoint(hash, it->first), it->second);
     }
 }
 

--- a/src/kernel/coinstats.cpp
+++ b/src/kernel/coinstats.cpp
@@ -34,22 +34,6 @@ CCoinsStats::CCoinsStats(int block_height, const uint256& block_hash)
     : nHeight(block_height),
       hashBlock(block_hash) {}
 
-// Database-independent metric indicating the UTXO set size
-uint64_t GetBogoSize(const CScript& script_pub_key)
-{
-    return GetBogoSize(script_pub_key.size());
-}
-
-uint64_t GetBogoSize(uint64_t script_pub_key_size)
-{
-    return 32 /* txid */ +
-           4 /* vout index */ +
-           4 /* height + coinbase */ +
-           8 /* amount */ +
-           2 /* scriptPubKey len */ +
-           script_pub_key_size /* scriptPubKey */;
-}
-
 template <typename T>
 static void TxOutSer(T& ss, const COutPoint& outpoint, const Coin& coin)
 {
@@ -136,7 +120,7 @@ static std::optional<CCoinsStats> ComputeUTXOStats(T hash_obj, const CCoinsViewD
             if (stats.total_amount.has_value()) {
                 stats.total_amount = CheckedAdd(*stats.total_amount, coin.out.nValue);
             }
-            stats.nBogoSize += GetBogoSize(coin.out.scriptPubKey);
+            stats.nBogoSize += GetBogoSize(coin.out.scriptPubKey.size());
             ApplyCoinHash(hash_obj, coin_hash_scratch, key, coin);
             stats.coins_count++;
         } else {

--- a/src/kernel/coinstats.cpp
+++ b/src/kernel/coinstats.cpp
@@ -108,12 +108,11 @@ static std::optional<CCoinsStats> ComputeUTXOStats(T hash_obj, const CCoinsViewD
     bool have_prevkey{false};
     while (pcursor->Valid()) {
         if (interruption_point && stats.coins_count % INTERRUPT_CHECK_INTERVAL == 0) interruption_point();
-        COutPoint key;
         Coin coin;
-        if (pcursor->GetKey(key) && pcursor->GetValue(coin)) {
-            if (!have_prevkey || key.hash != prevkey) {
+        if (const auto* key{pcursor->GetKey()}; key && pcursor->GetValue(coin)) {
+            if (!have_prevkey || key->hash != prevkey) {
                 stats.nTransactions++;
-                prevkey = key.hash;
+                prevkey = key->hash;
                 have_prevkey = true;
             }
             stats.nTransactionOutputs++;
@@ -121,7 +120,7 @@ static std::optional<CCoinsStats> ComputeUTXOStats(T hash_obj, const CCoinsViewD
                 stats.total_amount = CheckedAdd(*stats.total_amount, coin.out.nValue);
             }
             stats.nBogoSize += GetBogoSize(coin.out.scriptPubKey.size());
-            ApplyCoinHash(hash_obj, coin_hash_scratch, key, coin);
+            ApplyCoinHash(hash_obj, coin_hash_scratch, *key, coin);
             stats.coins_count++;
         } else {
             LogError("%s: unable to read value\n", __func__);
@@ -150,12 +149,11 @@ static std::optional<CCoinsStats> ComputeUTXOStats(std::nullptr_t, const CCoinsV
     bool have_prevkey{false};
     while (pcursor->Valid()) {
         if (interruption_point && stats.coins_count % INTERRUPT_CHECK_INTERVAL == 0) interruption_point();
-        COutPoint key;
         CoinStatsValue coin;
-        if (pcursor->GetKey(key) && pcursor->GetValue(coin)) {
-            if (!have_prevkey || key.hash != prevkey) {
+        if (const auto* key{pcursor->GetKey()}; key && pcursor->GetValue(coin)) {
+            if (!have_prevkey || key->hash != prevkey) {
                 stats.nTransactions++;
-                prevkey = key.hash;
+                prevkey = key->hash;
                 have_prevkey = true;
             }
             stats.nTransactionOutputs++;

--- a/src/kernel/coinstats.cpp
+++ b/src/kernel/coinstats.cpp
@@ -22,9 +22,7 @@
 #include <validation.h>
 
 #include <cstddef>
-#include <map>
 #include <memory>
-#include <utility>
 
 namespace kernel {
 
@@ -82,27 +80,6 @@ void RemoveCoinHash(MuHash3072& muhash, const COutPoint& outpoint, const Coin& c
 //! It is also possible, though very unlikely, that a change in this
 //! construction could cause a previously invalid (and potentially malicious)
 //! UTXO snapshot to be considered valid.
-template <typename T>
-static void ApplyHash(T& hash_obj, const Txid& hash, const std::map<uint32_t, Coin>& outputs)
-{
-    for (auto it = outputs.begin(); it != outputs.end(); ++it) {
-        ApplyCoinHash(hash_obj, COutPoint(hash, it->first), it->second);
-    }
-}
-
-static void ApplyStats(CCoinsStats& stats, const std::map<uint32_t, Coin>& outputs)
-{
-    assert(!outputs.empty());
-    stats.nTransactions++;
-    for (auto it = outputs.begin(); it != outputs.end(); ++it) {
-        stats.nTransactionOutputs++;
-        if (stats.total_amount.has_value()) {
-            stats.total_amount = CheckedAdd(*stats.total_amount, it->second.out.nValue);
-        }
-        stats.nBogoSize += GetBogoSize(it->second.out.scriptPubKey);
-    }
-}
-
 //! Calculate statistics about the unspent transaction output set
 template <typename T>
 static std::optional<CCoinsStats> ComputeUTXOStats(T hash_obj, const CCoinsViewDB& view, node::BlockManager& blockman, const std::function<void()>& interruption_point)
@@ -117,19 +94,23 @@ static std::optional<CCoinsStats> ComputeUTXOStats(T hash_obj, const CCoinsViewD
     CCoinsStats stats{Assert(pindex)->nHeight, pindex->GetBlockHash()};
 
     Txid prevkey;
-    std::map<uint32_t, Coin> outputs;
+    bool have_prevkey{false};
     while (pcursor->Valid()) {
         if (interruption_point) interruption_point();
         COutPoint key;
         Coin coin;
         if (pcursor->GetKey(key) && pcursor->GetValue(coin)) {
-            if (!outputs.empty() && key.hash != prevkey) {
-                ApplyStats(stats, outputs);
-                ApplyHash(hash_obj, prevkey, outputs);
-                outputs.clear();
+            if (!have_prevkey || key.hash != prevkey) {
+                stats.nTransactions++;
+                prevkey = key.hash;
+                have_prevkey = true;
             }
-            prevkey = key.hash;
-            outputs[key.n] = std::move(coin);
+            stats.nTransactionOutputs++;
+            if (stats.total_amount.has_value()) {
+                stats.total_amount = CheckedAdd(*stats.total_amount, coin.out.nValue);
+            }
+            stats.nBogoSize += GetBogoSize(coin.out.scriptPubKey);
+            ApplyCoinHash(hash_obj, key, coin);
             stats.coins_count++;
         } else {
             LogError("%s: unable to read value\n", __func__);
@@ -137,11 +118,6 @@ static std::optional<CCoinsStats> ComputeUTXOStats(T hash_obj, const CCoinsViewD
         }
         pcursor->Next();
     }
-    if (!outputs.empty()) {
-        ApplyStats(stats, outputs);
-        ApplyHash(hash_obj, prevkey, outputs);
-    }
-
     FinalizeHash(hash_obj, stats);
 
     stats.nDiskSize = view.EstimateSize();

--- a/src/kernel/coinstats.cpp
+++ b/src/kernel/coinstats.cpp
@@ -59,17 +59,23 @@ static size_t TxOutSerSize(const Coin& coin)
            coin.out.scriptPubKey.size();
 }
 
-static void ApplyCoinHash(HashWriter& ss, const COutPoint& outpoint, const Coin& coin)
+static void ApplyCoinHash(HashWriter& ss, DataStream&, const COutPoint& outpoint, const Coin& coin)
 {
     TxOutSer(ss, outpoint, coin);
+}
+
+static void ApplyCoinHash(MuHash3072& muhash, DataStream& ss, const COutPoint& outpoint, const Coin& coin)
+{
+    ScopedDataStreamUsage scoped_stream{ss};
+    ss.reserve(TxOutSerSize(coin));
+    TxOutSer(ss, outpoint, coin);
+    muhash.Insert(MakeUCharSpan(ss));
 }
 
 void ApplyCoinHash(MuHash3072& muhash, const COutPoint& outpoint, const Coin& coin)
 {
     DataStream ss{};
-    ss.reserve(TxOutSerSize(coin));
-    TxOutSer(ss, outpoint, coin);
-    muhash.Insert(MakeUCharSpan(ss));
+    ApplyCoinHash(muhash, ss, outpoint, coin);
 }
 
 void RemoveCoinHash(MuHash3072& muhash, const COutPoint& outpoint, const Coin& coin)
@@ -104,6 +110,7 @@ static std::optional<CCoinsStats> ComputeUTXOStats(T hash_obj, const CCoinsViewD
         pindex = blockman.LookupBlockIndex(pcursor->GetBestBlock());
     }
     CCoinsStats stats{Assert(pindex)->nHeight, pindex->GetBlockHash()};
+    DataStream coin_hash_scratch{};
 
     Txid prevkey;
     bool have_prevkey{false};
@@ -122,7 +129,7 @@ static std::optional<CCoinsStats> ComputeUTXOStats(T hash_obj, const CCoinsViewD
                 stats.total_amount = CheckedAdd(*stats.total_amount, coin.out.nValue);
             }
             stats.nBogoSize += GetBogoSize(coin.out.scriptPubKey);
-            ApplyCoinHash(hash_obj, key, coin);
+            ApplyCoinHash(hash_obj, coin_hash_scratch, key, coin);
             stats.coins_count++;
         } else {
             LogError("%s: unable to read value\n", __func__);

--- a/src/kernel/coinstats.cpp
+++ b/src/kernel/coinstats.cpp
@@ -70,8 +70,6 @@ void RemoveCoinHash(MuHash3072& muhash, const COutPoint& outpoint, const Coin& c
     muhash.Remove(MakeUCharSpan(ss));
 }
 
-static void ApplyCoinHash(std::nullptr_t, const COutPoint& outpoint, const Coin& coin) {}
-
 //! Warning: be very careful when changing this! assumeutxo and UTXO snapshot
 //! validation commitments are reliant on the hash constructed by this
 //! function.
@@ -152,6 +150,46 @@ static std::optional<CCoinsStats> ComputeUTXOStats(T hash_obj, const CCoinsViewD
     return stats;
 }
 
+static std::optional<CCoinsStats> ComputeUTXOStats(std::nullptr_t, const CCoinsViewDB& view, node::BlockManager& blockman, const std::function<void()>& interruption_point)
+{
+    std::unique_ptr<CCoinsViewCursor> pcursor;
+    CBlockIndex* pindex;
+    {
+        LOCK(::cs_main);
+        pcursor = view.Cursor();
+        pindex = blockman.LookupBlockIndex(pcursor->GetBestBlock());
+    }
+    CCoinsStats stats{Assert(pindex)->nHeight, pindex->GetBlockHash()};
+
+    Txid prevkey;
+    bool have_prevkey{false};
+    while (pcursor->Valid()) {
+        if (interruption_point) interruption_point();
+        COutPoint key;
+        Coin coin;
+        if (pcursor->GetKey(key) && pcursor->GetValue(coin)) {
+            if (!have_prevkey || key.hash != prevkey) {
+                stats.nTransactions++;
+                prevkey = key.hash;
+                have_prevkey = true;
+            }
+            stats.nTransactionOutputs++;
+            if (stats.total_amount.has_value()) {
+                stats.total_amount = CheckedAdd(*stats.total_amount, coin.out.nValue);
+            }
+            stats.nBogoSize += GetBogoSize(coin.out.scriptPubKey);
+            stats.coins_count++;
+        } else {
+            LogError("%s: unable to read value\n", __func__);
+            return std::nullopt;
+        }
+        pcursor->Next();
+    }
+
+    stats.nDiskSize = view.EstimateSize();
+    return stats;
+}
+
 std::optional<CCoinsStats> ComputeUTXOStats(CoinStatsHashType hash_type, const CCoinsViewDB& view, node::BlockManager& blockman, const std::function<void()>& interruption_point)
 {
     return [&]() -> std::optional<CCoinsStats> {
@@ -182,6 +220,5 @@ static void FinalizeHash(MuHash3072& muhash, CCoinsStats& stats)
     muhash.Finalize(out);
     stats.hashSerialized = out;
 }
-static void FinalizeHash(std::nullptr_t, CCoinsStats& stats) {}
 
 } // namespace kernel

--- a/src/kernel/coinstats.cpp
+++ b/src/kernel/coinstats.cpp
@@ -23,9 +23,12 @@
 #include <validation.h>
 
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 
 namespace kernel {
+
+static constexpr uint64_t INTERRUPT_CHECK_INTERVAL{8192};
 
 CCoinsStats::CCoinsStats(int block_height, const uint256& block_hash)
     : nHeight(block_height),
@@ -115,7 +118,7 @@ static std::optional<CCoinsStats> ComputeUTXOStats(T hash_obj, const CCoinsViewD
     Txid prevkey;
     bool have_prevkey{false};
     while (pcursor->Valid()) {
-        if (interruption_point) interruption_point();
+        if (interruption_point && stats.coins_count % INTERRUPT_CHECK_INTERVAL == 0) interruption_point();
         COutPoint key;
         Coin coin;
         if (pcursor->GetKey(key) && pcursor->GetValue(coin)) {
@@ -157,7 +160,7 @@ static std::optional<CCoinsStats> ComputeUTXOStats(std::nullptr_t, const CCoinsV
     Txid prevkey;
     bool have_prevkey{false};
     while (pcursor->Valid()) {
-        if (interruption_point) interruption_point();
+        if (interruption_point && stats.coins_count % INTERRUPT_CHECK_INTERVAL == 0) interruption_point();
         COutPoint key;
         Coin coin;
         if (pcursor->GetKey(key) && pcursor->GetValue(coin)) {

--- a/src/kernel/coinstats.cpp
+++ b/src/kernel/coinstats.cpp
@@ -37,12 +37,17 @@ CCoinsStats::CCoinsStats(int block_height, const uint256& block_hash)
 // Database-independent metric indicating the UTXO set size
 uint64_t GetBogoSize(const CScript& script_pub_key)
 {
+    return GetBogoSize(script_pub_key.size());
+}
+
+uint64_t GetBogoSize(uint64_t script_pub_key_size)
+{
     return 32 /* txid */ +
            4 /* vout index */ +
            4 /* height + coinbase */ +
            8 /* amount */ +
            2 /* scriptPubKey len */ +
-           script_pub_key.size() /* scriptPubKey */;
+           script_pub_key_size /* scriptPubKey */;
 }
 
 template <typename T>
@@ -162,7 +167,7 @@ static std::optional<CCoinsStats> ComputeUTXOStats(std::nullptr_t, const CCoinsV
     while (pcursor->Valid()) {
         if (interruption_point && stats.coins_count % INTERRUPT_CHECK_INTERVAL == 0) interruption_point();
         COutPoint key;
-        Coin coin;
+        CoinStatsValue coin;
         if (pcursor->GetKey(key) && pcursor->GetValue(coin)) {
             if (!have_prevkey || key.hash != prevkey) {
                 stats.nTransactions++;
@@ -171,9 +176,9 @@ static std::optional<CCoinsStats> ComputeUTXOStats(std::nullptr_t, const CCoinsV
             }
             stats.nTransactionOutputs++;
             if (stats.total_amount.has_value()) {
-                stats.total_amount = CheckedAdd(*stats.total_amount, coin.out.nValue);
+                stats.total_amount = CheckedAdd(*stats.total_amount, coin.nValue);
             }
-            stats.nBogoSize += GetBogoSize(coin.out.scriptPubKey);
+            stats.nBogoSize += GetBogoSize(coin.scriptPubKeySize);
             stats.coins_count++;
         } else {
             LogError("%s: unable to read value\n", __func__);

--- a/src/kernel/coinstats.cpp
+++ b/src/kernel/coinstats.cpp
@@ -11,6 +11,7 @@
 #include <node/blockstorage.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
+#include <serialize.h>
 #include <span.h>
 #include <streams.h>
 #include <sync.h>
@@ -49,6 +50,15 @@ static void TxOutSer(T& ss, const COutPoint& outpoint, const Coin& coin)
     ss << coin.out;
 }
 
+static size_t TxOutSerSize(const Coin& coin)
+{
+    return Txid::size() + sizeof(uint32_t) +
+           sizeof(uint32_t) +
+           sizeof(coin.out.nValue) +
+           GetSizeOfCompactSize(coin.out.scriptPubKey.size()) +
+           coin.out.scriptPubKey.size();
+}
+
 static void ApplyCoinHash(HashWriter& ss, const COutPoint& outpoint, const Coin& coin)
 {
     TxOutSer(ss, outpoint, coin);
@@ -57,6 +67,7 @@ static void ApplyCoinHash(HashWriter& ss, const COutPoint& outpoint, const Coin&
 void ApplyCoinHash(MuHash3072& muhash, const COutPoint& outpoint, const Coin& coin)
 {
     DataStream ss{};
+    ss.reserve(TxOutSerSize(coin));
     TxOutSer(ss, outpoint, coin);
     muhash.Insert(MakeUCharSpan(ss));
 }
@@ -64,6 +75,7 @@ void ApplyCoinHash(MuHash3072& muhash, const COutPoint& outpoint, const Coin& co
 void RemoveCoinHash(MuHash3072& muhash, const COutPoint& outpoint, const Coin& coin)
 {
     DataStream ss{};
+    ss.reserve(TxOutSerSize(coin));
     TxOutSer(ss, outpoint, coin);
     muhash.Remove(MakeUCharSpan(ss));
 }

--- a/src/kernel/coinstats.h
+++ b/src/kernel/coinstats.h
@@ -73,6 +73,7 @@ struct CCoinsStats {
 };
 
 uint64_t GetBogoSize(const CScript& script_pub_key);
+uint64_t GetBogoSize(uint64_t script_pub_key_size);
 
 void ApplyCoinHash(MuHash3072& muhash, const COutPoint& outpoint, const Coin& coin);
 void RemoveCoinHash(MuHash3072& muhash, const COutPoint& outpoint, const Coin& coin);

--- a/src/kernel/coinstats.h
+++ b/src/kernel/coinstats.h
@@ -16,7 +16,6 @@
 class CCoinsViewDB;
 class Coin;
 class COutPoint;
-class CScript;
 class MuHash3072;
 namespace node {
 class BlockManager;
@@ -72,8 +71,15 @@ struct CCoinsStats {
     CCoinsStats(int block_height, const uint256& block_hash);
 };
 
-uint64_t GetBogoSize(const CScript& script_pub_key);
-uint64_t GetBogoSize(uint64_t script_pub_key_size);
+constexpr uint64_t GetBogoSize(uint64_t script_pub_key_size)
+{
+    return 32 /* txid */ +
+           4 /* vout index */ +
+           4 /* height + coinbase */ +
+           8 /* amount */ +
+           2 /* scriptPubKey len */ +
+           script_pub_key_size /* scriptPubKey */;
+}
 
 void ApplyCoinHash(MuHash3072& muhash, const COutPoint& outpoint, const Coin& coin);
 void RemoveCoinHash(MuHash3072& muhash, const COutPoint& outpoint, const Coin& coin);

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -337,6 +337,38 @@ BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_FIXTURE_TEST_SUITE(coins_tests, BasicTestingSetup)
 
+BOOST_AUTO_TEST_CASE(coin_stats_value_matches_coin_deserialization)
+{
+    auto compressed_key{GenerateRandomKey()};
+    auto uncompressed_key{GenerateRandomKey(/*compressed=*/false)};
+    auto redeem_script{CScript{OP_TRUE}};
+    auto scripts{std::vector<CScript>{
+        CScript{} << OP_DUP << OP_HASH160 << ToByteVector(compressed_key.GetPubKey().GetID()) << OP_EQUALVERIFY << OP_CHECKSIG,
+        CScript{} << OP_HASH160 << ToByteVector(CScriptID{redeem_script}) << OP_EQUAL,
+        CScript{} << ToByteVector(compressed_key.GetPubKey()) << OP_CHECKSIG,
+        CScript{} << ToByteVector(uncompressed_key.GetPubKey()) << OP_CHECKSIG,
+        CScript{} << OP_RETURN << std::vector<unsigned char>(42, 0),
+        CScript{} << OP_RETURN << std::vector<unsigned char>(MAX_SCRIPT_SIZE + 1, 0),
+    }};
+
+    for (const CScript& script : scripts) {
+        auto input{Coin{CTxOut{42 * COIN, script}, /*nHeight=*/100, /*fCoinBase=*/false}};
+        DataStream serialized{};
+        serialized << input;
+
+        Coin full{};
+        CoinStatsValue stats{};
+        DataStream full_reader{serialized};
+        DataStream stats_reader{serialized};
+        full_reader >> full;
+        stats_reader >> stats;
+
+        BOOST_CHECK_EQUAL(stats.nValue, full.out.nValue);
+        BOOST_CHECK_EQUAL(stats.scriptPubKeySize, full.out.scriptPubKey.size());
+        BOOST_CHECK_EQUAL(stats_reader.size(), 0U);
+    }
+}
+
 struct UpdateTest : BasicTestingSetup {
 // Store of all necessary tx and undo data for next test
 typedef std::map<COutPoint, std::tuple<CTransaction,CTxUndo,Coin>> UtxoData;

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -17,6 +17,8 @@
 #include <util/check.h>
 #include <util/strencodings.h>
 
+#include <array>
+#include <limits>
 #include <map>
 #include <string>
 #include <variant>
@@ -300,6 +302,35 @@ BOOST_FIXTURE_TEST_CASE(coins_cache_dbbase_simulation_test, CacheTest)
 {
     CCoinsViewDB db_base{{.path = "test", .cache_bytes = 8_MiB, .memory_only = true}, {}};
     SimulationTest(&db_base, true);
+}
+
+BOOST_FIXTURE_TEST_CASE(coins_db_cursor_order, BasicTestingSetup)
+{
+    CCoinsViewDB db_base{{.path = "test", .cache_bytes = 8_MiB, .memory_only = true}, {}};
+    CCoinsViewCache cache{&db_base};
+    const Txid txid{Txid::FromUint256(m_rng.rand256())};
+    constexpr std::array<uint32_t, 7> output_indices{
+        0, 1, 127, 128, 255, 256, std::numeric_limits<uint32_t>::max()};
+    for (const uint32_t output_index : output_indices) {
+        cache.EmplaceCoinInternalDANGER(
+            COutPoint{txid, output_index},
+            Coin{CTxOut{1, CScript{}}, /*nHeight=*/1, /*fCoinBase=*/false});
+    }
+    cache.SetBestBlock(m_rng.rand256());
+    cache.Sync();
+
+    const auto cursor{db_base.Cursor()};
+    BOOST_REQUIRE(cursor);
+    std::vector<uint32_t> cursor_indices;
+    while (cursor->Valid()) {
+        COutPoint outpoint;
+        BOOST_REQUIRE(cursor->GetKey(outpoint));
+        BOOST_CHECK_EQUAL(outpoint.hash, txid);
+        cursor_indices.push_back(outpoint.n);
+        cursor->Next();
+    }
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+        cursor_indices.begin(), cursor_indices.end(), output_indices.begin(), output_indices.end());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -323,8 +323,13 @@ BOOST_FIXTURE_TEST_CASE(coins_db_cursor_order, BasicTestingSetup)
     BOOST_REQUIRE(cursor);
     std::vector<uint32_t> cursor_indices;
     while (cursor->Valid()) {
+        const auto* outpoint_ref{cursor->GetKey()};
+        BOOST_REQUIRE(outpoint_ref);
+        Coin coin{};
+        BOOST_REQUIRE(cursor->GetValue(coin));
         COutPoint outpoint;
         BOOST_REQUIRE(cursor->GetKey(outpoint));
+        BOOST_CHECK(*outpoint_ref == outpoint);
         BOOST_CHECK_EQUAL(outpoint.hash, txid);
         cursor_indices.push_back(outpoint.n);
         cursor->Next();

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -224,7 +224,7 @@ public:
         CCoinsViewCursor(in_block_hash), pcursor(pcursorIn) {}
     ~CCoinsViewDBCursor() = default;
 
-    bool GetKey(COutPoint &key) const override;
+    const COutPoint* GetKey() const override;
     bool GetValue(Coin &coin) const override;
     bool GetValue(CoinStatsValue& coin) const override;
 
@@ -257,14 +257,12 @@ std::unique_ptr<CCoinsViewCursor> CCoinsViewDB::Cursor() const
     return i;
 }
 
-bool CCoinsViewDBCursor::GetKey(COutPoint &key) const
+const COutPoint* CCoinsViewDBCursor::GetKey() const
 {
-    // Return cached key
     if (keyTmp.first == DB_COIN) {
-        key = keyTmp.second;
-        return true;
+        return &keyTmp.second;
     }
-    return false;
+    return nullptr;
 }
 
 bool CCoinsViewDBCursor::GetValue(Coin &coin) const

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -226,6 +226,7 @@ public:
 
     bool GetKey(COutPoint &key) const override;
     bool GetValue(Coin &coin) const override;
+    bool GetValue(CoinStatsValue& coin) const override;
 
     bool Valid() const override;
     void Next() override;
@@ -267,6 +268,11 @@ bool CCoinsViewDBCursor::GetKey(COutPoint &key) const
 }
 
 bool CCoinsViewDBCursor::GetValue(Coin &coin) const
+{
+    return pcursor->GetValue(coin);
+}
+
+bool CCoinsViewDBCursor::GetValue(CoinStatsValue& coin) const
 {
     return pcursor->GetValue(coin);
 }

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -398,6 +398,10 @@ class BlockchainTest(BitcoinTestFramework):
         # hash_type none should not return a UTXO set hash.
         res5 = node.gettxoutsetinfo(hash_type='none')
         assert 'hash_serialized_3' not in res5
+        del res5['disk_size']
+        res_without_hash = res.copy()
+        del res_without_hash['hash_serialized_3']
+        assert_equal(res5, res_without_hash)
 
         # hash_type muhash should return a different UTXO set hash.
         res6 = node.gettxoutsetinfo(hash_type='muhash')


### PR DESCRIPTION
**Problem:** UTXO statistics scans allocate a map per transaction, copy cursor keys, and construct full scripts for `hash_type=none`, even though the cursor returns entries in order and the un-hashed result only needs script sizes.

**Fix:** Stream cursor entries directly into hash calculations, reuse the MuHash serialization buffer, and decode only the amount and script size when no hash is requested. The series also batches interruption checks, inlines the fixed bogo size, and borrows cached cursor keys.
