### PR TITLE
kernel: accept NUL-terminated import paths

### DIFF
--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -1145,7 +1145,8 @@ int btck_chainstate_manager_import_blocks(btck_ChainstateManager* chainman, cons
         import_files.reserve(block_file_paths_data_len);
         for (uint32_t i = 0; i < block_file_paths_data_len; i++) {
             if (block_file_paths_data[i] != nullptr) {
-                import_files.emplace_back(std::string{block_file_paths_data[i], block_file_paths_lens[i]}.c_str());
+                const size_t path_len{block_file_paths_lens ? block_file_paths_lens[i] : std::strlen(block_file_paths_data[i])};
+                import_files.emplace_back(fs::PathFromString({block_file_paths_data[i], path_len}));
             }
         }
         auto& chainman_ref{*btck_ChainstateManager::get(chainman).m_chainman};

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -1283,7 +1283,7 @@ BITCOINKERNEL_API btck_BlockValidationState* BITCOINKERNEL_WARN_UNUSED_RESULT bt
  *
  * @param[in] chainstate_manager        Non-null.
  * @param[in] block_file_paths_data     Nullable, array of block files described by their full filesystem paths.
- * @param[in] block_file_paths_lens     Nullable, array containing the lengths of each of the paths.
+ * @param[in] block_file_paths_lens     Nullable, array containing the lengths of each path. If null, paths are NUL-terminated.
  * @param[in] block_file_paths_data_len Length of the block_file_paths_data and block_file_paths_len arrays.
  * @return                              0 if the import blocks call was completed successfully, non-zero otherwise.
  */

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -4,6 +4,7 @@
 
 #include <kernel/bitcoinkernel.h>
 #include <kernel/bitcoinkernel_wrapper.h>
+#include <streams.h>
 #include <util/fs.h>
 
 #define BOOST_TEST_MODULE Bitcoin Kernel Test Suite
@@ -831,6 +832,40 @@ std::unique_ptr<ChainMan> create_chainman(TestDirectory& test_directory,
 
     auto chainman{std::make_unique<ChainMan>(context, chainman_opts)};
     return chainman;
+}
+
+BOOST_AUTO_TEST_CASE(btck_import_blocks_null_path_lengths)
+{
+    auto test_directory{TestDirectory{"import_blocks_null_lens_bitcoin_kernel"}};
+
+    // Call the documented C API directly with NUL-terminated paths.
+    auto* context_options{btck_context_options_create()};
+    auto* chain_params{btck_chain_parameters_create(btck_ChainType_REGTEST)};
+    btck_context_options_set_chainparams(context_options, chain_params);
+    auto* context{btck_context_create(context_options)};
+    BOOST_REQUIRE(context);
+    auto data_dir{PathToString(test_directory.m_directory)};
+    auto blocks_dir{PathToString(test_directory.m_directory / "blocks")};
+    auto* options{btck_chainstate_manager_options_create(context, data_dir.c_str(), data_dir.size(), blocks_dir.c_str(), blocks_dir.size())};
+    BOOST_REQUIRE(options);
+    btck_chainstate_manager_options_update_block_tree_db_in_memory(options, 1);
+    btck_chainstate_manager_options_update_chainstate_db_in_memory(options, 1);
+    auto* chainman{btck_chainstate_manager_create(options)};
+    BOOST_REQUIRE(chainman);
+
+    auto empty_blk{test_directory.m_directory / "empty_blk.dat"};
+    {
+        AutoFile file{fsbridge::fopen(empty_blk, "wb")};
+        BOOST_REQUIRE(!file.IsNull());
+    }
+    const char* paths[]{empty_blk.c_str()};
+    BOOST_CHECK_EQUAL(btck_chainstate_manager_import_blocks(chainman, paths, nullptr, 1), 0);
+
+    btck_chainstate_manager_destroy(chainman);
+    btck_chainstate_manager_options_destroy(options);
+    btck_context_destroy(context);
+    btck_context_options_destroy(context_options);
+    btck_chain_parameters_destroy(chain_params);
 }
 
 void chainman_reindex_test(TestDirectory& test_directory)


### PR DESCRIPTION
**Problem:** `btck_chainstate_manager_import_blocks()` documents `block_file_paths_lens` as nullable, but dereferences it unconditionally.
A Kernel C or FFI caller following that contract segfaults when it passes NUL-terminated paths without a length array.
This does not affect `bitcoind` or any P2P or RPC path.

**Fix:** When the length array is absent, derive each non-null path length with `std::strlen()` and construct the path from those bytes.
Clarify the header documentation and cover the documented use through the raw C API.
The focused regression test exits with status 139 without the fallback and passes with it.
