### PR TITLE
net: limit concurrent headers redownloads in IBD

### DIFF
--- a/src/headerssync.cpp
+++ b/src/headerssync.cpp
@@ -82,7 +82,8 @@ HeadersSyncState::ProcessingResult HeadersSyncState::ProcessNextHeaders(
         // threshold (at which point m_download_state is updated to REDOWNLOAD).
         ret.success = ValidateAndStoreHeadersCommitments(received_headers);
         if (ret.success) {
-            if (full_headers_message || m_download_state == State::REDOWNLOAD) {
+            ret.entered_redownload = m_download_state == State::REDOWNLOAD;
+            if (full_headers_message || ret.entered_redownload) {
                 // A full headers message means the peer may have more to give us;
                 // also if we just switched to REDOWNLOAD then we need to re-request
                 // headers from the beginning.

--- a/src/headerssync.h
+++ b/src/headerssync.h
@@ -148,6 +148,7 @@ public:
         std::vector<CBlockHeader> pow_validated_headers;
         bool success{false};
         bool request_more{false};
+        bool entered_redownload{false};
     };
 
     /** Process a batch of headers, once a sync via this mechanism has started
@@ -169,6 +170,7 @@ public:
      *                       aborted; true otherwise.
      * ProcessingResult.request_more: if true, the caller is suggested to call
      *                       NextHeadersRequestLocator and send a getheaders message using it.
+     * ProcessingResult.entered_redownload: true if this call entered REDOWNLOAD.
      */
     ProcessingResult ProcessNextHeaders(std::span<const CBlockHeader>
             received_headers, bool full_headers_message);

--- a/src/headerssync.h
+++ b/src/headerssync.h
@@ -128,6 +128,9 @@ public:
     /** Return the amount of work in the chain received during the PRESYNC phase. */
     arith_uint256 GetPresyncWork() const { return m_current_chain_work; }
 
+    /** Return the number of compressed headers retained during REDOWNLOAD. */
+    size_t GetRedownloadBufferSize() const { return m_redownloaded_headers.size(); }
+
     /** Construct a HeadersSyncState object representing a headers sync via this
      *  download-twice mechanism).
      *

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -767,6 +767,8 @@ private:
         EXCLUSIVE_LOCKS_REQUIRED(peer.m_headers_sync_mutex, !m_headers_presync_mutex, g_msgproc_mutex);
     void ClearHeadersSyncState(Peer& peer)
         EXCLUSIVE_LOCKS_REQUIRED(peer.m_headers_sync_mutex, !m_headers_presync_mutex);
+    bool MayStartHeadersRedownload(const CNode& pfrom)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_headers_presync_mutex);
     /** Check work on a headers chain to be processed, and if insufficient,
      * initiate our anti-DoS headers sync mechanism.
      *
@@ -2930,12 +2932,26 @@ void PeerManagerImpl::ClearHeadersSyncState(Peer& peer)
     WITH_LOCK(m_headers_presync_mutex, m_headers_presync_stats.erase(peer.m_id));
 }
 
+bool PeerManagerImpl::MayStartHeadersRedownload(const CNode& pfrom)
+{
+    if (!pfrom.IsInboundConn() || !m_chainman.IsInitialBlockDownload()) return true;
+    LOCK(m_headers_presync_mutex);
+    // Entries without presync height/time are in REDOWNLOAD.
+    return std::ranges::count_if(m_headers_presync_stats, [](auto& entry) { return !entry.second.second; }) < MAX_OUTBOUND_FULL_RELAY_CONNECTIONS;
+}
+
 bool PeerManagerImpl::IsContinuationOfLowWorkHeadersSync(Peer& peer, CNode& pfrom, std::vector<CBlockHeader>& headers)
 {
     if (peer.m_headers_sync) {
         auto result = peer.m_headers_sync->ProcessNextHeaders(headers, headers.size() == m_opts.max_headers_result);
         // If it is a valid continuation, we should treat the existing getheaders request as responded to.
         if (result.success) peer.m_last_getheaders_timestamp = {};
+        if (result.entered_redownload && !MayStartHeadersRedownload(pfrom)) {
+            LogDebug(BCLog::NET, "Ignoring low-work chain (height=%d) from peer=%d: too many headers redownloads in progress", peer.m_headers_sync->GetPresyncHeight(), pfrom.GetId());
+            ClearHeadersSyncState(peer);
+            headers.clear();
+            return true;
+        }
         if (result.request_more) {
             auto locator = peer.m_headers_sync->NextHeadersRequestLocator();
             // If we were instructed to ask for a locator, it should not be empty.

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2934,7 +2934,7 @@ void PeerManagerImpl::ClearHeadersSyncState(Peer& peer)
 
 bool PeerManagerImpl::MayStartHeadersRedownload(const CNode& pfrom)
 {
-    if (!pfrom.IsInboundConn() || !m_chainman.IsInitialBlockDownload()) return true;
+    if (pfrom.IsFullOutboundConn() || !m_chainman.IsInitialBlockDownload()) return true;
     LOCK(m_headers_presync_mutex);
     // Entries without presync height/time are in REDOWNLOAD.
     return std::ranges::count_if(m_headers_presync_stats, [](auto& entry) { return !entry.second.second; }) < MAX_OUTBOUND_FULL_RELAY_CONNECTIONS;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -765,6 +765,8 @@ private:
     bool IsContinuationOfLowWorkHeadersSync(Peer& peer, CNode& pfrom,
             std::vector<CBlockHeader>& headers)
         EXCLUSIVE_LOCKS_REQUIRED(peer.m_headers_sync_mutex, !m_headers_presync_mutex, g_msgproc_mutex);
+    void ClearHeadersSyncState(Peer& peer)
+        EXCLUSIVE_LOCKS_REQUIRED(peer.m_headers_sync_mutex, !m_headers_presync_mutex);
     /** Check work on a headers chain to be processed, and if insufficient,
      * initiate our anti-DoS headers sync mechanism.
      *
@@ -2922,6 +2924,12 @@ bool PeerManagerImpl::CheckHeadersAreContinuous(const std::vector<CBlockHeader>&
     return true;
 }
 
+void PeerManagerImpl::ClearHeadersSyncState(Peer& peer)
+{
+    peer.m_headers_sync.reset();
+    WITH_LOCK(m_headers_presync_mutex, m_headers_presync_stats.erase(peer.m_id));
+}
+
 bool PeerManagerImpl::IsContinuationOfLowWorkHeadersSync(Peer& peer, CNode& pfrom, std::vector<CBlockHeader>& headers)
 {
     if (peer.m_headers_sync) {
@@ -2945,13 +2953,10 @@ bool PeerManagerImpl::IsContinuationOfLowWorkHeadersSync(Peer& peer, CNode& pfro
         }
 
         if (peer.m_headers_sync->GetState() == HeadersSyncState::State::FINAL) {
-            peer.m_headers_sync.reset(nullptr);
-
             // Delete this peer's entry in m_headers_presync_stats.
             // If this is m_headers_presync_bestpeer, it will be replaced later
             // by the next peer that triggers the else{} branch below.
-            LOCK(m_headers_presync_mutex);
-            m_headers_presync_stats.erase(pfrom.GetId());
+            ClearHeadersSyncState(peer);
         } else {
             // Build statistics for this peer's sync.
             HeadersPresyncStats stats;
@@ -3210,11 +3215,7 @@ void PeerManagerImpl::ProcessHeadersMessage(CNode& pfrom, Peer& peer,
         // message suggests that the peer suddenly has nothing to give us
         // (perhaps it reorged to our chain). Clear download state for this peer.
         LOCK(peer.m_headers_sync_mutex);
-        if (peer.m_headers_sync) {
-            peer.m_headers_sync.reset(nullptr);
-            LOCK(m_headers_presync_mutex);
-            m_headers_presync_stats.erase(pfrom.GetId());
-        }
+        if (peer.m_headers_sync) ClearHeadersSyncState(peer);
         // A headers message with no headers cannot be an announcement, so assume
         // it is a response to our last getheaders request, if there is one.
         peer.m_last_getheaders_timestamp = {};

--- a/src/test/headers_sync_chainwork_tests.cpp
+++ b/src/test/headers_sync_chainwork_tests.cpp
@@ -12,10 +12,10 @@
 #include <test/util/setup_common.h>
 #include <validation.h>
 
+#include <boost/test/unit_test.hpp>
+
 #include <cstddef>
 #include <vector>
-
-#include <boost/test/unit_test.hpp>
 
 using State = HeadersSyncState::State;
 
@@ -50,6 +50,7 @@ constexpr arith_uint256 CHAIN_WORK{TARGET_BLOCKS * 2};
 // required to reach the CHAIN_WORK threshold, to behave similarly to mainnet.
 constexpr size_t REDOWNLOAD_BUFFER_SIZE{TARGET_BLOCKS - (MAX_HEADERS_RESULTS + 123)};
 constexpr size_t COMMITMENT_PERIOD{600}; // Somewhat close to mainnet.
+constexpr size_t CONCURRENT_SYNCS{10};
 
 struct HeadersGeneratorSetup : public RegTestingSetup {
     const CBlock& genesis{Params().GenesisBlock()};
@@ -221,6 +222,28 @@ BOOST_AUTO_TEST_CASE(happy_path)
             /*exp_headers_size=*/first_chain.size() - 1, /*exp_pow_validated_prev=*/first_chain.front().GetHash(),
             /*exp_locator_hash=*/std::nullopt);
     }
+}
+
+BOOST_AUTO_TEST_CASE(concurrent_redownload_buffers)
+{
+    auto& first_chain{FirstChain()};
+    std::vector<HeadersSyncState> syncs;
+    syncs.reserve(CONCURRENT_SYNCS);
+    size_t retained_bytes{0};
+
+    // Keep every REDOWNLOAD buffer alive at the same time.
+    for (size_t i{0}; i < CONCURRENT_SYNCS; ++i) {
+        auto& sync{syncs.emplace_back(CreateState())};
+        auto result{sync.ProcessNextHeaders(first_chain, true)};
+        BOOST_REQUIRE(result.success && result.request_more);
+        BOOST_REQUIRE_EQUAL(sync.GetState(), State::REDOWNLOAD);
+        result = sync.ProcessNextHeaders({first_chain.begin(), REDOWNLOAD_BUFFER_SIZE}, true);
+        BOOST_REQUIRE(result.success && result.request_more);
+        BOOST_CHECK_EQUAL(sync.GetRedownloadBufferSize(), REDOWNLOAD_BUFFER_SIZE);
+        retained_bytes += sync.GetRedownloadBufferSize() * sizeof(CompressedHeader);
+    }
+
+    BOOST_CHECK_EQUAL(retained_bytes, 6'180'960);
 }
 
 BOOST_AUTO_TEST_CASE(too_little_work)

--- a/src/test/headers_sync_chainwork_tests.cpp
+++ b/src/test/headers_sync_chainwork_tests.cpp
@@ -235,10 +235,10 @@ BOOST_AUTO_TEST_CASE(concurrent_redownload_buffers)
     for (size_t i{0}; i < CONCURRENT_SYNCS; ++i) {
         auto& sync{syncs.emplace_back(CreateState())};
         auto result{sync.ProcessNextHeaders(first_chain, true)};
-        BOOST_REQUIRE(result.success && result.request_more);
+        BOOST_REQUIRE(result.success && result.request_more && result.entered_redownload);
         BOOST_REQUIRE_EQUAL(sync.GetState(), State::REDOWNLOAD);
         result = sync.ProcessNextHeaders({first_chain.begin(), REDOWNLOAD_BUFFER_SIZE}, true);
-        BOOST_REQUIRE(result.success && result.request_more);
+        BOOST_REQUIRE(result.success && result.request_more && !result.entered_redownload);
         BOOST_CHECK_EQUAL(sync.GetRedownloadBufferSize(), REDOWNLOAD_BUFFER_SIZE);
         retained_bytes += sync.GetRedownloadBufferSize() * sizeof(CompressedHeader);
     }

--- a/test/functional/p2p_headers_sync_with_minchainwork.py
+++ b/test/functional/p2p_headers_sync_with_minchainwork.py
@@ -180,27 +180,27 @@ class RejectLowDifficultyHeadersTest(BitcoinTestFramework):
         )
         for p in admitted_peers:
             p.send_and_ping(continuation_message)
-        with node.assert_debug_log(expected_msgs=[], unexpected_msgs=["too many headers redownloads in progress"]):  # TODO: Excess inbound peers enter REDOWNLOAD instead of logging a rejection
+        with node.assert_debug_log(expected_msgs=["too many headers redownloads in progress"]):
             for p in extra_peers:
                 p.send_and_ping(continuation_message)
 
-        assert_equal(self.count_presynced(node, 2 * MAX_HEADERS_RESULTS), len(all_peers))  # TODO: Excess non-full-outbound peers enter REDOWNLOAD instead of being rejected
-        assert_equal(self.count_presynced(node, -1), 0)  # TODO: Excess non-full-outbound peers keep REDOWNLOAD state instead of releasing it
+        assert_equal(self.count_presynced(node, 2 * MAX_HEADERS_RESULTS), MAX_UNRESERVED_HEADERS_REDOWNLOADS + 2)  # TODO: Excess non-full-outbound peers enter REDOWNLOAD instead of being rejected
+        assert_equal(self.count_presynced(node, -1), 1)  # TODO: Excess non-full-outbound peers keep REDOWNLOAD state instead of releasing it
 
         # Existing REDOWNLOAD states can continue after the limit is reached.
         for p in admitted_peers:
             p.send_and_ping(headers_message)
-        assert_equal(self.count_presynced(node, 2 * MAX_HEADERS_RESULTS), len(all_peers))  # TODO: Excess non-full-outbound peers continue instead of leaving only admitted REDOWNLOAD states active
+        assert_equal(self.count_presynced(node, 2 * MAX_HEADERS_RESULTS), MAX_UNRESERVED_HEADERS_REDOWNLOADS + 2)  # TODO: Excess non-full-outbound peers continue instead of leaving only admitted REDOWNLOAD states active
 
         # Release two states so a new inbound peer can enter REDOWNLOAD.
         inbound_peers[0].send_and_ping(msg_headers())
         full_outbound_peer.send_and_ping(msg_headers())
-        assert_equal(self.count_presynced(node, 2 * MAX_HEADERS_RESULTS), MAX_UNRESERVED_HEADERS_REDOWNLOADS + 1)  # TODO: Excess non-full-outbound peers retain REDOWNLOAD state, leaving too few slots for replacement_peer
+        assert_equal(self.count_presynced(node, 2 * MAX_HEADERS_RESULTS), MAX_UNRESERVED_HEADERS_REDOWNLOADS)  # TODO: A block-relay-only peer retains REDOWNLOAD state, leaving no slot for replacement_peer
         replacement_peer = node.add_p2p_connection(P2PInterface())
         replacement_peer.send_and_ping(headers_message)
         replacement_peer.send_and_ping(continuation_message)
 
-        assert_equal(self.count_presynced(node, 2 * MAX_HEADERS_RESULTS), MAX_UNRESERVED_HEADERS_REDOWNLOADS + 2)  # TODO: Excess non-full-outbound peers remain active instead of leaving a released slot for replacement_peer
+        assert_equal(self.count_presynced(node, 2 * MAX_HEADERS_RESULTS), MAX_UNRESERVED_HEADERS_REDOWNLOADS)
 
         node.disconnect_p2ps()
         self.reconnect_all()

--- a/test/functional/p2p_headers_sync_with_minchainwork.py
+++ b/test/functional/p2p_headers_sync_with_minchainwork.py
@@ -11,11 +11,11 @@ from test_framework.p2p import (
 )
 
 from test_framework.messages import (
+    MAX_HEADERS_RESULTS,
     msg_headers,
 )
 
 from test_framework.blocktools import (
-    NORMAL_GBT_REQUEST_PARAMS,
     create_block,
 )
 
@@ -55,14 +55,15 @@ class RejectLowDifficultyHeadersTest(BitcoinTestFramework):
             n.setmocktime(time)
 
     def create_low_work_headers_message(self, node):
-        new_blocks = []
-        hashPrevBlock = int(node.getblockhash(0), 16)
-        for i in range(2000):
-            block = create_block(hashprev = hashPrevBlock, tmpl=node.getblocktemplate(NORMAL_GBT_REQUEST_PARAMS))
+        genesis = node.getblock(node.getblockhash(0))
+        headers = []
+        hash_prev_block = int(genesis['hash'], 16)
+        for height in range(1, MAX_HEADERS_RESULTS + 1):
+            block = create_block(hashprev=hash_prev_block, height=height, ntime=genesis['time'] + height)
             block.solve()
-            new_blocks.append(block)
-            hashPrevBlock = block.hash_int
-        return msg_headers(headers=new_blocks)
+            headers.append(block)
+            hash_prev_block = block.hash_int
+        return msg_headers(headers=headers)
 
     def test_chains_sync_when_long_enough(self):
         self.log.info("Generate blocks on the node with no required chainwork, and verify nodes 1 and 2 have no new headers in their headers tree")
@@ -139,11 +140,11 @@ class RejectLowDifficultyHeadersTest(BitcoinTestFramework):
         if (current_height < 3000):
             self.generate(node, 3000-current_height, sync_fun=self.no_op)
 
-        # Send a group of 2000 headers, forking from genesis.
+        # Send a full headers message, forking from genesis.
         p2p.send_and_ping(self.create_low_work_headers_message(node))
 
         # getpeerinfo should show a sync in progress
-        assert_equal(node.getpeerinfo()[0]['presynced_headers'], 2000)
+        assert_equal(node.getpeerinfo()[0]['presynced_headers'], MAX_HEADERS_RESULTS)
 
     def test_large_reorgs_can_succeed(self):
         self.log.info("Test that a 2000+ block reorg, starting from a point that is more than 2000 blocks before a locator entry, can succeed")

--- a/test/functional/p2p_headers_sync_with_minchainwork.py
+++ b/test/functional/p2p_headers_sync_with_minchainwork.py
@@ -25,6 +25,7 @@ import time
 
 NODE1_BLOCKS_REQUIRED = 15
 NODE2_BLOCKS_REQUIRED = 2047
+MAX_UNRESERVED_HEADERS_REDOWNLOADS = 8  # MAX_OUTBOUND_FULL_RELAY_CONNECTIONS in src/net.h
 
 
 class RejectLowDifficultyHeadersTest(BitcoinTestFramework):
@@ -54,16 +55,20 @@ class RejectLowDifficultyHeadersTest(BitcoinTestFramework):
         for n in self.nodes:
             n.setmocktime(time)
 
-    def create_low_work_headers_message(self, node):
+    def create_low_work_headers_message(self, node, *, start_height=1, hash_prev_block=None):
         genesis = node.getblock(node.getblockhash(0))
         headers = []
-        hash_prev_block = int(genesis['hash'], 16)
-        for height in range(1, MAX_HEADERS_RESULTS + 1):
+        if hash_prev_block is None:
+            hash_prev_block = int(genesis['hash'], 16)
+        for height in range(start_height, start_height + MAX_HEADERS_RESULTS):
             block = create_block(hashprev=hash_prev_block, height=height, ntime=genesis['time'] + height)
             block.solve()
             headers.append(block)
             hash_prev_block = block.hash_int
         return msg_headers(headers=headers)
+
+    def count_presynced(self, node, height):
+        return [peer['presynced_headers'] for peer in node.getpeerinfo()].count(height)
 
     def test_chains_sync_when_long_enough(self):
         self.log.info("Generate blocks on the node with no required chainwork, and verify nodes 1 and 2 have no new headers in their headers tree")
@@ -146,6 +151,61 @@ class RejectLowDifficultyHeadersTest(BitcoinTestFramework):
         # getpeerinfo should show a sync in progress
         assert_equal(node.getpeerinfo()[0]['presynced_headers'], MAX_HEADERS_RESULTS)
 
+    def test_ibd_headers_redownload_admission(self):
+        self.log.info("Test headers redownload admission during IBD")
+
+        self.disconnect_all()
+        node = self.nodes[2]
+        assert node.getblockchaininfo()['initialblockdownload']
+        inbound_peers = [node.add_p2p_connection(P2PInterface()) for _ in range(MAX_UNRESERVED_HEADERS_REDOWNLOADS)]
+        full_outbound_peer = node.add_outbound_p2p_connection(P2PInterface(), p2p_idx=0)
+        extra_peers = [
+            node.add_p2p_connection(P2PInterface()),
+            node.add_outbound_p2p_connection(P2PInterface(), p2p_idx=1, connection_type="block-relay-only"),
+        ]
+
+        headers_message = self.create_low_work_headers_message(node)
+        admitted_peers = inbound_peers + [full_outbound_peer]
+        all_peers = admitted_peers + extra_peers
+        for p in all_peers:
+            p.send_and_ping(headers_message)
+
+        # PRESYNC remains unrestricted.
+        assert_equal(self.count_presynced(node, MAX_HEADERS_RESULTS), len(all_peers))
+
+        continuation_message = self.create_low_work_headers_message(
+            node,
+            start_height=MAX_HEADERS_RESULTS + 1,
+            hash_prev_block=headers_message.headers[-1].hash_int,
+        )
+        for p in admitted_peers:
+            p.send_and_ping(continuation_message)
+        with node.assert_debug_log(expected_msgs=[], unexpected_msgs=["too many headers redownloads in progress"]):  # TODO: Excess inbound peers enter REDOWNLOAD instead of logging a rejection
+            for p in extra_peers:
+                p.send_and_ping(continuation_message)
+
+        assert_equal(self.count_presynced(node, 2 * MAX_HEADERS_RESULTS), len(all_peers))  # TODO: Excess non-full-outbound peers enter REDOWNLOAD instead of being rejected
+        assert_equal(self.count_presynced(node, -1), 0)  # TODO: Excess non-full-outbound peers keep REDOWNLOAD state instead of releasing it
+
+        # Existing REDOWNLOAD states can continue after the limit is reached.
+        for p in admitted_peers:
+            p.send_and_ping(headers_message)
+        assert_equal(self.count_presynced(node, 2 * MAX_HEADERS_RESULTS), len(all_peers))  # TODO: Excess non-full-outbound peers continue instead of leaving only admitted REDOWNLOAD states active
+
+        # Release two states so a new inbound peer can enter REDOWNLOAD.
+        inbound_peers[0].send_and_ping(msg_headers())
+        full_outbound_peer.send_and_ping(msg_headers())
+        assert_equal(self.count_presynced(node, 2 * MAX_HEADERS_RESULTS), MAX_UNRESERVED_HEADERS_REDOWNLOADS + 1)  # TODO: Excess non-full-outbound peers retain REDOWNLOAD state, leaving too few slots for replacement_peer
+        replacement_peer = node.add_p2p_connection(P2PInterface())
+        replacement_peer.send_and_ping(headers_message)
+        replacement_peer.send_and_ping(continuation_message)
+
+        assert_equal(self.count_presynced(node, 2 * MAX_HEADERS_RESULTS), MAX_UNRESERVED_HEADERS_REDOWNLOADS + 2)  # TODO: Excess non-full-outbound peers remain active instead of leaving a released slot for replacement_peer
+
+        node.disconnect_p2ps()
+        self.reconnect_all()
+        self.sync_all()
+
     def test_large_reorgs_can_succeed(self):
         self.log.info("Test that a 2000+ block reorg, starting from a point that is more than 2000 blocks before a locator entry, can succeed")
 
@@ -170,6 +230,8 @@ class RejectLowDifficultyHeadersTest(BitcoinTestFramework):
 
 
     def run_test(self):
+        self.test_ibd_headers_redownload_admission()
+
         self.test_chains_sync_when_long_enough()
 
         self.test_large_reorgs_can_succeed()

--- a/test/functional/p2p_headers_sync_with_minchainwork.py
+++ b/test/functional/p2p_headers_sync_with_minchainwork.py
@@ -206,6 +206,30 @@ class RejectLowDifficultyHeadersTest(BitcoinTestFramework):
         self.reconnect_all()
         self.sync_all()
 
+    def test_post_ibd_headers_redownloads(self):
+        self.log.info("Test concurrent headers redownloads after IBD")
+
+        node = self.nodes[2]
+        assert not node.getblockchaininfo()['initialblockdownload']
+        self.disconnect_all()
+
+        peers = [node.add_p2p_connection(P2PInterface()) for _ in range(MAX_UNRESERVED_HEADERS_REDOWNLOADS + 2)]
+        headers_message = self.create_low_work_headers_message(node)
+        continuation_message = self.create_low_work_headers_message(
+            node,
+            start_height=MAX_HEADERS_RESULTS + 1,
+            hash_prev_block=headers_message.headers[-1].hash_int,
+        )
+        for p in peers:
+            p.send_and_ping(headers_message)
+            p.send_and_ping(continuation_message)
+
+        assert_equal(self.count_presynced(node, 2 * MAX_HEADERS_RESULTS), len(peers))
+
+        node.disconnect_p2ps()
+        self.reconnect_all()
+        self.sync_all()
+
     def test_large_reorgs_can_succeed(self):
         self.log.info("Test that a 2000+ block reorg, starting from a point that is more than 2000 blocks before a locator entry, can succeed")
 
@@ -233,6 +257,8 @@ class RejectLowDifficultyHeadersTest(BitcoinTestFramework):
         self.test_ibd_headers_redownload_admission()
 
         self.test_chains_sync_when_long_enough()
+
+        self.test_post_ibd_headers_redownloads()
 
         self.test_large_reorgs_can_succeed()
 

--- a/test/functional/p2p_headers_sync_with_minchainwork.py
+++ b/test/functional/p2p_headers_sync_with_minchainwork.py
@@ -54,6 +54,16 @@ class RejectLowDifficultyHeadersTest(BitcoinTestFramework):
         for n in self.nodes:
             n.setmocktime(time)
 
+    def create_low_work_headers_message(self, node):
+        new_blocks = []
+        hashPrevBlock = int(node.getblockhash(0), 16)
+        for i in range(2000):
+            block = create_block(hashprev = hashPrevBlock, tmpl=node.getblocktemplate(NORMAL_GBT_REQUEST_PARAMS))
+            block.solve()
+            new_blocks.append(block)
+            hashPrevBlock = block.hash_int
+        return msg_headers(headers=new_blocks)
+
     def test_chains_sync_when_long_enough(self):
         self.log.info("Generate blocks on the node with no required chainwork, and verify nodes 1 and 2 have no new headers in their headers tree")
         with (
@@ -130,16 +140,7 @@ class RejectLowDifficultyHeadersTest(BitcoinTestFramework):
             self.generate(node, 3000-current_height, sync_fun=self.no_op)
 
         # Send a group of 2000 headers, forking from genesis.
-        new_blocks = []
-        hashPrevBlock = int(node.getblockhash(0), 16)
-        for i in range(2000):
-            block = create_block(hashprev = hashPrevBlock, tmpl=node.getblocktemplate(NORMAL_GBT_REQUEST_PARAMS))
-            block.solve()
-            new_blocks.append(block)
-            hashPrevBlock = block.hash_int
-
-        headers_message = msg_headers(headers=new_blocks)
-        p2p.send_and_ping(headers_message)
+        p2p.send_and_ping(self.create_low_work_headers_message(node))
 
         # getpeerinfo should show a sync in progress
         assert_equal(node.getpeerinfo()[0]['presynced_headers'], 2000)

--- a/test/functional/p2p_headers_sync_with_minchainwork.py
+++ b/test/functional/p2p_headers_sync_with_minchainwork.py
@@ -184,18 +184,18 @@ class RejectLowDifficultyHeadersTest(BitcoinTestFramework):
             for p in extra_peers:
                 p.send_and_ping(continuation_message)
 
-        assert_equal(self.count_presynced(node, 2 * MAX_HEADERS_RESULTS), MAX_UNRESERVED_HEADERS_REDOWNLOADS + 2)  # TODO: Excess non-full-outbound peers enter REDOWNLOAD instead of being rejected
-        assert_equal(self.count_presynced(node, -1), 1)  # TODO: Excess non-full-outbound peers keep REDOWNLOAD state instead of releasing it
+        assert_equal(self.count_presynced(node, 2 * MAX_HEADERS_RESULTS), MAX_UNRESERVED_HEADERS_REDOWNLOADS + 1)
+        assert_equal(self.count_presynced(node, -1), len(extra_peers))
 
         # Existing REDOWNLOAD states can continue after the limit is reached.
         for p in admitted_peers:
             p.send_and_ping(headers_message)
-        assert_equal(self.count_presynced(node, 2 * MAX_HEADERS_RESULTS), MAX_UNRESERVED_HEADERS_REDOWNLOADS + 2)  # TODO: Excess non-full-outbound peers continue instead of leaving only admitted REDOWNLOAD states active
+        assert_equal(self.count_presynced(node, 2 * MAX_HEADERS_RESULTS), MAX_UNRESERVED_HEADERS_REDOWNLOADS + 1)
 
         # Release two states so a new inbound peer can enter REDOWNLOAD.
         inbound_peers[0].send_and_ping(msg_headers())
         full_outbound_peer.send_and_ping(msg_headers())
-        assert_equal(self.count_presynced(node, 2 * MAX_HEADERS_RESULTS), MAX_UNRESERVED_HEADERS_REDOWNLOADS)  # TODO: A block-relay-only peer retains REDOWNLOAD state, leaving no slot for replacement_peer
+        assert_equal(self.count_presynced(node, 2 * MAX_HEADERS_RESULTS), MAX_UNRESERVED_HEADERS_REDOWNLOADS - 1)
         replacement_peer = node.add_p2p_connection(P2PInterface())
         replacement_peer.send_and_ping(headers_message)
         replacement_peer.send_and_ping(continuation_message)


### PR DESCRIPTION
**Problem:** During IBD, peers can replay the same public sufficient-work header chain through their own low-work syncs.
`PRESYNC` commitments remain small, but each sync that reaches `REDOWNLOAD` can retain up to 15,218 compressed headers, about 713 KiB of payload with the current mainnet parameters.
Aggregate temporary memory therefore grows with peer count.

**Fix:** Keep the low-memory `PRESYNC` phase unrestricted.
During IBD, once eight `REDOWNLOAD` states are active, prevent non-full-outbound peers from entering that phase before their redownload buffers can grow.
Automatic full-relay outbounds remain eligible while their redownloads count toward the threshold.
Existing redownloads continue, and behavior after IBD remains unchanged.
