### PR TITLE
validation: prefetch input prevouts during VerifyDB disconnects

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -373,6 +373,26 @@ void CCoinsViewCache::SanityCheck() const
     assert(recomputed_usage == cachedCoinsUsage);
 }
 
+void CoinsViewOverlay::StartWorkers(size_t workers_count) noexcept
+{
+    // Only submit tasks if we have something to fetch.
+    if (m_inputs.empty()) return;
+
+    std::vector<std::function<void()>> tasks(workers_count, [this] {
+        while (ProcessInput()) {}
+    });
+    if (auto futures{m_thread_pool->Submit(std::move(tasks))}) {
+        m_futures = std::move(*futures);
+    } else {
+        // Submit can fail if a shared owner of the thread pool outside of this class calls Stop() or
+        // Interrupt() on a different thread after the caller observed a positive WorkersCount(). In that case
+        // parallel fetching will not make progress, so we clear the inputs to fall back to single threaded fetching.
+        LogWarning("Failed to submit prevout fetch tasks; falling back to single-threaded fetching for this block.");
+        m_inputs.clear();
+        StopFetching(); // Assert nothing changed if we failed to start tasks.
+    }
+}
+
 CCoinsViewCache::ResetGuard CoinsViewOverlay::StartFetching(const CBlock& block LIFETIMEBOUND) noexcept
 {
     Assert(m_futures.empty());
@@ -391,22 +411,7 @@ CCoinsViewCache::ResetGuard CoinsViewOverlay::StartFetching(const CBlock& block 
             }
             earlier_txids.emplace(tx->GetHash());
         }
-        // Only submit tasks if we have something to fetch.
-        if (m_inputs.size()) {
-            std::vector<std::function<void()>> tasks(workers_count, [this] {
-                while (ProcessInput()) {}
-            });
-            if (auto futures{m_thread_pool->Submit(std::move(tasks))}) {
-                m_futures = std::move(*futures);
-            } else {
-                // Submit can fail if a shared owner of the thread pool outside of this class calls Stop() or
-                // Interrupt() on a different thread after we call WorkersCount() above. In that case parallel
-                // fetching will not make progress, so we clear the inputs to fall back to single threaded fetching.
-                LogWarning("Failed to submit prevout fetch tasks; falling back to single-threaded fetching for this block.");
-                m_inputs.clear();
-                StopFetching(); // Assert nothing changed if we failed to start tasks.
-            }
-        }
+        StartWorkers(workers_count);
     }
     return CreateResetGuard();
 }

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -416,6 +416,24 @@ CCoinsViewCache::ResetGuard CoinsViewOverlay::StartFetching(const CBlock& block 
     return CreateResetGuard();
 }
 
+CCoinsViewCache::ResetGuard CoinsViewOverlay::StartFetchingForDisconnect(const CBlock& block LIFETIMEBOUND) noexcept
+{
+    Assert(m_futures.empty());
+    Assert(m_inputs.empty());
+    Assert(m_input_head.load(std::memory_order_relaxed) == 0);
+    Assert(m_input_tail == 0);
+    if (const auto workers_count{m_thread_pool->WorkersCount()}; workers_count > 0) {
+        // DisconnectBlock restores transactions and their inputs in reverse order.
+        for (const auto& tx : block.vtx | std::views::drop(1) | std::views::reverse) {
+            for (const auto& input : tx->vin | std::views::reverse) {
+                m_inputs.emplace_back(input.prevout);
+            }
+        }
+        StartWorkers(workers_count);
+    }
+    return CreateResetGuard();
+}
+
 static const uint64_t MIN_TRANSACTION_OUTPUT_WEIGHT{WITNESS_SCALE_FACTOR * ::GetSerializeSize(CTxOut())};
 static const uint64_t MAX_OUTPUTS_PER_BLOCK{MAX_BLOCK_WEIGHT / MIN_TRANSACTION_OUTPUT_WEIGHT};
 

--- a/src/coins.h
+++ b/src/coins.h
@@ -741,6 +741,8 @@ private:
     std::shared_ptr<ThreadPool> m_thread_pool;
     std::vector<std::future<void>> m_futures{};
 
+    void StartWorkers(size_t workers_count) noexcept;
+
 protected:
     void Reset() noexcept override
     {

--- a/src/coins.h
+++ b/src/coins.h
@@ -593,16 +593,16 @@ private:
 };
 
 /**
- * CCoinsViewCache subclass that asynchronously fetches most block input prevouts in parallel during ConnectBlock without
- * mutating the base cache.
+ * CCoinsViewCache subclass that asynchronously fetches most block input prevouts in parallel during block connection or
+ * disconnection without mutating the base cache.
  *
- * Only used in ConnectBlock to pass as an ephemeral view that can be reset if the block is invalid.
+ * Used as an ephemeral view that can be reset if validation fails.
  * It provides the same interface as CCoinsViewCache.
- * It adds an additional StartFetching method to provide the block.
+ * It adds StartFetching methods to provide the block and expected input access order.
  *
- * When a block is passed to StartFetching, the inputs of the block are flattened into a vector of InputToFetch
- * objects. StartFetching then submits worker tasks to a ThreadPool and keeps the returned futures alive until fetching
- * is stopped.
+ * When a block is passed to a StartFetching method, the inputs of the block are flattened into a vector of
+ * InputToFetch objects in the order the caller will access them. Worker tasks are then submitted to a ThreadPool
+ * and the returned futures are kept alive until fetching is stopped.
  *
  * ProcessInput() atomically fetches and increments m_input_head, so each thread can only access a single element of the
  * m_inputs vector at a time. Workers race to claim inputs, so they may fetch elements in any order. If the fetched
@@ -722,8 +722,8 @@ private:
 
     std::optional<Coin> FetchCoinFromBase(const COutPoint& outpoint) const override
     {
-        // This assumes ConnectBlock accesses all inputs in the same order as
-        // they are added to m_inputs in StartFetching.
+        // This assumes the caller accesses all inputs in the same order as
+        // they were added to m_inputs by the StartFetching method used.
         if (m_input_tail < m_inputs.size() && m_inputs[m_input_tail].outpoint == outpoint) {
             // We advance the tail since the input is cached and not accessed through this method again.
             auto& input{m_inputs[m_input_tail++]};
@@ -733,7 +733,8 @@ private:
             return std::move(input.coin);
         }
 
-        // We will only get here for BIP30 checks, an invalid block, or if the threadpool has not been started.
+        // We will only get here for outpoints missing from the queue: BIP30 checks, DisconnectBlock's reads
+        // of each transaction's own outputs, an invalid block, or if the threadpool has not been started.
         return base->PeekCoin(outpoint);
     }
 
@@ -760,8 +761,11 @@ public:
 
     ~CoinsViewOverlay() noexcept override { StopFetching(); }
 
-    //! Start fetching inputs from block.
+    //! Start fetching inputs in ConnectBlock access order.
     [[nodiscard]] ResetGuard StartFetching(const CBlock& block LIFETIMEBOUND) noexcept;
+
+    //! Start fetching inputs in DisconnectBlock access order.
+    [[nodiscard]] ResetGuard StartFetchingForDisconnect(const CBlock& block LIFETIMEBOUND) noexcept;
 
     void Flush(bool reallocate_cache = true) override
     {

--- a/src/coins.h
+++ b/src/coins.h
@@ -778,6 +778,9 @@ public:
 
     //! Verify that all parallel fetched input prevouts have been consumed.
     bool AllInputsConsumed() const noexcept { return m_input_tail == m_inputs.size(); }
+
+    //! @returns the thread pool used for fetching, so another view can share its workers.
+    std::shared_ptr<ThreadPool> GetThreadPool() const noexcept { return m_thread_pool; }
 };
 
 //! Utility function to add all of a transaction's outputs to a cache.

--- a/src/test/coinsviewoverlay_tests.cpp
+++ b/src/test/coinsviewoverlay_tests.cpp
@@ -187,6 +187,26 @@ BOOST_AUTO_TEST_CASE(fetch_no_inputs)
     BOOST_CHECK_EQUAL(view.GetCacheSize(), 0);
 }
 
+BOOST_AUTO_TEST_CASE(fetch_inputs_for_disconnect)
+{
+    const auto block{CreateBlock()};
+    CCoinsViewDB db{{.path = "", .cache_bytes = 1_MiB, .memory_only = true}, {}};
+    CCoinsViewCache main_cache{&db};
+    CoinsViewOverlay view{&main_cache, MakeStartedThreadPool()};
+
+    for (int i{0}; i < 2; ++i) {
+        const auto reset_guard{view.StartFetchingForDisconnect(block)};
+        for (const auto& tx : block.vtx | std::views::drop(1) | std::views::reverse) {
+            // DisconnectBlock accesses transaction outputs before restoring inputs.
+            BOOST_CHECK(view.AccessCoin(COutPoint{tx->GetHash(), 0}).IsSpent());
+            for (const auto& input : tx->vin | std::views::reverse) {
+                BOOST_CHECK(view.AccessCoin(input.prevout).IsSpent());
+            }
+        }
+        BOOST_CHECK(view.AllInputsConsumed());
+    }
+}
+
 // Access coins that are not block inputs
 BOOST_AUTO_TEST_CASE(access_non_input_coins)
 {

--- a/src/test/validation_chainstate_tests.cpp
+++ b/src/test/validation_chainstate_tests.cpp
@@ -33,6 +33,24 @@ class CTxMemPool;
 
 BOOST_FIXTURE_TEST_SUITE(validation_chainstate_tests, ChainTestingSetup)
 
+class CoinsViewAccessTracker : public CCoinsViewBacked
+{
+public:
+    CoinsViewAccessTracker(CCoinsView& view, std::vector<COutPoint>& accesses)
+        : CCoinsViewBacked{&view}, m_accesses{accesses}
+    {
+    }
+
+    std::optional<Coin> GetCoin(const COutPoint& outpoint) const override
+    {
+        m_accesses.push_back(outpoint);
+        return CCoinsViewBacked::GetCoin(outpoint);
+    }
+
+private:
+    std::vector<COutPoint>& m_accesses;
+};
+
 //! Test resizing coins-related Chainstate caches during runtime.
 //!
 BOOST_AUTO_TEST_CASE(validation_chainstate_resize_caches)
@@ -96,6 +114,49 @@ BOOST_FIXTURE_TEST_CASE(connect_tip_does_not_cache_inputs_on_failed_connect, Tes
     LOCK(cs_main);
     BOOST_CHECK_EQUAL(tip, chainstate.m_chain.Tip()->GetBlockHash()); // block rejected
     BOOST_CHECK(!chainstate.CoinsTip().HaveCoinInCache(outpoint));    // input not cached
+}
+
+BOOST_FIXTURE_TEST_CASE(disconnect_block_coin_access_order, TestChain100Setup)
+{
+    mineBlocks(3);
+    const CScript script_pub_key{CScript{} << ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG};
+    const std::vector<COutPoint> parent_inputs{
+        COutPoint{m_coinbase_txns[0]->GetHash(), 0},
+        COutPoint{m_coinbase_txns[1]->GetHash(), 0},
+    };
+    const CMutableTransaction parent{CreateValidMempoolTransaction(
+        {m_coinbase_txns[0], m_coinbase_txns[1]}, parent_inputs, /*input_height=*/1,
+        {coinbaseKey}, {CTxOut{99 * COIN, script_pub_key}}, /*submit=*/false)};
+    const CTransactionRef parent_ref{MakeTransactionRef(parent)};
+    const std::vector<COutPoint> child_inputs{
+        COutPoint{parent_ref->GetHash(), 0},
+        COutPoint{m_coinbase_txns[2]->GetHash(), 0},
+    };
+    const CMutableTransaction child{CreateValidMempoolTransaction(
+        {parent_ref, m_coinbase_txns[2]}, child_inputs, /*input_height=*/1,
+        {coinbaseKey}, {CTxOut{148 * COIN, script_pub_key}}, /*submit=*/false)};
+    const CBlock block{CreateAndProcessBlock({parent, child}, script_pub_key)};
+
+    LOCK(cs_main);
+    Chainstate& chainstate{Assert(m_node.chainman)->ActiveChainstate()};
+    const CBlockIndex* tip{chainstate.m_chain.Tip()};
+    BOOST_REQUIRE_EQUAL(tip->GetBlockHash(), block.GetHash());
+
+    std::vector<COutPoint> accesses;
+    CoinsViewAccessTracker tracker{chainstate.CoinsTip(), accesses};
+    CCoinsViewCache view{&tracker};
+    BOOST_REQUIRE_EQUAL(chainstate.DisconnectBlock(block, tip, view), DISCONNECT_OK);
+
+    // Restoring the child's first input caches the parent output before the parent is disconnected.
+    const std::vector<COutPoint> expected{
+        COutPoint{block.vtx[2]->GetHash(), 0},
+        child_inputs[1],
+        child_inputs[0],
+        parent_inputs[1],
+        parent_inputs[0],
+        COutPoint{block.vtx[0]->GetHash(), 0},
+    };
+    BOOST_CHECK_EQUAL_COLLECTIONS(accesses.begin(), accesses.end(), expected.begin(), expected.end());
 }
 
 //! Test UpdateTip behavior for both active and background chainstates.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4651,6 +4651,7 @@ VerifyDBResult CVerifyDB::VerifyDB(
     nCheckLevel = std::max(0, std::min(4, nCheckLevel));
     LogInfo("Verifying last %i blocks at level %i", nCheckDepth, nCheckLevel);
     CCoinsViewCache coins(&coinsview);
+    CoinsViewOverlay view{&coins, chainstate.PrevoutFetchPool()};
     CBlockIndex* pindex;
     CBlockIndex* pindexFailure = nullptr;
     int nGoodTransactions = 0;
@@ -4703,16 +4704,18 @@ VerifyDBResult CVerifyDB::VerifyDB(
             }
         }
         // check level 3: check for inconsistencies during memory-only disconnect of tip blocks
-        size_t curr_coins_usage = coins.DynamicMemoryUsage() + chainstate.CoinsTip().DynamicMemoryUsage();
+        size_t curr_coins_usage = coins.DynamicMemoryUsage() + view.DynamicMemoryUsage() + chainstate.CoinsTip().DynamicMemoryUsage();
 
         if (nCheckLevel >= 3) {
             if (curr_coins_usage <= chainstate.m_coinstip_cache_size_bytes) {
                 assert(coins.GetBestBlock() == pindex->GetBlockHash());
-                DisconnectResult res = chainstate.DisconnectBlock(block, pindex, coins);
+                const auto reset_guard{view.StartFetchingForDisconnect(block)};
+                DisconnectResult res = chainstate.DisconnectBlock(block, pindex, view);
                 if (res == DISCONNECT_FAILED) {
                     LogError("Verification error: irrecoverable inconsistency in block data at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
                     return VerifyDBResult::CORRUPTED_BLOCK_DB;
                 }
+                view.Flush(/*reallocate_cache=*/false);
                 if (res == DISCONNECT_UNCLEAN) {
                     nGoodTransactions = 0;
                     pindexFailure = pindex;

--- a/src/validation.h
+++ b/src/validation.h
@@ -54,6 +54,7 @@
 class Chainstate;
 class CTxMemPool;
 class ChainstateManager;
+class ThreadPool;
 struct ChainTxData;
 class DisconnectedBlockTransactions;
 struct PrecomputedTransactionData;
@@ -712,6 +713,13 @@ public:
     {
         AssertLockHeld(::cs_main);
         return Assert(m_coins_views)->m_catcherview;
+    }
+
+    //! @returns The shared thread pool used to fetch block input prevouts in parallel.
+    std::shared_ptr<ThreadPool> PrevoutFetchPool() EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
+    {
+        AssertLockHeld(::cs_main);
+        return Assert(Assert(m_coins_views)->m_connect_block_view)->GetThreadPool();
     }
 
     //! Destructs all objects related to accessing the UTXO set.


### PR DESCRIPTION
Context: Follow-up to the [VerifyDB suggestion](https://github.com/bitcoin/bitcoin/pull/31132#discussion_r2645502461) and [reusable-overlay discussion](https://github.com/bitcoin/bitcoin/pull/34164#discussion_r2657511963).

**Problem:** Prefetching the level-4 reconnect inputs is ineffective. Level 3 has already disconnected every checked block into the same cache, so [the inputs needed by level 4 are already resident](https://github.com/bitcoin/bitcoin/pull/31132#discussion_r2682805433).

Level 3 still performs serial backing-view lookups. `DisconnectBlock()` [checks each input prevout before restoring it from undo data](https://github.com/bitcoin/bitcoin/blob/a2e074d66ac17ca7907909bbbb563e77185a45e5/src/validation.cpp#L2161-L2186) while [processing transactions and inputs in reverse order](https://github.com/bitcoin/bitcoin/blob/a2e074d66ac17ca7907909bbbb563e77185a45e5/src/validation.cpp#L2191-L2260), so each miss is resolved before the next input is processed.

This is exercised by startup verification at `-checklevel=3` and `-checklevel=4`, as well as the `verifychain` RPC.

**Fix:** Keep VerifyDB's existing multi-block cache and place one reusable `CoinsViewOverlay` on top. Prefetch each block's non-coinbase input prevouts in the reverse order used by `DisconnectBlock()`, then flush each completed disconnect into the multi-block cache. The reset guard clears the one-block overlay before it is reused.

Reuse the chainstate's existing `-prevoutfetchthreads` pool. VerifyDB holds `cs_main`, so the connect overlay cannot use the pool concurrently, and no second worker set is created.

A characterization test first records the existing `DisconnectBlock()` coin lookup order, including an in-block dependency whose restored output becomes a cache hit.

<details><summary>Benchmark</summary>

Build the base and this branch into separate directories:

```sh
git worktree add ../bitcoin-verifydb-before a2e074d66ac17ca7907909bbbb563e77185a45e5
cmake -S ../bitcoin-verifydb-before -B build-before -DCMAKE_BUILD_TYPE=Release -DBUILD_GUI=OFF -DBUILD_TESTS=OFF
cmake --build build-before -j --target bitcoind bitcoin-cli
cmake -S . -B build-after -DCMAKE_BUILD_TYPE=Release -DBUILD_GUI=OFF -DBUILD_TESTS=OFF
cmake --build build-after -j --target bitcoind bitcoin-cli
```

Point `DATADIR` at the mainnet datadir on the device being measured. This runs maximum-level startup verification over 1,000 recent blocks three times per build with a 4 GiB cache. Check `debug.log` after each run for `Skipped verification of level >=3`. If that appears, reduce `-checkblocks` or increase `-dbcache` before comparing timings. Do not make a performance claim until the HDD and SD-card results are available.

```sh
export DATADIR="/path/to/mainnet/datadir"
hyperfine --runs 3 \
    --command-name before \
    'build-before/bin/bitcoind -datadir="$DATADIR" -checkblocks=1000 -checklevel=4 -dbcache=4096 -networkactive=0 -nowallet -startupnotify="build-before/bin/bitcoin-cli -datadir=\"$DATADIR\" stop"' \
    --command-name after \
    'build-after/bin/bitcoind -datadir="$DATADIR" -checkblocks=1000 -checklevel=4 -dbcache=4096 -networkactive=0 -nowallet -startupnotify="build-after/bin/bitcoin-cli -datadir=\"$DATADIR\" stop"'
```

`-stopatheight=1` cannot replace `-startupnotify` here. `LoadChainTip()` evaluates it before `VerifyLoadedChainstate()` calls `VerifyDB()`. Because shutdown has already been requested, the verification loop exits without doing the measured work.
</details>