### PR TITLE
net: refresh peer activity after accepted transactions

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3190,6 +3190,11 @@ void PeerManagerImpl::ProcessValidTx(NodeId nodeid, const CTransactionRef& tx, c
     AssertLockHeld(g_msgproc_mutex);
     AssertLockHeld(m_tx_download_mutex);
 
+    m_connman.ForNode(nodeid, [](CNode* node) {
+        node->m_last_tx_time = GetTime<std::chrono::seconds>();
+        return true;
+    });
+
     m_txdownloadman.MempoolAcceptedTx(tx);
 
     LogDebug(BCLog::MEMPOOL, "AcceptToMemoryPool: peer=%d: accepted %s (wtxid=%s) (poolsz %u txn, %u kB)\n",
@@ -4541,7 +4546,6 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
 
         if (result.m_result_type == MempoolAcceptResult::ResultType::VALID) {
             ProcessValidTx(pfrom.GetId(), ptx, result.m_replaced_transactions);
-            pfrom.m_last_tx_time = GetTime<std::chrono::seconds>();
         }
         if (state.IsInvalid()) {
             if (auto package_to_validate{ProcessInvalidTx(pfrom.GetId(), ptx, state, /*first_time_failure=*/true)}) {

--- a/src/test/fuzz/process_messages.cpp
+++ b/src/test/fuzz/process_messages.cpp
@@ -117,6 +117,7 @@ FUZZ_TARGET(process_messages, .init = initialize_process_messages)
         net_msg.data = ConsumeRandomLengthByteVector(fuzzed_data_provider, MAX_PROTOCOL_MESSAGE_LENGTH);
 
         CNode& random_node = *PickValue(fuzzed_data_provider, peers);
+        const auto mempool_size_before{node.mempool->size()};
 
         connman.FlushSendBuffer(random_node);
         (void)connman.ReceiveMsgFrom(random_node, std::move(net_msg));
@@ -131,8 +132,16 @@ FUZZ_TARGET(process_messages, .init = initialize_process_messages)
             }
             node.peerman->SendMessages(random_node);
         }
+
+        node.validation_signals->SyncWithValidationInterfaceQueue();
+
+        // A TX message can accept the message itself, an orphan made ready by an earlier
+        // parent, or an eligible package. Each case must refresh the sending peer's
+        // eviction timestamp when it grows the mempool.
+        if (random_message_type == NetMsgType::TX && node.mempool->size() > mempool_size_before) {
+            assert(random_node.m_last_tx_time.load() == GetTime<std::chrono::seconds>());
+        }
     }
-    node.validation_signals->SyncWithValidationInterfaceQueue();
     node.validation_signals->UnregisterValidationInterface(node.peerman.get());
     node.connman->StopNodes();
     if (block_index_size != WITH_LOCK(chainman.GetMutex(), return chainman.BlockIndex().size())) {

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <addrman.h>
+#include <addresstype.h>
 #include <bip324.h>
 #include <chainparams.h>
 #include <clientversion.h>
@@ -21,6 +22,7 @@
 #include <test/util/net.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
+#include <test/util/time.h>
 #include <test/util/validation.h>
 #include <util/strencodings.h>
 #include <util/string.h>
@@ -1666,6 +1668,70 @@ BOOST_AUTO_TEST_CASE(addlocal_onlynet_externalip)
         g_reachable_nets.Add(net);
     }
     fDiscover = discover_orig;
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_FIXTURE_TEST_SUITE(net_processing_tests, TestChain100Setup)
+
+BOOST_FIXTURE_TEST_CASE(last_tx_time_ignores_orphan_acceptance, TestChain100Setup)
+{
+    m_clock.set(1700000000s);
+    LOCK(NetEventsInterface::g_msgproc_mutex);
+
+    auto& connman{static_cast<ConnmanTestMsg&>(*m_node.connman)};
+    m_node.validation_signals->RegisterValidationInterface(m_node.peerman.get());
+
+    auto* peer = new CNode{
+        /*id=*/0,
+        /*sock=*/nullptr,
+        /*addrIn=*/CAddress{Lookup("1.2.3.4", 8333, /*fAllowLookup=*/false).value(), NODE_NETWORK},
+        /*nKeyedNetGroupIn=*/0,
+        /*nLocalHostNonceIn=*/0,
+        /*addrBindIn=*/CService{},
+        /*addrNameIn=*/"",
+        /*conn_type_in=*/ConnectionType::INBOUND,
+        /*inbound_onion=*/false,
+        /*network_key=*/0,
+    };
+
+    connman.Handshake(*peer,
+                      /*successfully_connected=*/true,
+                      /*remote_services=*/static_cast<ServiceFlags>(NODE_NETWORK | NODE_WITNESS),
+                      /*local_services=*/static_cast<ServiceFlags>(NODE_NETWORK | NODE_WITNESS),
+                      PROTOCOL_VERSION,
+                      /*relay_txs=*/true);
+    connman.FlushSendBuffer(*peer);
+    connman.AddTestNode(*peer);
+
+    const CScript destination{GetScriptForDestination(PKHash(coinbaseKey.GetPubKey()))};
+    const auto parent{MakeTransactionRef(CreateValidMempoolTransaction(
+        m_coinbase_txns.front(), /*input_vout=*/0, /*input_height=*/1, coinbaseKey,
+        destination, m_coinbase_txns.front()->vout.front().nValue - 1000, /*submit=*/false))};
+    const auto orphan{MakeTransactionRef(CreateValidMempoolTransaction(
+        parent, /*input_vout=*/0, /*input_height=*/101, coinbaseKey,
+        destination, parent->vout.front().nValue - 1000, /*submit=*/false))};
+
+    BOOST_REQUIRE(connman.ReceiveMsgFrom(*peer, NetMsg::Make(NetMsgType::TX, TX_WITH_WITNESS(*orphan))));
+    peer->fPauseSend = false;
+    BOOST_REQUIRE(!connman.ProcessMessagesOnce(*peer));
+    BOOST_CHECK(!m_node.mempool->exists(orphan->GetHash()));
+
+    m_clock.set(1700000001s);
+    BOOST_REQUIRE(connman.ReceiveMsgFrom(*peer, NetMsg::Make(NetMsgType::TX, TX_WITH_WITNESS(*parent))));
+    peer->fPauseSend = false;
+    BOOST_REQUIRE(connman.ProcessMessagesOnce(*peer));
+    BOOST_CHECK_EQUAL(peer->m_last_tx_time.load(), 1700000001s);
+
+    m_clock.set(1700000002s);
+    BOOST_REQUIRE(connman.ProcessMessagesOnce(*peer));
+    BOOST_CHECK(m_node.mempool->exists(orphan->GetHash()));
+    BOOST_CHECK_EQUAL(peer->m_last_tx_time.load(), 1700000001s);
+
+    m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    m_node.validation_signals->UnregisterValidationInterface(m_node.peerman.get());
+    m_node.peerman->FinalizeNode(*peer);
+    connman.ClearTestNodes();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -1674,7 +1674,7 @@ BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_FIXTURE_TEST_SUITE(net_processing_tests, TestChain100Setup)
 
-BOOST_FIXTURE_TEST_CASE(last_tx_time_ignores_orphan_acceptance, TestChain100Setup)
+BOOST_FIXTURE_TEST_CASE(last_tx_time_tracks_orphan_acceptance, TestChain100Setup)
 {
     m_clock.set(1700000000s);
     LOCK(NetEventsInterface::g_msgproc_mutex);
@@ -1726,7 +1726,7 @@ BOOST_FIXTURE_TEST_CASE(last_tx_time_ignores_orphan_acceptance, TestChain100Setu
     m_clock.set(1700000002s);
     BOOST_REQUIRE(connman.ProcessMessagesOnce(*peer));
     BOOST_CHECK(m_node.mempool->exists(orphan->GetHash()));
-    BOOST_CHECK_EQUAL(peer->m_last_tx_time.load(), 1700000001s);
+    BOOST_CHECK_EQUAL(peer->m_last_tx_time.load(), 1700000002s);
 
     m_node.validation_signals->SyncWithValidationInterfaceQueue();
     m_node.validation_signals->UnregisterValidationInterface(m_node.peerman.get());


### PR DESCRIPTION
**Problem:** A peer that sends an orphan followed by its parent can have a transaction accepted while `getpeerinfo.last_transaction` remains stale.
The same gap affects accepted packages because only direct `TX` acceptance refreshes the timestamp.
Under inbound eviction pressure, the peer can lose protection for its most recent valid transaction.

**Fix:** Refresh the originating peer in `ProcessValidTx()`, shared by direct, orphan, and package acceptance.

<details>
<summary>Detailed explanation</summary>

`m_last_tx_time` identifies inbound peers that recently relayed transactions.
When an orphan becomes valid after its parent arrives, or when package acceptance succeeds, `ProcessValidTx()` records the accepted transaction but does not update that timestamp.
The node can therefore evict a peer that has just relayed a valid transaction.

Updating the timestamp in `ProcessValidTx()` covers every accepted transaction path at their common point.
The regression covers orphan release, and the `process_messages` fuzz target checks the same property for any `TX` message that grows the mempool.
</details>
