### PR TITLE
kernel: handle invalid C API arguments

### DIFF
--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -526,7 +526,7 @@ size_t btck_transaction_count_outputs(const btck_Transaction* transaction)
 const btck_TransactionOutput* btck_transaction_get_output_at(const btck_Transaction* transaction, size_t output_index)
 {
     const CTransaction& tx = *btck_Transaction::get(transaction);
-    assert(output_index < tx.vout.size());
+    if (output_index >= tx.vout.size()) return nullptr;
     return btck_TransactionOutput::ref(&tx.vout[output_index]);
 }
 
@@ -537,8 +537,9 @@ size_t btck_transaction_count_inputs(const btck_Transaction* transaction)
 
 const btck_TransactionInput* btck_transaction_get_input_at(const btck_Transaction* transaction, size_t input_index)
 {
-    assert(input_index < btck_Transaction::get(transaction)->vin.size());
-    return btck_TransactionInput::ref(&btck_Transaction::get(transaction)->vin[input_index]);
+    const CTransaction& tx = *btck_Transaction::get(transaction);
+    if (input_index >= tx.vin.size()) return nullptr;
+    return btck_TransactionInput::ref(&tx.vin[input_index]);
 }
 
 uint32_t btck_transaction_get_locktime(const btck_Transaction* transaction)
@@ -1200,8 +1201,9 @@ size_t btck_block_count_transactions(const btck_Block* block)
 
 const btck_Transaction* btck_block_get_transaction_at(const btck_Block* block, size_t index)
 {
-    assert(index < btck_Block::get(block)->vtx.size());
-    return btck_Transaction::ref(&btck_Block::get(block)->vtx[index]);
+    const auto& block_ptr{btck_Block::get(block)};
+    if (index >= block_ptr->vtx.size()) return nullptr;
+    return btck_Transaction::ref(&block_ptr->vtx[index]);
 }
 
 btck_BlockHeader* btck_block_get_header(const btck_Block* block)
@@ -1312,8 +1314,9 @@ size_t btck_block_spent_outputs_count(const btck_BlockSpentOutputs* block_spent_
 
 const btck_TransactionSpentOutputs* btck_block_spent_outputs_get_transaction_spent_outputs_at(const btck_BlockSpentOutputs* block_spent_outputs, size_t transaction_index)
 {
-    assert(transaction_index < btck_BlockSpentOutputs::get(block_spent_outputs)->vtxundo.size());
-    const auto* tx_undo{&btck_BlockSpentOutputs::get(block_spent_outputs)->vtxundo.at(transaction_index)};
+    const auto& block_undo{*btck_BlockSpentOutputs::get(block_spent_outputs)};
+    if (transaction_index >= block_undo.vtxundo.size()) return nullptr;
+    const auto* tx_undo{&block_undo.vtxundo.at(transaction_index)};
     return btck_TransactionSpentOutputs::ref(tx_undo);
 }
 
@@ -1339,8 +1342,9 @@ void btck_transaction_spent_outputs_destroy(btck_TransactionSpentOutputs* transa
 
 const btck_Coin* btck_transaction_spent_outputs_get_coin_at(const btck_TransactionSpentOutputs* transaction_spent_outputs, size_t coin_index)
 {
-    assert(coin_index < btck_TransactionSpentOutputs::get(transaction_spent_outputs).vprevout.size());
-    const Coin* coin{&btck_TransactionSpentOutputs::get(transaction_spent_outputs).vprevout.at(coin_index)};
+    const auto& tx_undo{btck_TransactionSpentOutputs::get(transaction_spent_outputs)};
+    if (coin_index >= tx_undo.vprevout.size()) return nullptr;
+    const Coin* coin{&tx_undo.vprevout.at(coin_index)};
     return btck_Coin::ref(coin);
 }
 

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -153,7 +153,7 @@ struct btck_TxValidationState : Handle<btck_TxValidationState, TxValidationState
 
 namespace {
 
-BCLog::Level get_bclog_level(btck_LogLevel level)
+std::optional<BCLog::Level> get_bclog_level(btck_LogLevel level)
 {
     switch (level) {
     case btck_LogLevel_INFO: {
@@ -166,10 +166,10 @@ BCLog::Level get_bclog_level(btck_LogLevel level)
         return BCLog::Level::Trace;
     }
     }
-    assert(false);
+    return std::nullopt;
 }
 
-BCLog::LogFlags get_bclog_flag(btck_LogCategory category)
+std::optional<BCLog::LogFlags> get_bclog_flag(btck_LogCategory category)
 {
     switch (category) {
     case btck_LogCategory_BENCH: {
@@ -206,7 +206,7 @@ BCLog::LogFlags get_bclog_flag(btck_LogCategory category)
         return BCLog::LogFlags::ALL;
     }
     }
-    assert(false);
+    return std::nullopt;
 }
 
 btck_SynchronizationState cast_state(SynchronizationState state)
@@ -808,21 +808,29 @@ void btck_logging_set_options(const btck_LoggingOptions options)
 void btck_logging_set_level_category(btck_LogCategory category, btck_LogLevel level)
 {
     LOCK(cs_main);
+    const auto log_level{get_bclog_level(level)};
+    const auto log_category{get_bclog_flag(category)};
+    if (!log_level || !log_category) return;
+
     if (category == btck_LogCategory_ALL) {
-        LogInstance().SetLogLevel(get_bclog_level(level));
+        LogInstance().SetLogLevel(*log_level);
     }
 
-    LogInstance().AddCategoryLogLevel(get_bclog_flag(category), get_bclog_level(level));
+    LogInstance().AddCategoryLogLevel(*log_category, *log_level);
 }
 
 void btck_logging_enable_category(btck_LogCategory category)
 {
-    LogInstance().EnableCategory(get_bclog_flag(category));
+    const auto log_category{get_bclog_flag(category)};
+    if (!log_category) return;
+    LogInstance().EnableCategory(*log_category);
 }
 
 void btck_logging_disable_category(btck_LogCategory category)
 {
-    LogInstance().DisableCategory(get_bclog_flag(category));
+    const auto log_category{get_bclog_flag(category)};
+    if (!log_category) return;
+    LogInstance().DisableCategory(*log_category);
 }
 
 void btck_logging_disable()

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -667,8 +667,11 @@ int btck_script_pubkey_verify(const btck_ScriptPubkey* script_pubkey,
                               const btck_ScriptVerificationFlags flags,
                               btck_ScriptVerifyStatus* status)
 {
-    // Assert that all specified flags are part of the interface before continuing
-    assert((flags & ~btck_ScriptVerificationFlags_ALL) == 0);
+    // Reject flags that are not part of the public interface before continuing.
+    if (flags & ~btck_ScriptVerificationFlags_ALL) {
+        if (status) *status = btck_ScriptVerifyStatus_ERROR_INVALID_FLAGS_COMBINATION;
+        return 0;
+    }
 
     if (!is_valid_flag_combination(script_verify_flags::from_int(flags))) {
         if (status) *status = btck_ScriptVerifyStatus_ERROR_INVALID_FLAGS_COMBINATION;
@@ -676,7 +679,10 @@ int btck_script_pubkey_verify(const btck_ScriptPubkey* script_pubkey,
     }
 
     const CTransaction& tx{*btck_Transaction::get(tx_to)};
-    assert(input_index < tx.vin.size());
+    if (input_index >= tx.vin.size()) {
+        if (status) *status = btck_ScriptVerifyStatus_ERROR_TX_INPUT_INDEX;
+        return 0;
+    }
 
     const PrecomputedTransactionData& txdata{precomputed_txdata ? btck_PrecomputedTransactionData::get(precomputed_txdata) : PrecomputedTransactionData(tx)};
 

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -871,7 +871,7 @@ btck_ChainParameters* btck_chain_parameters_create(const btck_ChainType chain_ty
         return btck_ChainParameters::ref(const_cast<CChainParams*>(CChainParams::RegTest().release()));
     }
     }
-    assert(false);
+    return nullptr;
 }
 
 btck_ChainParameters* btck_chain_parameters_create_signet(const void* challenge, size_t challenge_len)

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -627,9 +627,11 @@ btck_PrecomputedTransactionData* btck_precomputed_transaction_data_create(
 {
     try {
         const CTransaction& tx{*btck_Transaction::get(tx_to)};
+        if (spent_outputs_len > 0 && (spent_outputs_ == nullptr || spent_outputs_len != tx.vin.size())) {
+            return nullptr;
+        }
         auto txdata{btck_PrecomputedTransactionData::create()};
         if (spent_outputs_ != nullptr && spent_outputs_len > 0) {
-            assert(spent_outputs_len == tx.vin.size());
             std::vector<CTxOut> spent_outputs;
             spent_outputs.reserve(spent_outputs_len);
             for (size_t i = 0; i < spent_outputs_len; i++) {

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -718,8 +718,8 @@ BITCOINKERNEL_API void btck_transaction_destroy(btck_Transaction* transaction);
  * @brief Create precomputed transaction data for script verification.
  *
  * @param[in] tx_to             Non-null.
- * @param[in] spent_outputs     Nullable for non-taproot verification. Points to an array of
- *                              outputs spent by the transaction.
+ * @param[in] spent_outputs     Nullable only when spent_outputs_len is zero. Otherwise, points
+ *                              to an array containing one output per transaction input.
  * @param[in] spent_outputs_len Length of the spent_outputs array.
  * @return                      The precomputed data, or null on error.
  */

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -519,6 +519,7 @@ typedef uint8_t btck_ScriptVerifyStatus;
 #define btck_ScriptVerifyStatus_OK ((btck_ScriptVerifyStatus)(0))
 #define btck_ScriptVerifyStatus_ERROR_INVALID_FLAGS_COMBINATION ((btck_ScriptVerifyStatus)(1)) //!< The flags were combined in an invalid way.
 #define btck_ScriptVerifyStatus_ERROR_SPENT_OUTPUTS_REQUIRED ((btck_ScriptVerifyStatus)(2))    //!< The taproot flag was set, so valid spent_outputs have to be provided.
+#define btck_ScriptVerifyStatus_ERROR_TX_INPUT_INDEX ((btck_ScriptVerifyStatus)(3))            //!< The input index is out of range for the transaction.
 
 /**
  * Script verification flags that may be composed with each other.

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -637,7 +637,7 @@ BITCOINKERNEL_API size_t btck_transaction_count_outputs(
  *
  * @param[in] transaction  Non-null.
  * @param[in] output_index The index of the transaction output to be retrieved.
- * @return                 The transaction output
+ * @return                 The transaction output, or null if output_index is out of range.
  */
 BITCOINKERNEL_API const btck_TransactionOutput* btck_transaction_get_output_at(
     const btck_Transaction* transaction, size_t output_index) BITCOINKERNEL_ARG_NONNULL(1);
@@ -649,7 +649,7 @@ BITCOINKERNEL_API const btck_TransactionOutput* btck_transaction_get_output_at(
  *
  * @param[in] transaction Non-null.
  * @param[in] input_index The index of the transaction input to be retrieved.
- * @return                 The transaction input
+ * @return                 The transaction input, or null if input_index is out of range.
  */
 BITCOINKERNEL_API const btck_TransactionInput* btck_transaction_get_input_at(
     const btck_Transaction* transaction, size_t input_index) BITCOINKERNEL_ARG_NONNULL(1);
@@ -1437,7 +1437,7 @@ BITCOINKERNEL_API size_t btck_block_count_transactions(
  *
  * @param[in] block             Non-null.
  * @param[in] transaction_index The index of the transaction to be retrieved.
- * @return                      The transaction.
+ * @return                      The transaction, or null if transaction_index is out of range.
  */
 BITCOINKERNEL_API const btck_Transaction* btck_block_get_transaction_at(
     const btck_Block* block, size_t transaction_index) BITCOINKERNEL_ARG_NONNULL(1);
@@ -1607,7 +1607,7 @@ BITCOINKERNEL_API size_t btck_block_spent_outputs_count(
  *
  * @param[in] block_spent_outputs             Non-null.
  * @param[in] transaction_spent_outputs_index The index of the transaction spent outputs within the block spent outputs.
- * @return                                    A transaction spent outputs pointer.
+ * @return                                    A transaction spent outputs pointer, or null if the index is out of range.
  */
 BITCOINKERNEL_API const btck_TransactionSpentOutputs* btck_block_spent_outputs_get_transaction_spent_outputs_at(
     const btck_BlockSpentOutputs* block_spent_outputs,
@@ -1652,7 +1652,7 @@ BITCOINKERNEL_API size_t btck_transaction_spent_outputs_count(
  * @param[in] transaction_spent_outputs Non-null.
  * @param[in] coin_index                The index of the to be retrieved coin within the
  *                                      transaction spent outputs.
- * @return                              A coin pointer.
+ * @return                              A coin pointer, or null if coin_index is out of range.
  */
 BITCOINKERNEL_API const btck_Coin* btck_transaction_spent_outputs_get_coin_at(
     const btck_TransactionSpentOutputs* transaction_spent_outputs,

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -961,7 +961,7 @@ BITCOINKERNEL_API void btck_logging_connection_destroy(btck_LoggingConnection* l
  * passed in chain type.
  *
  * @param[in] chain_type Controls the chain parameters type created.
- * @return               An allocated chain parameters opaque struct.
+ * @return               An allocated chain parameters opaque struct, or null if chain_type is invalid.
  */
 BITCOINKERNEL_API btck_ChainParameters* BITCOINKERNEL_WARN_UNUSED_RESULT btck_chain_parameters_create(
     btck_ChainType chain_type);

--- a/src/kernel/bitcoinkernel_wrapper.h
+++ b/src/kernel/bitcoinkernel_wrapper.h
@@ -99,6 +99,7 @@ enum class ScriptVerifyStatus : btck_ScriptVerifyStatus {
     OK = btck_ScriptVerifyStatus_OK,
     ERROR_INVALID_FLAGS_COMBINATION = btck_ScriptVerifyStatus_ERROR_INVALID_FLAGS_COMBINATION,
     ERROR_SPENT_OUTPUTS_REQUIRED = btck_ScriptVerifyStatus_ERROR_SPENT_OUTPUTS_REQUIRED,
+    ERROR_TX_INPUT_INDEX = btck_ScriptVerifyStatus_ERROR_TX_INPUT_INDEX,
 };
 
 enum class ScriptVerificationFlags : btck_ScriptVerificationFlags {

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -688,6 +688,10 @@ BOOST_AUTO_TEST_CASE(logging_tests)
     logging_disable_category(LogCategory::BENCH);
     logging_enable_category(LogCategory::VALIDATION);
     logging_disable_category(LogCategory::VALIDATION);
+    btck_logging_set_level_category(/*category=*/255, btck_LogLevel_INFO);
+    btck_logging_set_level_category(btck_LogCategory_BENCH, /*level=*/255);
+    btck_logging_enable_category(/*category=*/255);
+    btck_logging_disable_category(/*category=*/255);
 
     // Check that connecting, connecting another, and then disconnecting and connecting a logger again works.
     {

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -548,6 +548,11 @@ BOOST_AUTO_TEST_CASE(btck_precomputed_txdata) {
         /*spent_outputs=*/{},
     }};
     CheckHandle(precomputed_txdata, precomputed_txdata_2);
+
+    const auto output_0{tx.GetOutput(0)};
+    const btck_TransactionOutput* spent_outputs[]{output_0.get()};
+    BOOST_CHECK_EQUAL(btck_precomputed_transaction_data_create(tx.get(), nullptr, 1), nullptr);
+    BOOST_CHECK_EQUAL(btck_precomputed_transaction_data_create(tx.get(), spent_outputs, tx.CountInputs() + 1), nullptr);
 }
 
 BOOST_AUTO_TEST_CASE(btck_script_verify_tests)

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -647,6 +647,30 @@ BOOST_AUTO_TEST_CASE(btck_script_verify_tests)
         /*amount=*/135125,
         /*input_index=*/1,
         /*taproot=*/true);
+
+    btck_ScriptVerifyStatus status{btck_ScriptVerifyStatus_OK};
+    BOOST_CHECK_EQUAL(btck_script_pubkey_verify(
+                          legacy_spent_script_pubkey.get(),
+                          /*amount=*/0,
+                          legacy_spending_tx.get(),
+                          /*precomputed_txdata=*/nullptr,
+                          legacy_spending_tx.CountInputs(),
+                          static_cast<btck_ScriptVerificationFlags>(VERIFY_ALL_PRE_SEGWIT),
+                          &status),
+                      0);
+    BOOST_CHECK_EQUAL(status, btck_ScriptVerifyStatus_ERROR_TX_INPUT_INDEX);
+
+    status = btck_ScriptVerifyStatus_OK;
+    BOOST_CHECK_EQUAL(btck_script_pubkey_verify(
+                          legacy_spent_script_pubkey.get(),
+                          /*amount=*/0,
+                          legacy_spending_tx.get(),
+                          /*precomputed_txdata=*/nullptr,
+                          /*input_index=*/0,
+                          uint32_t{1U << 31},
+                          &status),
+                      0);
+    BOOST_CHECK_EQUAL(status, btck_ScriptVerifyStatus_ERROR_INVALID_FLAGS_COMBINATION);
 }
 
 BOOST_AUTO_TEST_CASE(logging_tests)

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -728,6 +728,7 @@ BOOST_AUTO_TEST_CASE(btck_context_tests)
         ChainParams params{ChainType::MAINNET};
         ChainParams regtest_params{ChainType::REGTEST};
         CheckHandle(params, regtest_params);
+        BOOST_CHECK_EQUAL(btck_chain_parameters_create(/*chain_type=*/255), nullptr);
         options.SetChainParams(params);
         options.SetNotifications(std::make_shared<TestKernelNotifications>());
         Context context{options};

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -412,6 +412,8 @@ BOOST_AUTO_TEST_CASE(btck_transaction_tests)
     auto output{tx.GetOutput(tx.CountOutputs() - 1)};
     BOOST_CHECK_EQUAL(output.Amount(), 42130042);
     auto script_pubkey{output.GetScriptPubkey()};
+    BOOST_CHECK_EQUAL(btck_transaction_get_output_at(tx.get(), tx.CountOutputs()), nullptr);
+    BOOST_CHECK_EQUAL(btck_transaction_get_input_at(tx.get(), tx.CountInputs()), nullptr);
     {
         auto tx_new{Transaction{tx_data}};
         // This is safe, because we now use copy assignment
@@ -744,6 +746,7 @@ BOOST_AUTO_TEST_CASE(btck_block)
     CheckHandle(block, block_100);
     Block block_tx{hex_string_to_byte_vec(REGTEST_BLOCK_DATA[205])};
     CheckRange(block_tx.Transactions(), block_tx.CountTransactions());
+    BOOST_CHECK_EQUAL(btck_block_get_transaction_at(block_tx.get(), block_tx.CountTransactions()), nullptr);
     auto invalid_data = hex_string_to_byte_vec("012300");
     BOOST_CHECK_THROW(Block{invalid_data}, std::runtime_error);
     auto empty_data = hex_string_to_byte_vec("");
@@ -1221,6 +1224,7 @@ BOOST_AUTO_TEST_CASE(btck_chainman_regtest_tests)
     CheckHandle(block_spent_outputs, block_spent_outputs_prev);
     CheckRange(block_spent_outputs_prev.TxsSpentOutputs(), block_spent_outputs_prev.Count());
     BOOST_CHECK_EQUAL(block_spent_outputs.Count(), 1);
+    BOOST_CHECK_EQUAL(btck_block_spent_outputs_get_transaction_spent_outputs_at(block_spent_outputs.get(), block_spent_outputs.Count()), nullptr);
 
     // Get transaction spent outputs from the last transaction in the two blocks
     TransactionSpentOutputsView transaction_spent_outputs{block_spent_outputs.GetTxSpentOutputs(block_spent_outputs.Count() - 1)};
@@ -1228,6 +1232,7 @@ BOOST_AUTO_TEST_CASE(btck_chainman_regtest_tests)
     TransactionSpentOutputs owned_transaction_spent_outputs_prev{block_spent_outputs_prev.GetTxSpentOutputs(block_spent_outputs_prev.Count() - 1)};
     CheckHandle(owned_transaction_spent_outputs, owned_transaction_spent_outputs_prev);
     CheckRange(transaction_spent_outputs.Coins(), transaction_spent_outputs.Count());
+    BOOST_CHECK_EQUAL(btck_transaction_spent_outputs_get_coin_at(transaction_spent_outputs.get(), transaction_spent_outputs.Count()), nullptr);
 
     // Get the last coin from the transaction spent outputs
     CoinView coin{transaction_spent_outputs.GetCoin(transaction_spent_outputs.Count() - 1)};


### PR DESCRIPTION
**Problem:** Several public Kernel C API functions assert on invalid-but-representable arguments, including collection boundaries, unsupported enum values, mismatched precomputed spent-output arrays, and script-verification input indexes.
An embedding application can therefore terminate instead of receiving an API failure it can handle.

**Fix:** Return `nullptr` from fallible constructors and accessors, report script-verification failures through `btck_ScriptVerifyStatus`, and ignore invalid logging settings.
Document the nullable results so C callers can check them.

<details>
<summary>API contract coverage</summary>

Collection accessors return `nullptr` at the count boundary.
Precomputed transaction data requires either zero spent outputs or exactly one for each transaction input.
Script verification rejects unknown flag bits and reports an out-of-range input index through `btck_ScriptVerifyStatus`.
Unsupported chain types return `nullptr`, while invalid logging categories and levels leave the logging configuration unchanged.
These are local embedding API hardenings and do not change P2P or consensus behavior.
</details>
