### PR TITLE
torcontrol: back off after disconnect

### DIFF
--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -738,8 +738,12 @@ void TorController::disconnected_cb(TorControlConnection& _conn)
     if (!m_reconnect)
         return;
 
-    LogDebug(BCLog::TOR, "Not connected to Tor control port %s, will retry", m_tor_control_center);
+    LogDebug(BCLog::TOR, "Not connected to Tor control port %s, retrying in %.1f seconds", m_tor_control_center, m_reconnect_timeout.count());
     _conn.Disconnect();
+    if (!m_interrupt.sleep_for(std::chrono::duration_cast<std::chrono::milliseconds>(m_reconnect_timeout))) {
+        return;
+    }
+    m_reconnect_timeout = std::min(m_reconnect_timeout * RECONNECT_TIMEOUT_EXP, RECONNECT_TIMEOUT_MAX);
 }
 
 fs::path TorController::GetPrivateKeyFile()

--- a/test/functional/feature_torcontrol.py
+++ b/test/functional/feature_torcontrol.py
@@ -6,6 +6,7 @@
 from contextlib import contextmanager
 import socket
 import threading
+import time
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
@@ -22,6 +23,7 @@ class MockTorControlServer:
         self.running = False
         self.thread = None
         self.received_commands = []
+        self.connection_times = []
         self.manual_mode = manual_mode
         self.conn_ready = threading.Event()
 
@@ -49,6 +51,7 @@ class MockTorControlServer:
         while self.running:
             try:
                 self.conn, _ = self.sock.accept()
+                self.connection_times.append(time.monotonic())
                 self.conn.settimeout(1.0)
                 self.conn_ready.set()
                 self._handle_connection(self.conn)
@@ -82,6 +85,12 @@ class MockTorControlServer:
     def send_raw(self, data):
         if self.conn:
             self.conn.sendall(data.encode('utf-8'))
+
+    def disconnect(self):
+        assert self.conn
+        disconnected_at = time.monotonic()
+        self.conn.shutdown(socket.SHUT_RDWR)
+        return disconnected_at
 
     def _get_response(self, command):
         if command == "PROTOCOLINFO 1":
@@ -256,12 +265,29 @@ class TorControlTest(BitcoinTestFramework):
 
         mock_tor.stop()
 
+    def test_reconnect_delay(self):
+        self.log.info("Test Tor control reconnect delay after disconnect")
+
+        mock_tor = MockTorControlServer(self.next_port())
+        self.restart_with_mock(mock_tor)
+        self.wait_until(lambda: len(mock_tor.received_commands) >= 4, timeout=10)
+
+        disconnected_at = mock_tor.disconnect()
+        self.wait_until(lambda: len(mock_tor.connection_times) >= 2, timeout=10)
+        reconnect_delay = mock_tor.connection_times[1] - disconnected_at
+
+        # TODO: Reconnection should wait to avoid a busy loop after a disconnect.
+        assert reconnect_delay < 0.5, f"reconnected after {reconnect_delay:.3f}s"
+
+        mock_tor.stop()
+
     def run_test(self):
         self.test_basic()
         self.test_partial_data()
         self.test_pow_fallback()
         self.test_oversized_line()
         self.test_overmany_lines()
+        self.test_reconnect_delay()
 
 
 if __name__ == '__main__':

--- a/test/functional/feature_torcontrol.py
+++ b/test/functional/feature_torcontrol.py
@@ -276,8 +276,7 @@ class TorControlTest(BitcoinTestFramework):
         self.wait_until(lambda: len(mock_tor.connection_times) >= 2, timeout=10)
         reconnect_delay = mock_tor.connection_times[1] - disconnected_at
 
-        # TODO: Reconnection should wait to avoid a busy loop after a disconnect.
-        assert reconnect_delay < 0.5, f"reconnected after {reconnect_delay:.3f}s"
+        assert reconnect_delay >= 0.5, f"reconnected after {reconnect_delay:.3f}s"
 
         mock_tor.stop()
 


### PR DESCRIPTION
**Problem:** A configured Tor-control endpoint can accept a control connection and then immediately close it.
Established-session disconnects return to `ThreadControl()` with no delay, while failed connection attempts use exponential backoff.
Repeating that sequence can keep the `torcontrol` thread busy.

**Fix:** Apply the existing interruptible exponential backoff after an established Tor-control connection drops.
Successful reconnections reset the delay to its normal initial value.

<details>
<summary>Detailed explanation</summary>

When the Tor control socket cannot connect, `ThreadControl()` waits before its next attempt and increases the retry delay.
After a connection succeeds, it resets that delay and begins the normal authentication and onion-service setup.
If the established socket then closes, `disconnected_cb()` used to close it and return directly to the connection loop.
A local process listening on the configured `-torcontrol` address could therefore make the controller reconnect as quickly as the operating system allowed.

The change uses the same interruptible sleep and timeout growth already used for failed connection attempts.
Shutdown still interrupts the wait immediately, and a later successful connection resets the next delay to one second.

The functional test completes a mock Tor-control session, closes its socket, and measures the next accepted connection.
It now requires at least 500 ms before reconnecting, which distinguishes the backoff from the previous immediate retry while leaving margin below the one-second initial interval.
</details>
