### PR TITLE
txgraph: avoid equal-feerate fee overflow

### DIFF
--- a/src/test/txgraph_tests.cpp
+++ b/src/test/txgraph_tests.cpp
@@ -436,7 +436,7 @@ BOOST_AUTO_TEST_CASE(txgraph_equal_feerate_prefix_does_not_overflow)
 {
     auto graph = MakeTxGraph(/*max_cluster_count=*/10, /*max_cluster_size=*/1000, HIGH_ACCEPTABLE_COST, PointerComparator);
 
-    constexpr int64_t fee{std::numeric_limits<int64_t>::max() / 3}; // TODO: Equal-feerate FeeFrac sums can overflow.
+    constexpr int64_t fee{1 + std::numeric_limits<int64_t>::max() / 2}; // Smallest fee whose sum with itself exceeds int64_t's maximum.
     std::vector<TxGraph::Ref> refs;
     graph->AddTransaction(refs.emplace_back(), FeePerWeight{fee, 1});
     graph->AddTransaction(refs.emplace_back(), FeePerWeight{0, 1});

--- a/src/test/txgraph_tests.cpp
+++ b/src/test/txgraph_tests.cpp
@@ -8,6 +8,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <limits>
 #include <memory>
 #include <vector>
 
@@ -428,6 +429,25 @@ BOOST_AUTO_TEST_CASE(txgraph_staging)
 
     BOOST_CHECK_EQUAL(graph->GetTransactionCount(TxGraph::Level::MAIN), 1);
 
+    graph->SanityCheck();
+}
+
+BOOST_AUTO_TEST_CASE(txgraph_equal_feerate_prefix_does_not_overflow)
+{
+    auto graph = MakeTxGraph(/*max_cluster_count=*/10, /*max_cluster_size=*/1000, HIGH_ACCEPTABLE_COST, PointerComparator);
+
+    constexpr int64_t fee{std::numeric_limits<int64_t>::max() / 3}; // TODO: Equal-feerate FeeFrac sums can overflow.
+    std::vector<TxGraph::Ref> refs;
+    graph->AddTransaction(refs.emplace_back(), FeePerWeight{fee, 1});
+    graph->AddTransaction(refs.emplace_back(), FeePerWeight{0, 1});
+    graph->AddTransaction(refs.emplace_back(), FeePerWeight{fee, 1});
+    graph->AddTransaction(refs.emplace_back(), FeePerWeight{fee, 1});
+
+    graph->AddDependency(/*parent=*/refs[0], /*child=*/refs[1]);
+    graph->AddDependency(/*parent=*/refs[2], /*child=*/refs[1]);
+    graph->AddDependency(/*parent=*/refs[3], /*child=*/refs[1]);
+
+    BOOST_CHECK_EQUAL(graph->GetCluster(refs[0], TxGraph::Level::MAIN).size(), refs.size());
     graph->SanityCheck();
 }
 

--- a/src/txgraph.cpp
+++ b/src/txgraph.cpp
@@ -99,11 +99,10 @@ struct TrimTxData
     uint64_t m_uf_size;
 };
 
-/** The sum of all chunk feerate FeeFracs with the same feerate as the current chunk,
- *  up to and including the current chunk. */
+/** Track the running size of an equal-feerate chunk prefix without summing fees. */
 struct EqualFeerateChunkPrefix
 {
-    FeeFrac m_feerate;
+    FeeFrac m_feerate; //!< The feerate of the last added chunk.
     int32_t m_size{0}; //!< Total size of the current equal-feerate chunk prefix.
 
     EqualFeerateChunkPrefix() = default;
@@ -111,15 +110,10 @@ struct EqualFeerateChunkPrefix
 
     void Add(const FeeFrac& feerate) noexcept
     {
-        // Update m_feerate to include this chunk, starting over when the feerate changed.
-        if (ByRatio{feerate} < ByRatio{m_feerate}) {
-            m_feerate = feerate;
-        } else {
-            // Note that this is adding fees to fees, and sizes to sizes, so the overall
-            // ratio remains the same; it's just accounting for the size of the added chunk.
-            m_feerate += feerate;
-        }
-        m_size = m_feerate.size;
+        // Update m_size to include this chunk, starting over when the feerate changed.
+        if (ByRatio{feerate} < ByRatio{m_feerate}) m_size = 0;
+        m_feerate = feerate;
+        m_size += feerate.size;
     }
 };
 

--- a/src/txgraph.cpp
+++ b/src/txgraph.cpp
@@ -99,6 +99,30 @@ struct TrimTxData
     uint64_t m_uf_size;
 };
 
+/** The sum of all chunk feerate FeeFracs with the same feerate as the current chunk,
+ *  up to and including the current chunk. */
+struct EqualFeerateChunkPrefix
+{
+    FeeFrac m_feerate;
+    int32_t m_size{0}; //!< Total size of the current equal-feerate chunk prefix.
+
+    EqualFeerateChunkPrefix() = default;
+    explicit EqualFeerateChunkPrefix(const FeeFrac& feerate) noexcept : m_feerate{feerate}, m_size{feerate.size} {}
+
+    void Add(const FeeFrac& feerate) noexcept
+    {
+        // Update m_feerate to include this chunk, starting over when the feerate changed.
+        if (ByRatio{feerate} < ByRatio{m_feerate}) {
+            m_feerate = feerate;
+        } else {
+            // Note that this is adding fees to fees, and sizes to sizes, so the overall
+            // ratio remains the same; it's just accounting for the size of the added chunk.
+            m_feerate += feerate;
+        }
+        m_size = m_feerate.size;
+    }
+};
+
 /** A grouping of connected transactions inside a TxGraphImpl::ClusterSet. */
 class Cluster
 {
@@ -1090,23 +1114,13 @@ void GenericClusterImpl::Updated(TxGraphImpl& graph, int level, bool rename) noe
     if (level == 0 && (rename || IsAcceptable())) {
         auto chunking = ChunkLinearizationInfo(m_depgraph, m_linearization);
         LinearizationIndex lin_idx{0};
-        /** The sum of all chunk feerate FeeFracs with the same feerate as the current chunk,
-         *  up to and including the current chunk. */
-        FeeFrac equal_feerate_chunk_feerate;
+        EqualFeerateChunkPrefix equal_prefix;
         // Iterate over the chunks.
         for (unsigned chunk_idx = 0; chunk_idx < chunking.size(); ++chunk_idx) {
             auto& chunk = chunking[chunk_idx];
             auto chunk_count = chunk.transactions.Count();
             Assume(chunk_count > 0);
-            // Update equal_feerate_chunk_feerate to include this chunk, starting over when the
-            // feerate changed.
-            if (ByRatio{chunk.feerate} < ByRatio{equal_feerate_chunk_feerate}) {
-                equal_feerate_chunk_feerate = chunk.feerate;
-            } else {
-                // Note that this is adding fees to fees, and sizes to sizes, so the overall
-                // ratio remains the same; it's just accounting for the size of the added chunk.
-                equal_feerate_chunk_feerate += chunk.feerate;
-            }
+            equal_prefix.Add(chunk.feerate);
             // Determine the m_fallback_order maximum transaction in the chunk.
             auto it = chunk.transactions.begin();
             GraphIndex max_element = m_mapping[*it];
@@ -1125,7 +1139,7 @@ void GenericClusterImpl::Updated(TxGraphImpl& graph, int level, bool rename) noe
                 auto& entry = graph.m_entries[graph_idx];
                 entry.m_main_lin_index = lin_idx++;
                 entry.m_main_chunk_feerate = FeePerWeight::FromFeeFrac(chunk.feerate);
-                entry.m_main_equal_feerate_chunk_prefix_size = equal_feerate_chunk_feerate.size;
+                entry.m_main_equal_feerate_chunk_prefix_size = equal_prefix.m_size;
                 entry.m_main_max_chunk_fallback = max_element;
                 Assume(chunk.transactions[idx]);
                 chunk.transactions.Reset(idx);
@@ -2854,7 +2868,7 @@ void GenericClusterImpl::SanityCheck(const TxGraphImpl& graph, int level) const
     DepGraphIndex chunk_pos{0}; //!< position within the current chunk
     assert(m_depgraph.IsAcyclic());
     if (m_linearization.empty()) return;
-    FeeFrac equal_feerate_prefix = linchunking[chunk_num].feerate;
+    EqualFeerateChunkPrefix equal_prefix{linchunking[chunk_num].feerate};
     for (auto lin_pos : m_linearization) {
         assert(lin_pos < m_mapping.size());
         const auto& entry = graph.m_entries[m_mapping[lin_pos]];
@@ -2875,15 +2889,11 @@ void GenericClusterImpl::SanityCheck(const TxGraphImpl& graph, int level) const
                 ++chunk_num;
                 assert(chunk_num < linchunking.size());
                 chunk_pos = 0;
-                if (ByRatio{linchunking[chunk_num].feerate} < ByRatio{equal_feerate_prefix}) {
-                    equal_feerate_prefix = linchunking[chunk_num].feerate;
-                } else {
-                    assert(ByRatio{linchunking[chunk_num].feerate} == ByRatio{equal_feerate_prefix});
-                    equal_feerate_prefix += linchunking[chunk_num].feerate;
-                }
+                assert(ByRatio{linchunking[chunk_num].feerate} <= ByRatio{equal_prefix.m_feerate});
+                equal_prefix.Add(linchunking[chunk_num].feerate);
             }
             assert(entry.m_main_chunk_feerate == linchunking[chunk_num].feerate);
-            assert(entry.m_main_equal_feerate_chunk_prefix_size == equal_feerate_prefix.size);
+            assert(entry.m_main_equal_feerate_chunk_prefix_size == equal_prefix.m_size);
             // Verify that an entry in the chunk index exists for every chunk-ending transaction.
             ++chunk_pos;
             if (graph.m_main_clusterset.m_to_remove.empty()) {


### PR DESCRIPTION
**Problem:** TxGraph obtains the cumulative size of equal-feerate chunk prefixes by adding their complete `FeeFrac` values.
An authenticated `prioritisetransaction` caller can make `SetTransactionFee()` receive a modified fee close to `int64_t`'s maximum, so adding equal-feerate chunks can overflow the unused fee sum in `Updated()` or `SanityCheck()`.
Peer-submitted transaction fees are bounded by `MAX_MONEY` and cannot trigger this.

**Fix:** Track the previous chunk's feerate and the cumulative prefix size separately.
Use the same helper in `Updated()` and `SanityCheck()` so both paths calculate equal-feerate prefixes identically.

<details>
<summary>Detailed explanation</summary>

TxGraph divides a transaction cluster into chunks ordered by feerate.
For consecutive chunks with the same feerate, `GenericClusterImpl` records their cumulative size for its fallback ordering.

The previous code obtained that size by adding the chunks' complete `FeeFrac` values in both cluster materialization and `SanityCheck()`.
The ratio remains unchanged, but the accumulated fee is unused and can overflow `int64_t`.

The helper retains the previous chunk's `FeeFrac` for comparison and accumulates only the required size.
A focused regression test aborts clean master under Debug `-ftrapv` and passes after the change.

`CompareChunks()` has a separate aggregate-range requirement for its callers.
That does not limit TxGraph input: `AddTransaction()` requires only a positive size, and `SetTransactionFee()` accepts an `int64_t` fee.
This change removes only the prefix-accounting overflow and does not change diagram aggregation.

PRs #209, #217, and #238 address other arithmetic reached through extreme modified fees.
They cover RBF rule #4, fee-diagram and validation aggregates, and `TxMempoolInfo::nFeeDelta`, respectively.
None changes the equal-feerate prefix accounting inside TxGraph.
</details>
