### PR TITLE
refactor: use chrono literals for durations

### DIFF
--- a/src/banman.h
+++ b/src/banman.h
@@ -18,6 +18,7 @@
 
 // NOTE: When adjusting this, update rpcnet:setban's help ("24h")
 static constexpr unsigned int DEFAULT_MISBEHAVING_BANTIME{TicksSeconds(24h)};
+static_assert(DEFAULT_MISBEHAVING_BANTIME == 60 * 60 * 24);
 
 /// How often to dump banned addresses/subnets to disk.
 static constexpr std::chrono::minutes DUMP_BANS_INTERVAL{15};

--- a/src/banman.h
+++ b/src/banman.h
@@ -10,13 +10,14 @@
 #include <net_types.h>
 #include <sync.h>
 #include <util/fs.h>
+#include <util/time.h>
 
 #include <chrono>
 #include <cstdint>
 #include <memory>
 
 // NOTE: When adjusting this, update rpcnet:setban's help ("24h")
-static constexpr unsigned int DEFAULT_MISBEHAVING_BANTIME = 60 * 60 * 24; // Default 24-hour ban
+static constexpr unsigned int DEFAULT_MISBEHAVING_BANTIME{TicksSeconds(24h)};
 
 /// How often to dump banned addresses/subnets to disk.
 static constexpr std::chrono::minutes DUMP_BANS_INTERVAL{15};

--- a/src/chain.h
+++ b/src/chain.h
@@ -26,7 +26,7 @@
  * Maximum amount of time that a block timestamp is allowed to exceed the
  * current time before the block will be accepted.
  */
-static constexpr int64_t MAX_FUTURE_BLOCK_TIME = 2 * 60 * 60;
+static constexpr int64_t MAX_FUTURE_BLOCK_TIME{TicksSeconds(2h)};
 
 /**
  * Timestamp window used as a grace period by code that compares external

--- a/src/chain.h
+++ b/src/chain.h
@@ -27,6 +27,7 @@
  * current time before the block will be accepted.
  */
 static constexpr int64_t MAX_FUTURE_BLOCK_TIME{TicksSeconds(2h)};
+static_assert(MAX_FUTURE_BLOCK_TIME == 2 * 60 * 60);
 
 /**
  * Timestamp window used as a grace period by code that compares external

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -21,6 +21,7 @@
 #include <util/chaintype.h>
 #include <util/log.h>
 #include <util/strencodings.h>
+#include <util/time.h>
 
 #include <algorithm>
 #include <array>
@@ -29,6 +30,7 @@
 #include <cstring>
 #include <iterator>
 #include <map>
+#include <ratio>
 #include <span>
 #include <utility>
 
@@ -124,8 +126,8 @@ public:
         consensus.SegwitHeight = 481824; // 0000000000000000001c8018d9cb3b742ef25114f27563e3fc4a1902167f9893
         consensus.MinBIP9WarningHeight = 711648; // taproot activation height + miner confirmation window
         consensus.powLimit = uint256{"00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff"};
-        consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
-        consensus.nPowTargetSpacing = 10 * 60;
+        consensus.nPowTargetTimespan = TicksSeconds(2 * 7 * 24h);
+        consensus.nPowTargetSpacing = TicksSeconds(10min);
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.enforce_BIP94 = false;
         consensus.fPowNoRetargeting = false;
@@ -248,8 +250,8 @@ public:
         consensus.SegwitHeight = 834624; // 00000000002b980fcd729daaa248fd9316a5200e9b367f4ff2c42453e84201ca
         consensus.MinBIP9WarningHeight = 2013984; // taproot activation height + miner confirmation window
         consensus.powLimit = uint256{"00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff"};
-        consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
-        consensus.nPowTargetSpacing = 10 * 60;
+        consensus.nPowTargetTimespan = TicksSeconds(2 * 7 * 24h);
+        consensus.nPowTargetSpacing = TicksSeconds(10min);
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.enforce_BIP94 = false;
         consensus.fPowNoRetargeting = false;
@@ -348,8 +350,8 @@ public:
         consensus.SegwitHeight = 1;
         consensus.MinBIP9WarningHeight = 0;
         consensus.powLimit = uint256{"00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff"};
-        consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
-        consensus.nPowTargetSpacing = 10 * 60;
+        consensus.nPowTargetTimespan = TicksSeconds(2 * 7 * 24h);
+        consensus.nPowTargetSpacing = TicksSeconds(10min);
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.enforce_BIP94 = true;
         consensus.fPowNoRetargeting = false;
@@ -492,8 +494,8 @@ public:
         consensus.BIP66Height = 1;
         consensus.CSVHeight = 1;
         consensus.SegwitHeight = 1;
-        consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
-        consensus.nPowTargetSpacing = 10 * 60;
+        consensus.nPowTargetTimespan = TicksSeconds(2 * 7 * 24h);
+        consensus.nPowTargetSpacing = TicksSeconds(10min);
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.enforce_BIP94 = false;
         consensus.fPowNoRetargeting = false;
@@ -577,8 +579,8 @@ public:
         consensus.SegwitHeight = 0; // Always active unless overridden
         consensus.MinBIP9WarningHeight = 0;
         consensus.powLimit = uint256{"7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"};
-        consensus.nPowTargetTimespan = 24 * 60 * 60; // one day
-        consensus.nPowTargetSpacing = 10 * 60;
+        consensus.nPowTargetTimespan = TicksSeconds(24h);
+        consensus.nPowTargetSpacing = TicksSeconds(10min);
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.enforce_BIP94 = opts.enforce_bip94;
         consensus.fPowNoRetargeting = true;

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -127,7 +127,9 @@ public:
         consensus.MinBIP9WarningHeight = 711648; // taproot activation height + miner confirmation window
         consensus.powLimit = uint256{"00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff"};
         consensus.nPowTargetTimespan = TicksSeconds(2 * 7 * 24h);
+        static_assert(TicksSeconds(2 * 7 * 24h) == 14 * 24 * 60 * 60);
         consensus.nPowTargetSpacing = TicksSeconds(10min);
+        static_assert(TicksSeconds(10min) == 10 * 60);
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.enforce_BIP94 = false;
         consensus.fPowNoRetargeting = false;
@@ -251,7 +253,9 @@ public:
         consensus.MinBIP9WarningHeight = 2013984; // taproot activation height + miner confirmation window
         consensus.powLimit = uint256{"00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff"};
         consensus.nPowTargetTimespan = TicksSeconds(2 * 7 * 24h);
+        static_assert(TicksSeconds(2 * 7 * 24h) == 14 * 24 * 60 * 60);
         consensus.nPowTargetSpacing = TicksSeconds(10min);
+        static_assert(TicksSeconds(10min) == 10 * 60);
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.enforce_BIP94 = false;
         consensus.fPowNoRetargeting = false;
@@ -351,7 +355,9 @@ public:
         consensus.MinBIP9WarningHeight = 0;
         consensus.powLimit = uint256{"00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff"};
         consensus.nPowTargetTimespan = TicksSeconds(2 * 7 * 24h);
+        static_assert(TicksSeconds(2 * 7 * 24h) == 14 * 24 * 60 * 60);
         consensus.nPowTargetSpacing = TicksSeconds(10min);
+        static_assert(TicksSeconds(10min) == 10 * 60);
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.enforce_BIP94 = true;
         consensus.fPowNoRetargeting = false;
@@ -495,7 +501,9 @@ public:
         consensus.CSVHeight = 1;
         consensus.SegwitHeight = 1;
         consensus.nPowTargetTimespan = TicksSeconds(2 * 7 * 24h);
+        static_assert(TicksSeconds(2 * 7 * 24h) == 14 * 24 * 60 * 60);
         consensus.nPowTargetSpacing = TicksSeconds(10min);
+        static_assert(TicksSeconds(10min) == 10 * 60);
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.enforce_BIP94 = false;
         consensus.fPowNoRetargeting = false;
@@ -580,7 +588,9 @@ public:
         consensus.MinBIP9WarningHeight = 0;
         consensus.powLimit = uint256{"7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"};
         consensus.nPowTargetTimespan = TicksSeconds(24h);
+        static_assert(TicksSeconds(24h) == 24 * 60 * 60);
         consensus.nPowTargetSpacing = TicksSeconds(10min);
+        static_assert(TicksSeconds(10min) == 10 * 60);
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.enforce_BIP94 = opts.enforce_bip94;
         consensus.fPowNoRetargeting = true;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -84,6 +84,7 @@ static constexpr int DNSSEEDS_DELAY_PEER_THRESHOLD = 1000; // "many" vs "few" pe
 
 /** The default timeframe for -maxuploadtarget. 1 day. */
 static constexpr std::chrono::seconds MAX_UPLOAD_TIMEFRAME{24h};
+static_assert(MAX_UPLOAD_TIMEFRAME == std::chrono::seconds{60 * 60 * 24});
 
 // A random time period (0 to 1 seconds) is added to feeler connections to prevent synchronization.
 static constexpr auto FEELER_SLEEP_WINDOW{1s};

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -83,7 +83,7 @@ static constexpr std::chrono::minutes DNSSEEDS_DELAY_MANY_PEERS{5};
 static constexpr int DNSSEEDS_DELAY_PEER_THRESHOLD = 1000; // "many" vs "few" peers
 
 /** The default timeframe for -maxuploadtarget. 1 day. */
-static constexpr std::chrono::seconds MAX_UPLOAD_TIMEFRAME{60 * 60 * 24};
+static constexpr std::chrono::seconds MAX_UPLOAD_TIMEFRAME{24h};
 
 // A random time period (0 to 1 seconds) is added to feeler connections to prevent synchronization.
 static constexpr auto FEELER_SLEEP_WINDOW{1s};

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -116,9 +116,11 @@ static constexpr uint64_t RANDOMIZER_ID_ADDRESS_RELAY = 0x3cac0035b5866b90ULL;
 /// Age after which a stale block will no longer be served if requested as
 /// protection against fingerprinting. Set to one month.
 static constexpr int STALE_RELAY_AGE_LIMIT{TicksSeconds(30 * 24h)};
+static_assert(STALE_RELAY_AGE_LIMIT == 30 * 24 * 60 * 60);
 /// Age after which a block is considered historical for purposes of rate
 /// limiting block relay. Set to one week.
 static constexpr int HISTORICAL_BLOCK_AGE{TicksSeconds(7 * 24h)};
+static_assert(HISTORICAL_BLOCK_AGE == 7 * 24 * 60 * 60);
 /** Time between pings automatically sent out for latency probing and keepalive */
 static constexpr auto PING_INTERVAL{2min};
 /** The maximum number of entries in a locator */
@@ -4511,6 +4513,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
             // If pruning, don't inv blocks unless we have on disk and are likely to still have
             // for some reasonable time window that block relay might require.
             const int nPrunedBlocksLikelyToHave = MIN_BLOCKS_TO_KEEP - TicksSeconds(1h) / m_chainparams.GetConsensus().nPowTargetSpacing;
+            static_assert(TicksSeconds(1h) == 3600);
             if (m_chainman.m_blockman.IsPruneMode() && (!(pindex->nStatus & BLOCK_HAVE_DATA) || pindex->nHeight <= m_chainman.ActiveChain().Tip()->nHeight - nPrunedBlocksLikelyToHave)) {
                 LogDebug(BCLog::NET, " getblocks stopping, pruned or too old block at %d %s\n", pindex->nHeight, pindex->GetBlockHash().ToString());
                 break;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -114,11 +114,11 @@ static constexpr auto MINIMUM_CONNECT_TIME{30s};
 /** SHA256("main address relay")[0:8] */
 static constexpr uint64_t RANDOMIZER_ID_ADDRESS_RELAY = 0x3cac0035b5866b90ULL;
 /// Age after which a stale block will no longer be served if requested as
-/// protection against fingerprinting. Set to one month, denominated in seconds.
-static constexpr int STALE_RELAY_AGE_LIMIT = 30 * 24 * 60 * 60;
+/// protection against fingerprinting. Set to one month.
+static constexpr int STALE_RELAY_AGE_LIMIT{TicksSeconds(30 * 24h)};
 /// Age after which a block is considered historical for purposes of rate
-/// limiting block relay. Set to one week, denominated in seconds.
-static constexpr int HISTORICAL_BLOCK_AGE = 7 * 24 * 60 * 60;
+/// limiting block relay. Set to one week.
+static constexpr int HISTORICAL_BLOCK_AGE{TicksSeconds(7 * 24h)};
 /** Time between pings automatically sent out for latency probing and keepalive */
 static constexpr auto PING_INTERVAL{2min};
 /** The maximum number of entries in a locator */
@@ -4509,8 +4509,8 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
                 break;
             }
             // If pruning, don't inv blocks unless we have on disk and are likely to still have
-            // for some reasonable time window (1 hour) that block relay might require.
-            const int nPrunedBlocksLikelyToHave = MIN_BLOCKS_TO_KEEP - 3600 / m_chainparams.GetConsensus().nPowTargetSpacing;
+            // for some reasonable time window that block relay might require.
+            const int nPrunedBlocksLikelyToHave = MIN_BLOCKS_TO_KEEP - TicksSeconds(1h) / m_chainparams.GetConsensus().nPowTargetSpacing;
             if (m_chainman.m_blockman.IsPruneMode() && (!(pindex->nStatus & BLOCK_HAVE_DATA) || pindex->nHeight <= m_chainman.ActiveChain().Tip()->nHeight - nPrunedBlocksLikelyToHave)) {
                 LogDebug(BCLog::NET, " getblocks stopping, pruned or too old block at %d %s\n", pindex->nHeight, pindex->GetBlockHash().ToString());
                 break;

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -38,6 +38,7 @@
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
 #include <node/interface_ui.h>
+#include <util/time.h>
 #include <util/translation.h>
 #include <validation.h>
 
@@ -76,7 +77,7 @@
  *
  * Ref: https://github.com/bitcoin/bitcoin/pull/1026
  */
-static constexpr int64_t MAX_BLOCK_TIME_GAP = 90 * 60;
+static constexpr int64_t MAX_BLOCK_TIME_GAP{TicksSeconds(90min)};
 
 const std::string BitcoinGUI::DEFAULT_UIPLATFORM =
 #if defined(Q_OS_MACOS)

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -78,6 +78,7 @@
  * Ref: https://github.com/bitcoin/bitcoin/pull/1026
  */
 static constexpr int64_t MAX_BLOCK_TIME_GAP{TicksSeconds(90min)};
+static_assert(MAX_BLOCK_TIME_GAP == 90 * 60);
 
 const std::string BitcoinGUI::DEFAULT_UIPLATFORM =
 #if defined(Q_OS_MACOS)

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -783,9 +783,13 @@ QString formatNiceTimeOffset(qint64 secs)
     // Represent time from last generated block in human readable text
     QString timeBehindText;
     constexpr int HOUR_IN_SECONDS{TicksSeconds(1h)};
+    static_assert(HOUR_IN_SECONDS == 60*60);
     constexpr int DAY_IN_SECONDS{TicksSeconds(24h)};
+    static_assert(DAY_IN_SECONDS == 24*60*60);
     constexpr int WEEK_IN_SECONDS{TicksSeconds(7 * 24h)};
+    static_assert(WEEK_IN_SECONDS == 7*24*60*60);
     constexpr int YEAR_IN_SECONDS{TicksSeconds(std::chrono::years{1})};
+    static_assert(YEAR_IN_SECONDS == 31556952);
     if(secs < 60)
     {
         timeBehindText = QObject::tr("%n second(s)","",secs);

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -782,10 +782,10 @@ QString formatNiceTimeOffset(qint64 secs)
 {
     // Represent time from last generated block in human readable text
     QString timeBehindText;
-    const int HOUR_IN_SECONDS = 60*60;
-    const int DAY_IN_SECONDS = 24*60*60;
-    const int WEEK_IN_SECONDS = 7*24*60*60;
-    const int YEAR_IN_SECONDS = 31556952; // Average length of year in Gregorian calendar
+    constexpr int HOUR_IN_SECONDS{TicksSeconds(1h)};
+    constexpr int DAY_IN_SECONDS{TicksSeconds(24h)};
+    constexpr int WEEK_IN_SECONDS{TicksSeconds(7 * 24h)};
+    constexpr int YEAR_IN_SECONDS{TicksSeconds(std::chrono::years{1})};
     if(secs < 60)
     {
         timeBehindText = QObject::tr("%n second(s)","",secs);

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -9,6 +9,7 @@
 #include <qt/forms/ui_intro.h>
 #include <util/chaintype.h>
 #include <util/fs.h>
+#include <util/time.h>
 
 #include <qt/freespacechecker.h>
 #include <qt/guiconstants.h>
@@ -304,9 +305,9 @@ void Intro::UpdatePruneLabels(bool prune_checked)
     }
     ui->lblExplanation3->setVisible(prune_checked);
     ui->pruneGB->setEnabled(prune_checked);
-    static constexpr uint64_t nPowTargetSpacing = 10 * 60;  // from chainparams, which we don't have at this stage
+    static constexpr uint64_t nPowTargetSpacing{TicksSeconds(10min)};  // from chainparams, which we don't have at this stage
     static constexpr uint32_t expected_block_data_size = 2250000;  // includes undo data
-    const uint64_t expected_backup_days = m_prune_target_gb * 1e9 / (uint64_t(expected_block_data_size) * 86400 / nPowTargetSpacing);
+    const uint64_t expected_backup_days = m_prune_target_gb * 1e9 / (uint64_t(expected_block_data_size) * TicksSeconds(24h) / nPowTargetSpacing);
     ui->lblPruneSuffix->setText(
         //: Explanatory text on the capability of the current prune target.
         tr("(sufficient to restore backups %n day(s) old)", "", expected_backup_days));

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -306,8 +306,10 @@ void Intro::UpdatePruneLabels(bool prune_checked)
     ui->lblExplanation3->setVisible(prune_checked);
     ui->pruneGB->setEnabled(prune_checked);
     static constexpr uint64_t nPowTargetSpacing{TicksSeconds(10min)};  // from chainparams, which we don't have at this stage
+    static_assert(nPowTargetSpacing == 10 * 60);
     static constexpr uint32_t expected_block_data_size = 2250000;  // includes undo data
     const uint64_t expected_backup_days = m_prune_target_gb * 1e9 / (uint64_t(expected_block_data_size) * TicksSeconds(24h) / nPowTargetSpacing);
+    static_assert(TicksSeconds(24h) == 86400);
     ui->lblPruneSuffix->setText(
         //: Explanatory text on the capability of the current prune target.
         tr("(sufficient to restore backups %n day(s) old)", "", expected_backup_days));

--- a/src/qt/modaloverlay.cpp
+++ b/src/qt/modaloverlay.cpp
@@ -38,6 +38,7 @@ ModalOverlay::ModalOverlay(bool enable_wallet, QWidget* parent)
     m_animation.setTargetObject(this);
     m_animation.setPropertyName("pos");
     m_animation.setDuration(Ticks<std::chrono::milliseconds>(300ms));
+    static_assert(Ticks<std::chrono::milliseconds>(300ms) == 300);
     m_animation.setEasingCurve(QEasingCurve::OutQuad);
 }
 
@@ -115,9 +116,11 @@ void ModalOverlay::tipUpdate(int count, const QDateTime& blockDate, double nVeri
 
             // take first sample after 500 seconds or last available one
             if (sample.first < (currentDate.toMSecsSinceEpoch() - Ticks<std::chrono::milliseconds>(500s)) || i == blockProcessTime.size() - 1) {
+                static_assert(Ticks<std::chrono::milliseconds>(500s) == 500 * 1000);
                 progressDelta = blockProcessTime[0].second - sample.second;
                 timeDelta = blockProcessTime[0].first - sample.first;
                 progressPerHour = (progressDelta > 0) ? progressDelta / (double)timeDelta * Ticks<std::chrono::milliseconds>(1h) : 0;
+                static_assert(Ticks<std::chrono::milliseconds>(1h) == 1000 * 3600);
                 remainingMSecs = (progressDelta > 0) ? remainingProgress / progressDelta * timeDelta : -1;
                 break;
             }

--- a/src/qt/modaloverlay.cpp
+++ b/src/qt/modaloverlay.cpp
@@ -9,6 +9,7 @@
 
 #include <chainparams.h>
 #include <qt/guiutil.h>
+#include <util/time.h>
 
 #include <QEasingCurve>
 #include <QPropertyAnimation>
@@ -36,7 +37,7 @@ ModalOverlay::ModalOverlay(bool enable_wallet, QWidget* parent)
 
     m_animation.setTargetObject(this);
     m_animation.setPropertyName("pos");
-    m_animation.setDuration(300 /* ms */);
+    m_animation.setDuration(Ticks<std::chrono::milliseconds>(300ms));
     m_animation.setEasingCurve(QEasingCurve::OutQuad);
 }
 
@@ -113,10 +114,10 @@ void ModalOverlay::tipUpdate(int count, const QDateTime& blockDate, double nVeri
             QPair<qint64, double> sample = blockProcessTime[i];
 
             // take first sample after 500 seconds or last available one
-            if (sample.first < (currentDate.toMSecsSinceEpoch() - 500 * 1000) || i == blockProcessTime.size() - 1) {
+            if (sample.first < (currentDate.toMSecsSinceEpoch() - Ticks<std::chrono::milliseconds>(500s)) || i == blockProcessTime.size() - 1) {
                 progressDelta = blockProcessTime[0].second - sample.second;
                 timeDelta = blockProcessTime[0].first - sample.first;
-                progressPerHour = (progressDelta > 0) ? progressDelta / (double)timeDelta * 1000 * 3600 : 0;
+                progressPerHour = (progressDelta > 0) ? progressDelta / (double)timeDelta * Ticks<std::chrono::milliseconds>(1h) : 0;
                 remainingMSecs = (progressDelta > 0) ? remainingProgress / progressDelta * timeDelta : -1;
                 break;
             }

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -676,9 +676,13 @@ void RPCConsole::setClientModel(ClientModel *model, int bestblock_height, int64_
         peersTableContextMenu->addSeparator();
         peersTableContextMenu->addAction(tr("&Disconnect"), this, &RPCConsole::disconnectSelectedNode);
         peersTableContextMenu->addAction(ts.ban_for + " " + tr("1 &hour"), [this] { banSelectedNode(TicksSeconds(1h)); });
+        static_assert(TicksSeconds(1h) == 60 * 60);
         peersTableContextMenu->addAction(ts.ban_for + " " + tr("1 d&ay"), [this] { banSelectedNode(TicksSeconds(24h)); });
+        static_assert(TicksSeconds(24h) == 60 * 60 * 24);
         peersTableContextMenu->addAction(ts.ban_for + " " + tr("1 &week"), [this] { banSelectedNode(TicksSeconds(7 * 24h)); });
+        static_assert(TicksSeconds(7 * 24h) == 60 * 60 * 24 * 7);
         peersTableContextMenu->addAction(ts.ban_for + " " + tr("1 &year"), [this] { banSelectedNode(TicksSeconds(365 * 24h)); });
+        static_assert(TicksSeconds(365 * 24h) == 60 * 60 * 24 * 365);
         connect(ui->peerWidget, &QTableView::customContextMenuRequested, this, &RPCConsole::showPeersTableContextMenu);
 
         // peer table signal handling - update peer details when selecting new node

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -675,10 +675,10 @@ void RPCConsole::setClientModel(ClientModel *model, int bestblock_height, int64_
         });
         peersTableContextMenu->addSeparator();
         peersTableContextMenu->addAction(tr("&Disconnect"), this, &RPCConsole::disconnectSelectedNode);
-        peersTableContextMenu->addAction(ts.ban_for + " " + tr("1 &hour"), [this] { banSelectedNode(60 * 60); });
-        peersTableContextMenu->addAction(ts.ban_for + " " + tr("1 d&ay"), [this] { banSelectedNode(60 * 60 * 24); });
-        peersTableContextMenu->addAction(ts.ban_for + " " + tr("1 &week"), [this] { banSelectedNode(60 * 60 * 24 * 7); });
-        peersTableContextMenu->addAction(ts.ban_for + " " + tr("1 &year"), [this] { banSelectedNode(60 * 60 * 24 * 365); });
+        peersTableContextMenu->addAction(ts.ban_for + " " + tr("1 &hour"), [this] { banSelectedNode(TicksSeconds(1h)); });
+        peersTableContextMenu->addAction(ts.ban_for + " " + tr("1 d&ay"), [this] { banSelectedNode(TicksSeconds(24h)); });
+        peersTableContextMenu->addAction(ts.ban_for + " " + tr("1 &week"), [this] { banSelectedNode(TicksSeconds(7 * 24h)); });
+        peersTableContextMenu->addAction(ts.ban_for + " " + tr("1 &year"), [this] { banSelectedNode(TicksSeconds(365 * 24h)); });
         connect(ui->peerWidget, &QTableView::customContextMenuRequested, this, &RPCConsole::showPeersTableContextMenu);
 
         // peer table signal handling - update peer details when selecting new node

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -50,6 +50,7 @@
 #include <util/fs.h>
 #include <util/strencodings.h>
 #include <util/syserror.h>
+#include <util/time.h>
 #include <util/translation.h>
 #include <validation.h>
 #include <validationinterface.h>
@@ -1847,7 +1848,7 @@ static RPCMethod getchaintxstats()
 {
     ChainstateManager& chainman = EnsureAnyChainman(request.context);
     const CBlockIndex* pindex;
-    int blockcount = 30 * 24 * 60 * 60 / chainman.GetParams().GetConsensus().nPowTargetSpacing; // By default: 1 month
+    int blockcount = TicksSeconds(30 * 24h) / chainman.GetParams().GetConsensus().nPowTargetSpacing; // By default: 1 month
 
     if (request.params[1].isNull()) {
         LOCK(cs_main);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1849,6 +1849,7 @@ static RPCMethod getchaintxstats()
     ChainstateManager& chainman = EnsureAnyChainman(request.context);
     const CBlockIndex* pindex;
     int blockcount = TicksSeconds(30 * 24h) / chainman.GetParams().GetConsensus().nPowTargetSpacing; // By default: 1 month
+    static_assert(TicksSeconds(30 * 24h) == 30 * 24 * 60 * 60);
 
     if (request.params[1].isNull()) {
         LOCK(cs_main);

--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -97,7 +97,7 @@ static RPCMethod mockscheduler()
     }
 
     int64_t delta_seconds = request.params[0].getInt<int64_t>();
-    if (delta_seconds <= 0 || delta_seconds > 3600) {
+    if (delta_seconds <= 0 || delta_seconds > TicksSeconds(1h)) {
         throw std::runtime_error("delta_time must be between 1 and 3600 seconds (1 hr)");
     }
 

--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -100,6 +100,7 @@ static RPCMethod mockscheduler()
     if (delta_seconds <= 0 || delta_seconds > TicksSeconds(1h)) {
         throw std::runtime_error("delta_time must be between 1 and 3600 seconds (1 hr)");
     }
+    static_assert(TicksSeconds(1h) == 3600);
 
     const NodeContext& node_context{EnsureAnyNodeContext(request.context)};
     CHECK_NONFATAL(node_context.scheduler)->MockForward(std::chrono::seconds{delta_seconds});

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -612,6 +612,36 @@ BOOST_AUTO_TEST_CASE(util_ticksseconds)
     BOOST_CHECK_EQUAL(TicksSeconds(1500ms), 1);
 }
 
+BOOST_AUTO_TEST_CASE(util_chrono_literal_equivalence)
+{
+    BOOST_REQUIRE_EQUAL(60 * 60 * 24, TicksSeconds(24h));
+    BOOST_REQUIRE_EQUAL(2 * 60 * 60, TicksSeconds(2h));
+    BOOST_REQUIRE_EQUAL(14 * 24 * 60 * 60, TicksSeconds(2 * 7 * 24h));
+    BOOST_REQUIRE_EQUAL(10 * 60, TicksSeconds(10min));
+    BOOST_REQUIRE_EQUAL(24 * 60 * 60, TicksSeconds(24h));
+    BOOST_REQUIRE_EQUAL(std::chrono::seconds{60 * 60 * 24}.count(), std::chrono::seconds{24h}.count());
+    BOOST_REQUIRE_EQUAL(30 * 24 * 60 * 60, TicksSeconds(30 * 24h));
+    BOOST_REQUIRE_EQUAL(7 * 24 * 60 * 60, TicksSeconds(7 * 24h));
+    BOOST_REQUIRE_EQUAL(60 * 60 * 12, TicksSeconds(12h));
+    BOOST_REQUIRE_EQUAL(8 * 60 * 60, TicksSeconds(8h));
+    BOOST_REQUIRE_EQUAL(90 * 60, TicksSeconds(90min));
+    BOOST_REQUIRE_EQUAL(3600 / (10 * 60), TicksSeconds(1h) / TicksSeconds(10min));
+    BOOST_REQUIRE_EQUAL(300, Ticks<std::chrono::milliseconds>(300ms));
+    BOOST_REQUIRE_EQUAL(500 * 1000, Ticks<std::chrono::milliseconds>(500s));
+    BOOST_REQUIRE_EQUAL(1000 * 3600, Ticks<std::chrono::milliseconds>(1h));
+    BOOST_REQUIRE_EQUAL(3600, TicksSeconds(1h));
+    BOOST_REQUIRE_EQUAL(60 * 60, TicksSeconds(1h));
+    BOOST_REQUIRE_EQUAL(24 * 60 * 60, TicksSeconds(24h));
+    BOOST_REQUIRE_EQUAL(7 * 24 * 60 * 60, TicksSeconds(7 * 24h));
+    BOOST_REQUIRE_EQUAL(60 * 60 * 24 * 365, TicksSeconds(365 * 24h));
+    BOOST_REQUIRE_EQUAL(31556952, TicksSeconds(std::chrono::years{1}));
+    BOOST_REQUIRE_EQUAL(10 * 60, TicksSeconds(10min));
+    BOOST_REQUIRE_EQUAL(uint64_t{2250000} * 86400 / uint64_t{600}, uint64_t{2250000} * TicksSeconds(24h) / uint64_t{600});
+    BOOST_REQUIRE_EQUAL(30 * 24 * 60 * 60 / (10 * 60), TicksSeconds(30 * 24h) / TicksSeconds(10min));
+    BOOST_REQUIRE_EQUAL(5 * 60, TicksSeconds(5min));
+    BOOST_REQUIRE_EQUAL(60 * 60 * 24 * 7 * 2, TicksSeconds(2 * 7 * 24h));
+}
+
 BOOST_AUTO_TEST_CASE(test_IsDigit)
 {
     BOOST_CHECK_EQUAL(IsDigit('0'), true);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -211,6 +211,7 @@ protected:
 public:
 
     static constexpr int ROLLING_FEE_HALFLIFE{TicksSeconds(12h)}; // public only for testing
+    static_assert(ROLLING_FEE_HALFLIFE == 60 * 60 * 12);
 
     using indexed_transaction_set = boost::multi_index_container<
         CTxMemPoolEntry,

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -23,6 +23,7 @@
 #include <util/feefrac.h>
 #include <util/hasher.h>
 #include <util/result.h>
+#include <util/time.h>
 
 #include <boost/multi_index/hashed_index.hpp>
 #include <boost/multi_index/identity.hpp>
@@ -209,7 +210,7 @@ protected:
 
 public:
 
-    static constexpr int ROLLING_FEE_HALFLIFE{60 * 60 * 12}; // public only for testing
+    static constexpr int ROLLING_FEE_HALFLIFE{TicksSeconds(12h)}; // public only for testing
 
     using indexed_transaction_set = boost::multi_index_container<
         CTxMemPoolEntry,

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2358,7 +2358,6 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     if (m_chainman.AssumedValidBlock().IsNull()) {
         script_check_reason = "assumevalid=0 (always verify)";
     } else {
-        constexpr int64_t TWO_WEEKS_IN_SECONDS{60 * 60 * 24 * 7 * 2};
         // We've been configured with the hash of a block which has been externally verified to have a valid history.
         // A suitable default value is included with the software and updated from time to time.  Because validity
         //  relative to a piece of software is an objective fact these defaults can be easily reviewed.
@@ -2373,7 +2372,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
             script_check_reason = "block not in best header chain";
         } else if (m_chainman.m_best_header->nChainWork < m_chainman.MinimumChainWork()) {
             script_check_reason = "best header chainwork below minimumchainwork";
-        } else if (GetBlockProofEquivalentTime(*m_chainman.m_best_header, *pindex, *m_chainman.m_best_header, params.GetConsensus()) <= TWO_WEEKS_IN_SECONDS) {
+        } else if (GetBlockProofEquivalentTime(*m_chainman.m_best_header, *pindex, *m_chainman.m_best_header, params.GetConsensus()) <= TicksSeconds(2 * 7 * 24h)) {
             script_check_reason = "block too recent relative to best header";
         } else {
             // This block is a member of the assumed verified chain and an ancestor of the best header.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2392,6 +2392,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
             script_check_reason = nullptr;
         }
     }
+    static_assert(TicksSeconds(2 * 7 * 24h) == 60 * 60 * 24 * 7 * 2);
 
     const auto time_1{SteadyClock::now()};
     m_chainman.time_check += time_1 - time_start;

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -21,6 +21,7 @@
 #include <util/check.h>
 #include <util/moneystr.h>
 #include <util/rbf.h>
+#include <util/time.h>
 #include <util/trace.h>
 #include <util/translation.h>
 #include <wallet/coincontrol.h>
@@ -982,7 +983,7 @@ static bool IsCurrentForAntiFeeSniping(interfaces::Chain& chain, const uint256& 
     if (chain.isInitialBlockDownload()) {
         return false;
     }
-    constexpr int64_t MAX_ANTI_FEE_SNIPING_TIP_AGE = 8 * 60 * 60; // in seconds
+    constexpr int64_t MAX_ANTI_FEE_SNIPING_TIP_AGE{TicksSeconds(8h)};
     int64_t block_time;
     CHECK_NONFATAL(chain.findBlock(block_hash, FoundBlock().time(block_time)));
     if (block_time < (GetTime() - MAX_ANTI_FEE_SNIPING_TIP_AGE)) {

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -984,6 +984,7 @@ static bool IsCurrentForAntiFeeSniping(interfaces::Chain& chain, const uint256& 
         return false;
     }
     constexpr int64_t MAX_ANTI_FEE_SNIPING_TIP_AGE{TicksSeconds(8h)};
+    static_assert(MAX_ANTI_FEE_SNIPING_TIP_AGE == 8 * 60 * 60);
     int64_t block_time;
     CHECK_NONFATAL(chain.findBlock(block_hash, FoundBlock().time(block_time)));
     if (block_time < (GetTime() - MAX_ANTI_FEE_SNIPING_TIP_AGE)) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2147,7 +2147,7 @@ void CWallet::ResubmitWalletTransactions(node::TxBroadcast broadcast_method, boo
 
             // Attempt to rebroadcast all txes more than 5 minutes older than
             // the last block, or all txs if forcing.
-            if (!force && wtx.nTimeReceived > m_best_block_time - 5 * 60) continue;
+            if (!force && wtx.nTimeReceived > m_best_block_time - TicksSeconds(5min)) continue;
             to_submit.insert(&wtx);
         }
         // Now try submitting the transactions to the memory pool and (optionally) relay them.

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2148,6 +2148,7 @@ void CWallet::ResubmitWalletTransactions(node::TxBroadcast broadcast_method, boo
             // Attempt to rebroadcast all txes more than 5 minutes older than
             // the last block, or all txs if forcing.
             if (!force && wtx.nTimeReceived > m_best_block_time - TicksSeconds(5min)) continue;
+            static_assert(TicksSeconds(5min) == 5 * 60);
             to_submit.insert(&wtx);
         }
         // Now try submitting the transactions to the memory pool and (optionally) relay them.


### PR DESCRIPTION
**Problem:** Several fixed durations are written as raw time counts or multiplication chains, obscuring their units and making the declarations easier to miscalculate.

**Fix:** Express these durations with chrono literals and use the `Ticks` helpers where existing interfaces take integer time counts, preserving every destination type and value.

<details>
<summary>Conversion equivalence</summary>

The temporary verification commit directly asserts the 13 named constants, while the remaining runtime assignments and inline expressions are checked as independent old/new formulas because those destinations cannot be referenced by `static_assert`.

```cpp
BOOST_AUTO_TEST_CASE(util_chrono_literal_equivalence)
{
    BOOST_REQUIRE_EQUAL(60 * 60 * 24, TicksSeconds(24h));
    BOOST_REQUIRE_EQUAL(2 * 60 * 60, TicksSeconds(2h));
    BOOST_REQUIRE_EQUAL(14 * 24 * 60 * 60, TicksSeconds(2 * 7 * 24h));
    BOOST_REQUIRE_EQUAL(10 * 60, TicksSeconds(10min));
    BOOST_REQUIRE_EQUAL(24 * 60 * 60, TicksSeconds(24h));
    BOOST_REQUIRE_EQUAL(std::chrono::seconds{60 * 60 * 24}.count(), std::chrono::seconds{24h}.count());
    BOOST_REQUIRE_EQUAL(30 * 24 * 60 * 60, TicksSeconds(30 * 24h));
    BOOST_REQUIRE_EQUAL(7 * 24 * 60 * 60, TicksSeconds(7 * 24h));
    BOOST_REQUIRE_EQUAL(60 * 60 * 12, TicksSeconds(12h));
    BOOST_REQUIRE_EQUAL(8 * 60 * 60, TicksSeconds(8h));
    BOOST_REQUIRE_EQUAL(90 * 60, TicksSeconds(90min));
    BOOST_REQUIRE_EQUAL(3600 / (10 * 60), TicksSeconds(1h) / TicksSeconds(10min));
    BOOST_REQUIRE_EQUAL(300, Ticks<std::chrono::milliseconds>(300ms));
    BOOST_REQUIRE_EQUAL(500 * 1000, Ticks<std::chrono::milliseconds>(500s));
    BOOST_REQUIRE_EQUAL(1000 * 3600, Ticks<std::chrono::milliseconds>(1h));
    BOOST_REQUIRE_EQUAL(3600, TicksSeconds(1h));
    BOOST_REQUIRE_EQUAL(60 * 60, TicksSeconds(1h));
    BOOST_REQUIRE_EQUAL(24 * 60 * 60, TicksSeconds(24h));
    BOOST_REQUIRE_EQUAL(7 * 24 * 60 * 60, TicksSeconds(7 * 24h));
    BOOST_REQUIRE_EQUAL(60 * 60 * 24 * 365, TicksSeconds(365 * 24h));
    BOOST_REQUIRE_EQUAL(31556952, TicksSeconds(std::chrono::years{1}));
    BOOST_REQUIRE_EQUAL(10 * 60, TicksSeconds(10min));
    BOOST_REQUIRE_EQUAL(uint64_t{2250000} * 86400 / uint64_t{600}, uint64_t{2250000} * TicksSeconds(24h) / uint64_t{600});
    BOOST_REQUIRE_EQUAL(30 * 24 * 60 * 60 / (10 * 60), TicksSeconds(30 * 24h) / TicksSeconds(10min));
    BOOST_REQUIRE_EQUAL(5 * 60, TicksSeconds(5min));
    BOOST_REQUIRE_EQUAL(60 * 60 * 24 * 7 * 2, TicksSeconds(2 * 7 * 24h));
}
```
</details>

Follow-up to [#35792](https://github.com/bitcoin/bitcoin/pull/35792).
