### PR TITLE
wallet: preserve source ID during watch-only export

### DIFF
--- a/src/wallet/export.cpp
+++ b/src/wallet/export.cpp
@@ -37,8 +37,8 @@ util::Expected<std::vector<WalletDescInfo>, std::string> ExportDescriptors(const
             wallet.IsActiveScriptPubKeyMan(*desc_spk_man),
             wallet.IsInternalScriptPubKeyMan(desc_spk_man),
             is_range ? std::optional(std::make_pair(wallet_descriptor.range_start, wallet_descriptor.range_end)) : std::nullopt,
-            wallet_descriptor.next_index
-        );
+            wallet_descriptor.next_index,
+            wallet_descriptor.id);
     }
     return wallet_descriptors;
 }
@@ -106,10 +106,12 @@ util::Result<std::string> ExportWatchOnlyWallet(const CWallet& wallet, const fs:
             WalletDescriptor w_desc(std::move(descs.at(0)), desc_info.creation_time, range_start, range_end, desc_info.next_index);
 
             // For descriptors that cannot self expand (i.e. needs private keys or cache), retrieve the cache
-            uint256 desc_id = w_desc.id;
             if (!w_desc.descriptor->CanSelfExpand()) {
-                DescriptorScriptPubKeyMan* desc_spkm = dynamic_cast<DescriptorScriptPubKeyMan*>(wallet.GetScriptPubKeyMan(desc_id));
-                w_desc.cache = WITH_LOCK(desc_spkm->cs_desc_man, return desc_spkm->GetWalletDescriptor().cache);
+                if (auto desc_spkm{dynamic_cast<DescriptorScriptPubKeyMan*>(wallet.GetScriptPubKeyMan(desc_info.source_id))}) {
+                    w_desc.cache = WITH_LOCK(desc_spkm->cs_desc_man, return desc_spkm->GetWalletDescriptor().cache);
+                } else {
+                    return util::Error{strprintf(_("Error: Could not find source descriptor %s"), desc_info.source_id.GetHex())};
+                }
             }
 
             // Add to the watchonly wallet
@@ -125,7 +127,7 @@ util::Result<std::string> ExportWatchOnlyWallet(const CWallet& wallet, const fs:
                 if (desc_info.internal) {
                     internal = *desc_info.internal;
                 }
-                watchonly_wallet->AddActiveScriptPubKeyMan(desc_id, *Assert(w_desc.descriptor->GetOutputType()), internal);
+                watchonly_wallet->AddActiveScriptPubKeyMan(w_desc.id, *Assert(w_desc.descriptor->GetOutputType()), internal);
             }
         }
 

--- a/src/wallet/export.h
+++ b/src/wallet/export.h
@@ -14,8 +14,9 @@
 
 namespace wallet {
 // Struct containing all of the info from WalletDescriptor, except with the descriptor as a string,
-// and without its ID or cache.
-// Used when exporting descriptors from the wallet.
+// and without its cache.
+// Used when exporting descriptors from the wallet. The source ID is preserved because converting a
+// private descriptor to its public form can change its ID while its cache remains under the original ID.
 struct WalletDescInfo {
     std::string descriptor;
     uint64_t creation_time;
@@ -23,6 +24,7 @@ struct WalletDescInfo {
     std::optional<bool> internal;
     std::optional<std::pair<int64_t,int64_t>> range;
     int64_t next_index;
+    uint256 source_id;
 };
 
 //! Export the descriptors from a wallet so that they can be imported elsewhere

--- a/test/functional/wallet_exported_watchonly.py
+++ b/test/functional/wallet_exported_watchonly.py
@@ -12,7 +12,6 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_not_equal,
-    assert_raises,
     assert_raises_rpc_error,
 )
 from test_framework.wallet_util import generate_keypair
@@ -173,9 +172,7 @@ class WalletExportedWatchOnly(BitcoinTestFramework):
             online_wallet = self.export_and_restore(offline_wallet, "normalized_id_watchonly")
             assert_equal(online_wallet.getwalletinfo()["private_keys_enabled"], False)
 
-        assert_raises((ConnectionResetError, ConnectionAbortedError), export_and_check_watchonly)  # TODO: Export should not terminate the node when normalization changes the descriptor ID
-        self.offline.wait_until(lambda: self.offline.process.poll() is not None)
-        self.offline.wait_until_stopped(expected_ret_code=self.offline.process.returncode)
+        export_and_check_watchonly()
 
     def test_export_imported_descriptors(self):
         self.log.info("Test imported descriptors are exported to the watchonly wallet")

--- a/test/functional/wallet_exported_watchonly.py
+++ b/test/functional/wallet_exported_watchonly.py
@@ -6,11 +6,13 @@
 import os
 
 from test_framework.descriptors import descsum_create
+from test_framework.extendedkey import ExtendedPrivateKey
 from test_framework.key import H_POINT
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_not_equal,
+    assert_raises,
     assert_raises_rpc_error,
 )
 from test_framework.wallet_util import generate_keypair
@@ -158,6 +160,23 @@ class WalletExportedWatchOnly(BitcoinTestFramework):
         offline_wallet.unloadwallet()
         online_wallet.unloadwallet()
 
+    def test_export_normalized_descriptor_id(self):
+        self.log.info("Test normalization of a descriptor before watchonly export")
+        self.offline.createwallet("normalized_id")
+        offline_wallet = self.offline.get_wallet_rpc("normalized_id")
+        xprv1 = ExtendedPrivateKey.from_seed(bytes(range(32))).to_string()
+        xprv2 = ExtendedPrivateKey.from_seed(bytes(range(1, 33))).to_string()
+        descriptor = descsum_create(f"tr({H_POINT},sortedmulti_a(1,{xprv1}/0h/*,{xprv2}/*h))")
+        assert_equal(offline_wallet.importdescriptors([{"desc": descriptor, "timestamp": "now"}])[0]["success"], True)
+
+        def export_and_check_watchonly():
+            online_wallet = self.export_and_restore(offline_wallet, "normalized_id_watchonly")
+            assert_equal(online_wallet.getwalletinfo()["private_keys_enabled"], False)
+
+        assert_raises((ConnectionResetError, ConnectionAbortedError), export_and_check_watchonly)  # TODO: Export should not terminate the node when normalization changes the descriptor ID
+        self.offline.wait_until(lambda: self.offline.process.poll() is not None)
+        self.offline.wait_until_stopped(expected_ret_code=self.offline.process.returncode)
+
     def test_export_imported_descriptors(self):
         self.log.info("Test imported descriptors are exported to the watchonly wallet")
         self.offline.createwallet("imports")
@@ -298,6 +317,7 @@ class WalletExportedWatchOnly(BitcoinTestFramework):
         self.test_avoid_reuse()
         self.test_encrypted_wallet()
         self.test_export_blank_wallet()
+        self.test_export_normalized_descriptor_id()
 
 if __name__ == '__main__':
     WalletExportedWatchOnly(__file__).main()


### PR DESCRIPTION
**Problem:** An authenticated `exportwatchonlywallet` call can crash the node when a private descriptor has a different `DescriptorID` after conversion to its public form.
The RPC then looks up cached keys under the normalized ID, although the source wallet stores them under the original ID, and dereferences the missing manager.

**Fix:** Carry the source ID through descriptor export and use it to retrieve cached keys from the source wallet, while retaining the normalized ID for the watch-only manager.
Return an export error if the source manager is unavailable.

<details>
<summary>Detailed explanation</summary>

Descriptors with hardened derivation need cached public keys because the watch-only wallet cannot derive them from private keys.
In the regression descriptor, the `/0h/*` branch can be normalized for public derivation while the `/*h` branch remains cache-dependent, so the cache must be retrieved from the source manager before creating the destination manager.

The new `WalletDescInfo::source_id` field is internal to the export helper, so descriptor-listing RPC output remains unchanged.
The functional regression reaches the descriptor ID mismatch through the authenticated RPC path.

With the old lookup, the functional regression terminates the wallet process while retrieving the missing manager.
With the source-ID lookup, the export completes and the watch-only wallet can be restored.
The reproduced path affects process availability for callers with wallet RPC credentials, with no unauthenticated ingress, key loss, persistent corruption, or consensus impact found.
</details>
