### PR TITLE
test: cover IsFinalTx threshold domain

### DIFF
--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -348,6 +348,25 @@ BOOST_AUTO_TEST_CASE(tx_no_inputs)
     BOOST_CHECK(state.GetRejectReason() == "bad-txns-vin-empty");
 }
 
+BOOST_AUTO_TEST_CASE(is_final_tx_locktime_threshold_boundary)
+{
+    CMutableTransaction mtx;
+    mtx.vin.emplace_back();
+    mtx.vin[0].nSequence = 0; // Make finality depend on nLockTime.
+
+    mtx.nLockTime = LOCKTIME_THRESHOLD;
+    const CTransaction threshold_time_lock{mtx};
+    // LOCKTIME_THRESHOLD is the first timestamp value, so height must not satisfy it.
+    BOOST_CHECK(!IsFinalTx(threshold_time_lock, /*nBlockHeight=*/LOCKTIME_THRESHOLD + 1, /*nBlockTime=*/0));
+    BOOST_CHECK(!IsFinalTx(threshold_time_lock, /*nBlockHeight=*/0, /*nBlockTime=*/LOCKTIME_THRESHOLD));
+    BOOST_CHECK( IsFinalTx(threshold_time_lock, /*nBlockHeight=*/0, /*nBlockTime=*/LOCKTIME_THRESHOLD + 1));
+
+    mtx.nLockTime = LOCKTIME_THRESHOLD - 1;
+    const CTransaction height_lock{mtx};
+    BOOST_CHECK( IsFinalTx(height_lock, /*nBlockHeight=*/LOCKTIME_THRESHOLD, /*nBlockTime=*/0));
+    BOOST_CHECK(!IsFinalTx(height_lock, /*nBlockHeight=*/0, /*nBlockTime=*/LOCKTIME_THRESHOLD + 1));
+}
+
 BOOST_AUTO_TEST_CASE(tx_oversized)
 {
     auto createTransaction =[](size_t payloadSize) {


### PR DESCRIPTION
**Problem:** `LOCKTIME_THRESHOLD` is the first timestamp `nLockTime` value, but `transaction_tests` did not pin the exact domain switch. A one-line mutation changing the `IsFinalTx()` selector from `< LOCKTIME_THRESHOLD` to `<= LOCKTIME_THRESHOLD` survived because no test checked that the threshold itself is treated as time.

**Fix:** Add a focused `IsFinalTx` unit test with a non-final input sequence so `nLockTime` decides finality. It checks that a threshold locktime is satisfied by block time rather than height, that the exact threshold time remains non-final, and that the value just below the threshold still uses height semantics.

**Reproducer:** Applying this one-line mutation makes `transaction_tests/is_final_tx_locktime_threshold_boundary` fail on the threshold locktime assertions:

```patch
diff --git a/src/consensus/tx_verify.cpp b/src/consensus/tx_verify.cpp
@@
-    if ((int64_t)tx.nLockTime < ((int64_t)tx.nLockTime < LOCKTIME_THRESHOLD ? (int64_t)nBlockHeight : nBlockTime))
+    if ((int64_t)tx.nLockTime < ((int64_t)tx.nLockTime <= LOCKTIME_THRESHOLD ? (int64_t)nBlockHeight : nBlockTime))
```

<details>
<summary>Detailed explanation</summary>

`nLockTime` values below `LOCKTIME_THRESHOLD` are interpreted as block heights, while values at or above it are interpreted as timestamps.
`IsFinalTx()` makes that choice before comparing the transaction locktime to the candidate block height or block time.
The missing oracle was the exact threshold value: it should use the timestamp side, so a height greater than `LOCKTIME_THRESHOLD` must not make the transaction final.

The test sets one input sequence to a non-final value because final sequence numbers ignore `nLockTime`.
It then checks the threshold timestamp case and the just-below-threshold height case, which together discriminate the domain-selector mutation.
</details>
