### PR TITLE
net: reject oversized locators before allocating

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1253,13 +1253,15 @@ static void AddKnownTx(Peer& peer, const uint256& hash)
 /** Read a locator and stop hash, disconnecting if the locator is oversized. */
 bool ReadBlockLocator(DataStream& stream, CBlockLocator& locator, uint256& hash_stop, CNode& node, const std::string& msg_type)
 {
-    stream >> locator >> hash_stop;
-    if (locator.vHave.size() > MAX_LOCATOR_SZ) {
-        LogDebug(BCLog::NET, "%s locator size %lld > %d, %s", msg_type, locator.vHave.size(), MAX_LOCATOR_SZ, node.DisconnectMsg());
+    try {
+        locator.LimitedRead<MAX_LOCATOR_SZ>(stream);
+        stream >> hash_stop;
+        return true;
+    } catch (LimitedVectorExceededError& e) {
+        LogDebug(BCLog::NET, "%s locator size %u > %u, %s", msg_type, e.m_size, MAX_LOCATOR_SZ, node.DisconnectMsg());
         node.fDisconnect = true;
         return false;
     }
-    return true;
 }
 
 /** Whether this peer can serve us blocks. */

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1250,6 +1250,18 @@ static void AddKnownTx(Peer& peer, const uint256& hash)
     tx_relay->m_tx_inventory_known_filter.insert(hash);
 }
 
+/** Read a locator and stop hash, disconnecting if the locator is oversized. */
+bool ReadBlockLocator(DataStream& stream, CBlockLocator& locator, uint256& hash_stop, CNode& node, const std::string& msg_type)
+{
+    stream >> locator >> hash_stop;
+    if (locator.vHave.size() > MAX_LOCATOR_SZ) {
+        LogDebug(BCLog::NET, "%s locator size %lld > %d, %s", msg_type, locator.vHave.size(), MAX_LOCATOR_SZ, node.DisconnectMsg());
+        node.fDisconnect = true;
+        return false;
+    }
+    return true;
+}
+
 /** Whether this peer can serve us blocks. */
 static bool CanServeBlocks(const Peer& peer)
 {
@@ -4481,13 +4493,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
     if (msg_type == NetMsgType::GETBLOCKS) {
         CBlockLocator locator;
         uint256 hashStop;
-        vRecv >> locator >> hashStop;
-
-        if (locator.vHave.size() > MAX_LOCATOR_SZ) {
-            LogDebug(BCLog::NET, "getblocks locator size %lld > %d, %s", locator.vHave.size(), MAX_LOCATOR_SZ, pfrom.DisconnectMsg());
-            pfrom.fDisconnect = true;
-            return;
-        }
+        if (!ReadBlockLocator(vRecv, locator, hashStop, pfrom, msg_type)) return;
 
         // We might have announced the currently-being-connected tip using a
         // compact block, which resulted in the peer sending a getblocks
@@ -4616,13 +4622,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
     if (msg_type == NetMsgType::GETHEADERS) {
         CBlockLocator locator;
         uint256 hashStop;
-        vRecv >> locator >> hashStop;
-
-        if (locator.vHave.size() > MAX_LOCATOR_SZ) {
-            LogDebug(BCLog::NET, "getheaders locator size %lld > %d, %s", locator.vHave.size(), MAX_LOCATOR_SZ, pfrom.DisconnectMsg());
-            pfrom.fDisconnect = true;
-            return;
-        }
+        if (!ReadBlockLocator(vRecv, locator, hashStop, pfrom, msg_type)) return;
 
         if (m_chainman.m_blockman.LoadingBlocks()) {
             LogDebug(BCLog::NET, "Ignoring getheaders from peer=%d while importing/reindexing\n", pfrom.GetId());

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -137,6 +137,13 @@ struct CBlockLocator
         READWRITE(obj.vHave);
     }
 
+    template <size_t Limit, typename Stream>
+    void LimitedRead(Stream& s)
+    {
+        s.ignore(sizeof(DUMMY_VERSION));
+        s >> LIMITED_VECTOR(vHave, Limit);
+    }
+
     void SetNull()
     {
         vHave.clear();

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -791,10 +791,16 @@ struct DefaultFormatter
     static void Unser(Stream& s, T& t) { Unserialize(s, t); }
 };
 
-/**
- * Limited vector formatter. Throws an error if a vector is oversized.
- */
+class LimitedVectorExceededError : public std::ios_base::failure
+{
+public:
+    explicit LimitedVectorExceededError(size_t size)
+        : std::ios_base::failure{"Vector length limit exceeded"}, m_size{size} {}
 
+    size_t m_size;
+};
+
+/** Limited vector formatter. Throws an error if a vector is oversized. */
 template<size_t Limit, class Formatter = DefaultFormatter>
 struct LimitedVectorFormatter
 {
@@ -805,7 +811,7 @@ struct LimitedVectorFormatter
         v.clear();
         size_t size = ReadCompactSize(s);
         if (size > Limit) {
-            throw std::ios_base::failure("Vector length limit exceeded");
+            throw LimitedVectorExceededError{size};
         }
         v.reserve(size);
         for (size_t i = 0; i < size; ++i) {

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -1686,7 +1686,7 @@ BOOST_AUTO_TEST_CASE(oversized_locator_handling)
         BOOST_REQUIRE(connman.ReceiveMsgFrom(node, std::move(oversized_locator)));
         node.fPauseSend = false;
         BOOST_CHECK(!connman.ProcessMessagesOnce(node));
-        BOOST_CHECK(!node.fDisconnect); // TODO: reject oversized locators before allocating
+        BOOST_CHECK(node.fDisconnect);
 
         m_node.peerman->FinalizeNode(node);
     }

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -1668,4 +1668,28 @@ BOOST_AUTO_TEST_CASE(addlocal_onlynet_externalip)
     fDiscover = discover_orig;
 }
 
+BOOST_AUTO_TEST_CASE(oversized_locator_handling)
+{
+    LOCK(NetEventsInterface::g_msgproc_mutex);
+    auto& connman{static_cast<ConnmanTestMsg&>(*m_node.connman)};
+    const CAddress addr{Lookup("1.2.3.4", 8333, /*fAllowLookup=*/false).value(), NODE_NETWORK};
+
+    for (auto msg_type : {NetMsgType::GETBLOCKS, NetMsgType::GETHEADERS}) {
+        CNode node{/*id=*/0, /*sock=*/nullptr, addr, /*nKeyedNetGroupIn=*/0, /*nLocalHostNonceIn=*/0, /*addrBindIn=*/CService{}, /*addrNameIn=*/"", ConnectionType::INBOUND, /*inbound_onion=*/false, /*network_key=*/0};
+
+        connman.Handshake(node, /*successfully_connected=*/true, /*remote_services=*/ServiceFlags(NODE_NETWORK | NODE_WITNESS), /*local_services=*/NODE_NETWORK, PROTOCOL_VERSION, /*relay_txs=*/true);
+        connman.FlushSendBuffer(node);
+
+        // Advertise MAX_SIZE bytes of hashes but omit them.
+        auto oversized_locator{NetMsg::Make(msg_type, CBlockLocator::DUMMY_VERSION, COMPACTSIZE(MAX_SIZE / sizeof(uint256)))};
+
+        BOOST_REQUIRE(connman.ReceiveMsgFrom(node, std::move(oversized_locator)));
+        node.fPauseSend = false;
+        BOOST_CHECK(!connman.ProcessMessagesOnce(node));
+        BOOST_CHECK(!node.fDisconnect); // TODO: reject oversized locators before allocating
+
+        m_node.peerman->FinalizeNode(node);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
**Problem:** `getblocks` and `getheaders` deserialize locator hashes before enforcing `MAX_LOCATOR_SZ`.
A truncated oversized locator makes the generic vector reader reserve its first batch and throw before the existing disconnect check, leaving the peer connected.

**Fix:** Read the advertised count before allocating hashes and disconnect when it exceeds the existing limit.
`p2p_invalid_locator.py` preserves the established boundary for complete locators: both messages accept 101 hashes and disconnect at 102.
