### PR TITLE
txgraph: account for retained Entry capacity

### DIFF
--- a/src/test/txgraph_tests.cpp
+++ b/src/test/txgraph_tests.cpp
@@ -431,4 +431,28 @@ BOOST_AUTO_TEST_CASE(txgraph_staging)
     graph->SanityCheck();
 }
 
+BOOST_AUTO_TEST_CASE(txgraph_memory_usage_retained_entries)
+{
+    constexpr size_t CHURN_COUNT{1024};
+
+    auto fresh = MakeTxGraph(10, 1000, HIGH_ACCEPTABLE_COST, PointerComparator);
+    TxGraph::Ref fresh_ref;
+    fresh->AddTransaction(fresh_ref, FeePerWeight{1, 1});
+
+    auto churned = MakeTxGraph(10, 1000, HIGH_ACCEPTABLE_COST, PointerComparator);
+    for (size_t i{0}; i < CHURN_COUNT; ++i) {
+        TxGraph::Ref ref;
+        churned->AddTransaction(ref, FeePerWeight{1, 1});
+        churned->RemoveTransaction(ref);
+    }
+    BOOST_CHECK_EQUAL(churned->GetMainMemoryUsage(), 0);
+
+    TxGraph::Ref churned_ref;
+    churned->AddTransaction(churned_ref, FeePerWeight{1, 1});
+    BOOST_CHECK_EQUAL(churned->GetTransactionCount(TxGraph::Level::MAIN), fresh->GetTransactionCount(TxGraph::Level::MAIN));
+
+    // Compact() pops the churned entries but never shrinks m_entries.
+    BOOST_CHECK_EQUAL(churned->GetMainMemoryUsage(), fresh->GetMainMemoryUsage()); // TODO: Retained allocations bypass -maxmempool accounting
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/txgraph_tests.cpp
+++ b/src/test/txgraph_tests.cpp
@@ -452,7 +452,7 @@ BOOST_AUTO_TEST_CASE(txgraph_memory_usage_retained_entries)
     BOOST_CHECK_EQUAL(churned->GetTransactionCount(TxGraph::Level::MAIN), fresh->GetTransactionCount(TxGraph::Level::MAIN));
 
     // Compact() pops the churned entries but never shrinks m_entries.
-    BOOST_CHECK_EQUAL(churned->GetMainMemoryUsage(), fresh->GetMainMemoryUsage()); // TODO: Retained allocations bypass -maxmempool accounting
+    BOOST_CHECK_GT(churned->GetMainMemoryUsage(), fresh->GetMainMemoryUsage());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/txgraph.cpp
+++ b/src/txgraph.cpp
@@ -3550,11 +3550,12 @@ size_t TxGraphImpl::GetMainMemoryUsage() noexcept
     // Make sure splits/merges are applied, as memory usage may not be representative otherwise.
     SplitAll(/*up_to_level=*/0);
     ApplyDependencies(/*level=*/0);
+    if (m_main_clusterset.m_txcount == 0) return 0;
     // Compute memory usage
     size_t usage = /* From clusters */
                    m_main_clusterset.m_cluster_usage +
-                   /* From Entry objects. */
-                   sizeof(Entry) * m_main_clusterset.m_txcount +
+                   /* From Entry objects, including capacity retained after compaction. */
+                   memusage::DynamicUsage(m_entries) +
                    /* From the chunk index. */
                    memusage::DynamicUsage(m_main_chunkindex);
     return usage;


### PR DESCRIPTION
**Problem:** `GetMainMemoryUsage()` estimates `Entry` storage from the live transaction count, but `Compact()` removes entries without releasing `m_entries` capacity.
Mempool churn can therefore leave allocated memory outside `getmempoolinfo.usage` and the `-maxmempool` limit.

**Fix:** Account for the retained `m_entries` allocation when the main graph is non-empty.
The focused test keeps the empty churned graph at zero usage, then proves the same live transaction count costs more after churn.