### PR TITLE
test: guard security-critical randomness from test state

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -65,6 +65,7 @@ add_executable(test_bitcoin
   miniscript_tests.cpp
   minisketch_tests.cpp
   multisig_tests.cpp
+  musig_tests.cpp
   bip328_tests.cpp
   net_peer_connection_tests.cpp
   net_peer_eviction_tests.cpp

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -38,6 +38,15 @@ static const std::string strAddressBad = "1HV9Lc3sNHZxwj4Zk6fB38tEmBryq2cBiF";
 
 BOOST_FIXTURE_TEST_SUITE(key_tests, BasicTestingSetup)
 
+BOOST_AUTO_TEST_CASE(key_generation_ignores_deterministic_rng)
+{
+    SeedRandomForTest(SeedRand::ZEROS);
+    const CKey first_key{GenerateRandomKey()};
+    SeedRandomForTest(SeedRand::ZEROS);
+    const CKey second_key{GenerateRandomKey()};
+    BOOST_CHECK(first_key != second_key);
+}
+
 BOOST_AUTO_TEST_CASE(key_test1)
 {
     CKey key1  = DecodeSecret(strSecret1);

--- a/src/test/musig_tests.cpp
+++ b/src/test/musig_tests.cpp
@@ -1,0 +1,40 @@
+// Copyright (c) 2026-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <key.h>
+#include <musig.h>
+#include <test/util/random.h>
+#include <test/util/setup_common.h>
+#include <util/check.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <array>
+#include <vector>
+
+BOOST_FIXTURE_TEST_SUITE(musig_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(nonce_generation_ignores_deterministic_rng)
+{
+    std::array<unsigned char, 32> key_bytes{};
+    key_bytes.back() = 1;
+    CKey key;
+    key.Set(key_bytes.begin(), key_bytes.end(), /*fCompressedIn=*/true);
+    const std::vector<CPubKey> pubkeys{key.GetPubKey()};
+    const CPubKey aggregate_pubkey{*Assert(MuSig2AggregatePubkeys(pubkeys))};
+    const uint256 sighash{uint256::ONE};
+
+    const auto generate_nonce{[&] {
+        MuSig2SecNonce secnonce;
+        return CreateMuSig2Nonce(secnonce, sighash, key, aggregate_pubkey, pubkeys);
+    }};
+
+    SeedRandomForTest(SeedRand::ZEROS);
+    const std::vector<uint8_t> first_nonce{generate_nonce()};
+    SeedRandomForTest(SeedRand::ZEROS);
+    const std::vector<uint8_t> second_nonce{generate_nonce()};
+    BOOST_CHECK(first_nonce != second_nonce);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -1376,6 +1376,21 @@ public:
 
 } // namespace
 
+BOOST_AUTO_TEST_CASE(v2transport_session_key_ignores_deterministic_rng)
+{
+    const auto generate_handshake{[] {
+        V2Transport transport{/*nodeid=*/0, /*initiating=*/true};
+        const auto& [bytes, _more, _msg_type]{transport.GetBytesToSend(/*have_next_message=*/false)};
+        return std::vector<uint8_t>{bytes.begin(), bytes.end()};
+    }};
+
+    SeedRandomForTest(SeedRand::ZEROS);
+    const std::vector<uint8_t> first_handshake{generate_handshake()};
+    SeedRandomForTest(SeedRand::ZEROS);
+    const std::vector<uint8_t> second_handshake{generate_handshake()};
+    BOOST_CHECK(first_handshake != second_handshake);
+}
+
 BOOST_AUTO_TEST_CASE(v2transport_test)
 {
     // A mostly normal scenario, testing a transport in initiator mode.

--- a/src/test/random_tests.cpp
+++ b/src/test/random_tests.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <random.h>
-
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <util/time.h>
@@ -11,6 +10,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>
+#include <array>
 #include <random>
 
 BOOST_FIXTURE_TEST_SUITE(random_tests, BasicTestingSetup)
@@ -18,6 +18,17 @@ BOOST_FIXTURE_TEST_SUITE(random_tests, BasicTestingSetup)
 BOOST_AUTO_TEST_CASE(osrandom_tests)
 {
     BOOST_CHECK(Random_SanityCheck());
+}
+
+BOOST_AUTO_TEST_CASE(strongrandom_ignores_deterministic_rng)
+{
+    std::array<unsigned char, 32> first_bytes{};
+    std::array<unsigned char, 32> second_bytes{};
+    SeedRandomForTest(SeedRand::ZEROS);
+    GetStrongRandBytes(first_bytes);
+    SeedRandomForTest(SeedRand::ZEROS);
+    GetStrongRandBytes(second_bytes);
+    BOOST_CHECK(first_bytes != second_bytes);
 }
 
 BOOST_AUTO_TEST_CASE(fastrandom_tests_deterministic)

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -122,6 +122,31 @@ BOOST_FIXTURE_TEST_CASE(wallet_encryption_ignores_deterministic_rng, TestingSetu
     BOOST_CHECK(first.salt != second.salt);
 }
 
+BOOST_FIXTURE_TEST_CASE(addhdkey_ignores_deterministic_rng, WalletTestingSetup)
+{
+    const auto generate_xpub{[&](const std::string& name) {
+        std::vector<bilingual_str> warnings;
+        auto wallet_result{m_wallet_loader->createWallet(name, "", WALLET_FLAG_DESCRIPTORS | WALLET_FLAG_BLANK_WALLET, warnings)};
+        BOOST_REQUIRE(wallet_result);
+        std::unique_ptr<interfaces::Wallet> wallet{std::move(*wallet_result)};
+
+        JSONRPCRequest request;
+        request.context = &m_node;
+        request.URI = "/wallet/" + name;
+        request.strMethod = "addhdkey";
+        request.params = UniValue{UniValue::VARR};
+        request.params.push_back(UniValue{});
+        if (RPCIsInWarmup(nullptr)) SetRPCWarmupFinished();
+
+        SeedRandomForTest(SeedRand::ZEROS);
+        const std::string xpub{tableRPC.execute(request)["xpub"].get_str()};
+        wallet->remove();
+        return xpub;
+    }};
+
+    BOOST_CHECK(generate_xpub("first") != generate_xpub("second"));
+}
+
 BOOST_FIXTURE_TEST_CASE(update_non_range_descriptor, TestingSetup)
 {
     CWallet wallet(m_node.chain.get(), "", CreateMockableWalletDatabase());

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -91,6 +91,37 @@ BOOST_FIXTURE_TEST_CASE(wallet_seed_ignores_deterministic_rng, TestingSetup)
     BOOST_CHECK(first_destination != second_destination);
 }
 
+BOOST_FIXTURE_TEST_CASE(wallet_encryption_ignores_deterministic_rng, TestingSetup)
+{
+    struct EncryptionMaterial {
+        CKeyingMaterial master_key;
+        std::vector<unsigned char> salt;
+    };
+    const SecureString passphrase{"passphrase"};
+    const auto encrypt_wallet{[&] {
+        CWallet wallet{m_node.chain.get(), "", CreateMockableWalletDatabase()};
+        {
+            LOCK(wallet.cs_wallet);
+            wallet.SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
+            wallet.SetupDescriptorScriptPubKeyMans();
+        }
+
+        SeedRandomForTest(SeedRand::ZEROS);
+        BOOST_REQUIRE(wallet.EncryptWallet(passphrase));
+        const CMasterKey& master_key{wallet.mapMasterKeys.at(1)};
+        CCrypter crypter;
+        BOOST_REQUIRE(crypter.SetKeyFromPassphrase(passphrase, master_key.vchSalt, master_key.nDeriveIterations, master_key.nDerivationMethod));
+        CKeyingMaterial plain_master_key;
+        BOOST_REQUIRE(crypter.Decrypt(master_key.vchCryptedKey, plain_master_key));
+        return EncryptionMaterial{plain_master_key, master_key.vchSalt};
+    }};
+
+    const EncryptionMaterial first{encrypt_wallet()};
+    const EncryptionMaterial second{encrypt_wallet()};
+    BOOST_CHECK(first.master_key != second.master_key);
+    BOOST_CHECK(first.salt != second.salt);
+}
+
 BOOST_FIXTURE_TEST_CASE(update_non_range_descriptor, TestingSetup)
 {
     CWallet wallet(m_node.chain.get(), "", CreateMockableWalletDatabase());

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -71,6 +71,26 @@ static void AddKey(CWallet& wallet, const CKey& key)
     Assert(wallet.AddWalletDescriptor(w_desc, provider, "", false));
 }
 
+BOOST_FIXTURE_TEST_CASE(wallet_seed_ignores_deterministic_rng, TestingSetup)
+{
+    const auto generate_destination{[&] {
+        CWallet wallet{m_node.chain.get(), "", CreateMockableWalletDatabase()};
+        wallet.m_keypool_size = 1;
+        {
+            LOCK(wallet.cs_wallet);
+            wallet.SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
+            wallet.SetupDescriptorScriptPubKeyMans();
+        }
+        return getNewDestination(wallet, OutputType::BECH32);
+    }};
+
+    SeedRandomForTest(SeedRand::ZEROS);
+    const CTxDestination first_destination{generate_destination()};
+    SeedRandomForTest(SeedRand::ZEROS);
+    const CTxDestination second_destination{generate_destination()};
+    BOOST_CHECK(first_destination != second_destination);
+}
+
 BOOST_FIXTURE_TEST_CASE(update_non_range_descriptor, TestingSetup)
 {
     CWallet wallet(m_node.chain.get(), "", CreateMockableWalletDatabase());


### PR DESCRIPTION
**Problem:** Security-sensitive keys, nonces, and wallet material must remain independent of deterministic test state. Existing tests continue to pass when strong randomness is replaced with fresh deterministic test RNG output because the generated values remain valid.

**Fix:** Add focused tests that reset deterministic test state and require distinct strong bytes, generated keys, descriptor-wallet destinations, wallet encryption keys and salts, internally generated `addhdkey` xpubs, MuSig2 public nonces, and BIP324 handshake bytes. Production behavior is unchanged.

**Proof:** Before these tests were added, the first six mutations below passed the complete configured CTest and functional suites together. The BIP324 session-key mutation passed both suites separately. Each new test fails against its matching mutation.

<details>
<summary>Mutation proof</summary>

```diff
diff --git a/src/key.cpp b/src/key.cpp
index 000c533b7d..21d6168658 100644
--- a/src/key.cpp
+++ b/src/key.cpp
@@ -161,7 +161,7 @@ bool CKey::Check(const unsigned char *vch) {
 void CKey::MakeNewKey(bool fCompressedIn) {
     MakeKeyData();
     do {
-        GetStrongRandBytes(*keydata);
+        GetRandBytes(*keydata);
     } while (!Check(keydata->data()));
     fCompressed = fCompressedIn;
 }
diff --git a/src/musig.cpp b/src/musig.cpp
index 38a49fa2f3..b54c798c1f 100644
--- a/src/musig.cpp
+++ b/src/musig.cpp
@@ -144,7 +144,7 @@ std::vector<uint8_t> CreateMuSig2Nonce(MuSig2SecNonce& secnonce, const uint256&

     // Generate randomness for nonce
     uint256 rand;
-    GetStrongRandBytes(rand);
+    GetRandBytes(rand);

     // Generate nonce
     secp256k1_musig_pubnonce pubnonce;
diff --git a/src/net.cpp b/src/net.cpp
index e890e291c5..0689c8dd84 100644
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1021,7 +1021,12 @@ V2Transport::V2Transport(NodeId nodeid, bool initiating, const CKey& key, std::s
 }

 V2Transport::V2Transport(NodeId nodeid, bool initiating) noexcept
-    : V2Transport{nodeid, initiating, GenerateRandomKey(),
+    : V2Transport{nodeid, initiating, [] {
+                      CKey key;
+                      const uint256 random_key{GetRandHash()};
+                      key.Set(random_key.begin(), random_key.end(), true);
+                      return key;
+                  }(),
                   MakeByteSpan(GetRandHash()), GenerateRandomGarbage()} {}

 void V2Transport::SetReceiveState(RecvState recv_state) noexcept
diff --git a/src/random.cpp b/src/random.cpp
index f1c4bb86ff..7001af7bbc 100644
--- a/src/random.cpp
+++ b/src/random.cpp
@@ -606,7 +606,7 @@ void GetRandBytes(std::span<unsigned char> bytes) noexcept

 void GetStrongRandBytes(std::span<unsigned char> bytes) noexcept
 {
-    ProcRand(bytes.data(), bytes.size(), RNGLevel::SLOW, /*always_use_real_rng=*/true);
+    ProcRand(bytes.data(), bytes.size(), RNGLevel::SLOW, /*always_use_real_rng=*/false);
 }

 void RandAddPeriodic() noexcept
diff --git a/src/wallet/rpc/wallet.cpp b/src/wallet/rpc/wallet.cpp
index ed3c8bfd8e..79b1469c4a 100644
--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -10,6 +10,7 @@
 #include <coins.h>
 #include <core_io.h>
 #include <key_io.h>
+#include <random.h>
 #include <rpc/server.h>
 #include <rpc/util.h>
 #include <univalue.h>
@@ -876,7 +877,9 @@ RPCMethod addhdkey()

             CExtKey hdkey;
             if (request.params[0].isNull()) {
-                CKey seed_key = GenerateRandomKey();
+                CKey seed_key;
+                const uint256 random_seed{GetRandHash()};
+                seed_key.Set(random_seed.begin(), random_seed.end(), true);
                 hdkey.SetSeed(seed_key);
             } else {
                 hdkey = DecodeExtKey(request.params[0].get_str());
diff --git a/src/wallet/wallet.cpp b/src/wallet/wallet.cpp
index c36472b268..d6d951db8a 100644
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -840,12 +840,12 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
     CKeyingMaterial plain_master_key;

     plain_master_key.resize(WALLET_CRYPTO_KEY_SIZE);
-    GetStrongRandBytes(plain_master_key);
+    GetRandBytes(plain_master_key);

     CMasterKey master_key;

     master_key.vchSalt.resize(WALLET_CRYPTO_SALT_SIZE);
-    GetStrongRandBytes(master_key.vchSalt);
+    GetRandBytes(master_key.vchSalt);

     if (!EncryptMasterKey(strWalletPassphrase, plain_master_key, master_key)) {
         return false;
@@ -3645,7 +3645,9 @@ void CWallet::SetupOwnDescriptorScriptPubKeyMans(WalletBatch& batch)
     AssertLockHeld(cs_wallet);
     assert(!IsWalletFlagSet(WALLET_FLAG_EXTERNAL_SIGNER));
     // Make a seed
-    CKey seed_key = GenerateRandomKey();
+    CKey seed_key;
+    const uint256 random_seed{GetRandHash()};
+    seed_key.Set(random_seed.begin(), random_seed.end(), true);
     CPubKey seed = seed_key.GetPubKey();
     assert(seed_key.VerifyPubKey(seed));
```
</details>
