### PR TITLE
p2p: account BIP35 requests against relay capacity

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -5175,6 +5175,10 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         }
 
         if (auto tx_relay = peer.GetTxRelay(); tx_relay != nullptr) {
+            if (pfrom.IsInboundConn()) {
+                pfrom.m_relays_txs = true;
+                if (MaybeDisconnectForTxRelayCapacity(pfrom, msg_type) || pfrom.fDisconnect) return;
+            }
             LOCK(tx_relay->m_tx_inventory_mutex);
             tx_relay->m_send_mempool = true;
         }

--- a/test/functional/p2p_connection_limits.py
+++ b/test/functional/p2p_connection_limits.py
@@ -6,7 +6,8 @@
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.messages import (
     msg_version,
-    msg_filterload
+    msg_filterload,
+    msg_mempool,
 )
 from test_framework.p2p import (
     P2PInterface,
@@ -79,6 +80,15 @@ class P2PConnectionLimits(BitcoinTestFramework):
         with node.assert_debug_log(['connection dropped after filterload message'], timeout=2):
             peer1.send_without_ping(msg_filterload(data=b'\xbb'*(100)))
         self.wait_until(lambda: len(node.getpeerinfo()) == 1)
+
+        self.log.info('Check BIP35 requests against inbound transaction-relay capacity')
+        self.restart_node(0, ['-maxconnections=13', '-peerbloomfilters', '-inboundrelaypercent=0'])
+        peer1 = self.nodes[0].add_p2p_connection(P2PInterface(), send_version=False, wait_for_verack=False)
+        peer1.send_without_ping(self.create_blocks_only_version())
+        peer1.wait_for_verack()
+        with node.assert_debug_log(['received: mempool'], timeout=2):
+            peer1.send_without_ping(msg_mempool())
+        self.wait_until(lambda: peer1.is_connected is True)  # TODO: A BIP35 request makes this a transaction-relaying peer
 
         self.log.info('Test different values of inboundrelaypercent')
         self.restart_node(0, ['-maxconnections=13', '-inboundrelaypercent=0'])

--- a/test/functional/p2p_connection_limits.py
+++ b/test/functional/p2p_connection_limits.py
@@ -88,7 +88,7 @@ class P2PConnectionLimits(BitcoinTestFramework):
         peer1.wait_for_verack()
         with node.assert_debug_log(['received: mempool'], timeout=2):
             peer1.send_without_ping(msg_mempool())
-        self.wait_until(lambda: peer1.is_connected is True)  # TODO: A BIP35 request makes this a transaction-relaying peer
+        self.wait_until(lambda: peer1.is_connected is False)
 
         self.log.info('Test different values of inboundrelaypercent')
         self.restart_node(0, ['-maxconnections=13', '-inboundrelaypercent=0'])


### PR DESCRIPTION
**Problem:** With non-default `-peerbloomfilters`, an inbound peer can advertise `fRelay=false`, then request a BIP35 mempool snapshot while remaining outside the transaction-relay capacity introduced in [#28463](https://github.com/bitcoin/bitcoin/pull/28463).

**Fix:** Classify the peer as transaction-relaying before queuing the response and apply the existing inbound-capacity eviction.
