### PR TITLE
rpc: bound `gettxoutproof` UTXO lookups

### DIFF
--- a/doc/release-notes-00000.md
+++ b/doc/release-notes-00000.md
@@ -1,0 +1,7 @@
+# RPC
+
+* The `gettxoutproof` RPC now bounds UTXO lookup work across all requested
+  txids when no block hash or synced transaction index is available. For
+  requests with multiple txids, this fallback may fail to locate the block even
+  when one tx has an unspent output. Specify the block hash or enable `-txindex`
+  when reliable lookup is required.

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -4,7 +4,6 @@
 
 #include <coins.h>
 
-#include <consensus/consensus.h>
 #include <primitives/block.h>
 #include <random.h>
 #include <uint256.h>
@@ -410,9 +409,6 @@ CCoinsViewCache::ResetGuard CoinsViewOverlay::StartFetching(const CBlock& block 
     }
     return CreateResetGuard();
 }
-
-static const uint64_t MIN_TRANSACTION_OUTPUT_WEIGHT{WITNESS_SCALE_FACTOR * ::GetSerializeSize(CTxOut())};
-static const uint64_t MAX_OUTPUTS_PER_BLOCK{MAX_BLOCK_WEIGHT / MIN_TRANSACTION_OUTPUT_WEIGHT};
 
 const Coin& AccessByTxid(const CCoinsViewCache& view, const Txid& txid)
 {

--- a/src/coins.h
+++ b/src/coins.h
@@ -8,6 +8,7 @@
 
 #include <attributes.h>
 #include <compressor.h>
+#include <consensus/consensus.h>
 #include <core_memusage.h>
 #include <crypto/siphash.h>
 #include <memusage.h>
@@ -780,6 +781,9 @@ public:
 // TODO: pass in a boolean to limit these possible overwrites to known
 // (pre-BIP34) cases.
 void AddCoins(CCoinsViewCache& cache, const CTransaction& tx, int nHeight, bool check = false);
+
+//! `AccessByTxid` lookup limit derived from the maximum block and minimum output weights
+inline const uint64_t MAX_OUTPUTS_PER_BLOCK{MAX_BLOCK_WEIGHT / (WITNESS_SCALE_FACTOR * ::GetSerializeSize(CTxOut()))};
 
 //! Utility function to find any unspent output with a given txid.
 //! This function can be quite expensive because in the event of a transaction

--- a/src/rpc/txoutproof.cpp
+++ b/src/rpc/txoutproof.cpp
@@ -18,16 +18,30 @@
 #include <util/strencodings.h>
 #include <validation.h>
 
+#include <algorithm>
+#include <cstdint>
 #include <set>
 
 using node::GetTransaction;
 
-static const CBlockIndex* FindBlockByUTXO(Chainstate& active_chainstate, const std::set<Txid>& txids) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+//! Find the block creating the first unspent output of any of `txids`. `cs_main` is released
+//! between batches, so the scan does not observe a single chainstate snapshot.
+static const CBlockIndex* FindBlockByUTXO(ChainstateManager& chainman, const std::set<Txid>& txids)
 {
-    // Loop through txids and try to find which block they're in. Exit loop once a block is found.
-    for (const auto& tx : txids) {
-        const Coin& coin{AccessByTxid(active_chainstate.CoinsTip(), tx)};
-        if (!coin.IsSpent()) return active_chainstate.m_chain[coin.nHeight];
+    static constexpr uint64_t UTXO_LOOKUP_BATCH_SIZE{1'000};
+    for (const Txid& txid : txids) {
+        uint32_t output_index{0};
+        for (uint64_t lookups{0}; lookups < MAX_OUTPUTS_PER_BLOCK;) {
+            {
+                LOCK(cs_main);
+                Chainstate& active_chainstate{chainman.ActiveChainstate()};
+                const CCoinsViewCache& coins{active_chainstate.CoinsTip()};
+                for (const uint64_t batch_end{std::min(lookups + UTXO_LOOKUP_BATCH_SIZE, MAX_OUTPUTS_PER_BLOCK)}; lookups < batch_end; ++lookups, ++output_index) {
+                    const Coin& coin{coins.AccessCoin(COutPoint{txid, output_index})};
+                    if (!coin.IsSpent()) return active_chainstate.m_chain[coin.nHeight];
+                }
+            }
+        }
     }
     return nullptr;
 }
@@ -79,8 +93,7 @@ static RPCMethod gettxoutproof()
                 }
             // Allow txindex to catch up before we acquire cs_main, and only scan the UTXO set if it cannot answer.
             } else if (!g_txindex || !g_txindex->BlockUntilSyncedToCurrentChain()) {
-                LOCK(cs_main);
-                pblockindex = FindBlockByUTXO(chainman.ActiveChainstate(), setTxids);
+                pblockindex = FindBlockByUTXO(chainman, setTxids);
             }
 
             if (pblockindex == nullptr) {

--- a/src/rpc/txoutproof.cpp
+++ b/src/rpc/txoutproof.cpp
@@ -18,7 +18,19 @@
 #include <util/strencodings.h>
 #include <validation.h>
 
+#include <set>
+
 using node::GetTransaction;
+
+static const CBlockIndex* FindBlockByUTXO(Chainstate& active_chainstate, const std::set<Txid>& txids) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+{
+    // Loop through txids and try to find which block they're in. Exit loop once a block is found.
+    for (const auto& tx : txids) {
+        const Coin& coin{AccessByTxid(active_chainstate.CoinsTip(), tx)};
+        if (!coin.IsSpent()) return active_chainstate.m_chain[coin.nHeight];
+    }
+    return nullptr;
+}
 
 static RPCMethod gettxoutproof()
 {
@@ -67,16 +79,7 @@ static RPCMethod gettxoutproof()
                 }
             } else {
                 LOCK(cs_main);
-                Chainstate& active_chainstate = chainman.ActiveChainstate();
-
-                // Loop through txids and try to find which block they're in. Exit loop once a block is found.
-                for (const auto& tx : setTxids) {
-                    const Coin& coin{AccessByTxid(active_chainstate.CoinsTip(), tx)};
-                    if (!coin.IsSpent()) {
-                        pblockindex = active_chainstate.m_chain[coin.nHeight];
-                        break;
-                    }
-                }
+                pblockindex = FindBlockByUTXO(chainman.ActiveChainstate(), setTxids);
             }
 
 

--- a/src/rpc/txoutproof.cpp
+++ b/src/rpc/txoutproof.cpp
@@ -9,6 +9,7 @@
 #include <index/txindex.h>
 #include <merkleblock.h>
 #include <node/blockstorage.h>
+#include <node/context.h>
 #include <primitives/transaction.h>
 #include <rpc/blockchain.h>
 #include <rpc/server.h>
@@ -20,13 +21,14 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <functional>
 #include <set>
 
 using node::GetTransaction;
 
 //! Find the block creating the first unspent output of any of `txids`. `cs_main` is released
 //! between batches, so the scan does not observe a single chainstate snapshot.
-static const CBlockIndex* FindBlockByUTXO(ChainstateManager& chainman, const std::set<Txid>& txids)
+static const CBlockIndex* FindBlockByUTXO(ChainstateManager& chainman, const std::set<Txid>& txids, const std::function<void()>& interruption_point)
 {
     static constexpr uint64_t UTXO_LOOKUP_BATCH_SIZE{1'000};
     for (const Txid& txid : txids) {
@@ -41,6 +43,7 @@ static const CBlockIndex* FindBlockByUTXO(ChainstateManager& chainman, const std
                     if (!coin.IsSpent()) return active_chainstate.m_chain[coin.nHeight];
                 }
             }
+            interruption_point();
         }
     }
     return nullptr;
@@ -83,7 +86,8 @@ static RPCMethod gettxoutproof()
 
             const CBlockIndex* pblockindex = nullptr;
             uint256 hashBlock;
-            ChainstateManager& chainman = EnsureAnyChainman(request.context);
+            const node::NodeContext& node{EnsureAnyNodeContext(request.context)};
+            ChainstateManager& chainman{EnsureChainman(node)};
             if (!request.params[1].isNull()) {
                 LOCK(cs_main);
                 hashBlock = ParseHashV(request.params[1], "blockhash");
@@ -93,7 +97,7 @@ static RPCMethod gettxoutproof()
                 }
             // Allow txindex to catch up before we acquire cs_main, and only scan the UTXO set if it cannot answer.
             } else if (!g_txindex || !g_txindex->BlockUntilSyncedToCurrentChain()) {
-                pblockindex = FindBlockByUTXO(chainman, setTxids);
+                pblockindex = FindBlockByUTXO(chainman, setTxids, node.rpc_interruption_point);
             }
 
             if (pblockindex == nullptr) {

--- a/src/rpc/txoutproof.cpp
+++ b/src/rpc/txoutproof.cpp
@@ -26,25 +26,30 @@
 
 using node::GetTransaction;
 
-//! Find the block creating the first unspent output of any of `txids`. `cs_main` is released
-//! between batches, so the scan does not observe a single chainstate snapshot.
+//! Find the block creating the first unspent output of any of `txids`, scanning the UTXO set
+//! round-robin (every txid at output 0, then every txid at output 1, ...) so that one shared
+//! MAX_OUTPUTS_PER_BLOCK budget cannot be exhausted by the first txid alone. `cs_main` is
+//! released between batches, so the scan does not observe a single chainstate snapshot.
 static const CBlockIndex* FindBlockByUTXO(ChainstateManager& chainman, const std::set<Txid>& txids, const std::function<void()>& interruption_point)
 {
     static constexpr uint64_t UTXO_LOOKUP_BATCH_SIZE{1'000};
-    for (const Txid& txid : txids) {
-        uint32_t output_index{0};
-        for (uint64_t lookups{0}; lookups < MAX_OUTPUTS_PER_BLOCK;) {
-            {
-                LOCK(cs_main);
-                Chainstate& active_chainstate{chainman.ActiveChainstate()};
-                const CCoinsViewCache& coins{active_chainstate.CoinsTip()};
-                for (const uint64_t batch_end{std::min(lookups + UTXO_LOOKUP_BATCH_SIZE, MAX_OUTPUTS_PER_BLOCK)}; lookups < batch_end; ++lookups, ++output_index) {
-                    const Coin& coin{coins.AccessCoin(COutPoint{txid, output_index})};
-                    if (!coin.IsSpent()) return active_chainstate.m_chain[coin.nHeight];
+    auto txid{txids.begin()};
+    uint32_t output_index{0};
+    for (uint64_t lookups{0}; lookups < MAX_OUTPUTS_PER_BLOCK;) {
+        {
+            LOCK(cs_main);
+            Chainstate& active_chainstate{chainman.ActiveChainstate()};
+            const CCoinsViewCache& coins{active_chainstate.CoinsTip()};
+            for (const uint64_t batch_end{std::min(lookups + UTXO_LOOKUP_BATCH_SIZE, MAX_OUTPUTS_PER_BLOCK)}; lookups < batch_end; ++lookups) {
+                const Coin& coin{coins.AccessCoin(COutPoint{*txid, output_index})};
+                if (!coin.IsSpent()) return active_chainstate.m_chain[coin.nHeight];
+                if (++txid == txids.end()) {
+                    txid = txids.begin();
+                    ++output_index;
                 }
             }
-            interruption_point();
         }
+        interruption_point();
     }
     return nullptr;
 }
@@ -55,7 +60,9 @@ static RPCMethod gettxoutproof()
         "gettxoutproof",
         "Returns a hex-encoded proof that \"txid\" was included in a block.\n"
         "\nNOTE: By default this function only works sometimes. This is when there is an\n"
-        "unspent output in the utxo for this transaction. To make it always work,\n"
+        "unspent output in the utxo for this transaction. A request for multiple\n"
+        "transactions may fail even when one has an unspent output because all txids\n"
+        "share one UTXO lookup budget. To make it always work,\n"
         "you need to maintain a transaction index, using the -txindex command line option or\n"
         "specify the block in which the transaction is included manually (by blockhash).\n",
         {

--- a/src/rpc/txoutproof.cpp
+++ b/src/rpc/txoutproof.cpp
@@ -77,15 +77,10 @@ static RPCMethod gettxoutproof()
                 if (!pblockindex) {
                     throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
                 }
-            } else {
+            // Allow txindex to catch up before we acquire cs_main, and only scan the UTXO set if it cannot answer.
+            } else if (!g_txindex || !g_txindex->BlockUntilSyncedToCurrentChain()) {
                 LOCK(cs_main);
                 pblockindex = FindBlockByUTXO(chainman.ActiveChainstate(), setTxids);
-            }
-
-
-            // Allow txindex to catch up if we need to query it and before we acquire cs_main.
-            if (g_txindex && !pblockindex) {
-                g_txindex->BlockUntilSyncedToCurrentChain();
             }
 
             if (pblockindex == nullptr) {

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -18,6 +18,7 @@
 #include <util/strencodings.h>
 
 #include <map>
+#include <optional>
 #include <string>
 #include <variant>
 #include <vector>
@@ -99,6 +100,20 @@ public:
     CoinsCachePair& sentinel() const { return m_sentinel; }
     size_t& usage() const { return cachedCoinsUsage; }
     size_t& dirty() const { return m_dirty_count; }
+};
+
+struct CountingCoinsView : CoinsViewEmpty
+{
+    mutable uint64_t m_lookups{0};
+    COutPoint m_outpoint;
+    std::optional<Coin> m_coin;
+
+    std::optional<Coin> GetCoin(const COutPoint& outpoint) const override
+    {
+        ++m_lookups;
+        if (m_coin && outpoint == m_outpoint) return m_coin;
+        return std::nullopt;
+    }
 };
 
 } // namespace
@@ -305,6 +320,22 @@ BOOST_FIXTURE_TEST_CASE(coins_cache_dbbase_simulation_test, CacheTest)
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_FIXTURE_TEST_SUITE(coins_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(access_by_txid_lookup_bound)
+{
+    auto txid{Txid::FromUint256(m_rng.rand256())};
+    CountingCoinsView found_view;
+    found_view.m_outpoint = {txid, 2};
+    found_view.m_coin = {CTxOut{1, CScript{}}, 1, false};
+    CCoinsViewCache found_cache{&found_view};
+    BOOST_CHECK(AccessByTxid(found_cache, txid) == *found_view.m_coin);
+    BOOST_CHECK_EQUAL(found_view.m_lookups, found_view.m_outpoint.n + 1);
+
+    CountingCoinsView missing_view;
+    CCoinsViewCache missing_cache{&missing_view};
+    BOOST_CHECK(AccessByTxid(missing_cache, txid).IsSpent());
+    BOOST_CHECK_EQUAL(missing_view.m_lookups, MAX_OUTPUTS_PER_BLOCK);
+}
 
 struct UpdateTest : BasicTestingSetup {
 // Store of all necessary tx and undo data for next test


### PR DESCRIPTION
**Problem:** An authenticated RPC caller can make `gettxoutproof` run `AccessByTxid` for every supplied txid before consulting an enabled txindex.
Requests with many unknown or fully spent txids repeat a full UTXO fallback scan under `cs_main`, blocking validation and unrelated RPCs.

**Fix:** Consult a synced txindex before using the UTXO fallback.
When the index is unavailable, share one fallback scan budget across the request, release `cs_main` after every 1,000 lookups, and check for RPC interruption.
For multi-txid requests, the best-effort UTXO fallback may stop before checking every possible output. Callers can provide a block hash or enable txindex when reliable lookup is required, as documented by the RPC.

**Tests:** A focused unit test verifies the probe count through output 2 and that a miss stops at the configured lookup limit.
`rpc_txoutproof.py` passes at every RPC commit and checks unspent txs, fully spent txs with txindex, multiple txs, and explicit block hashes.

**Benchmark:** On an Apple M4 Max using fresh Debug regtest datadirs, 20 unknown txids make the old code perform 20 full fallback scans. This PR performs one shared scan budget.

```text
no txindex, 20-txid request
master  ██████████████████████████████  6.76 s
branch  █████░░░░░░░░░░░░░░░░░░░░░░░░░  1.13 s  (-5.63 s, 6.0x faster)

concurrent getblockcount, started after 0.2 s
master  ██████████████████████████████  5.57 s
branch  ▓░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  0.14 s  (-5.43 s, 39.8x faster)

synced txindex, 20-txid request
master  ██████████████████████████████  5.70 s
branch  ▒░░░░░░░░░░░░░░░░░░░░░░░░░░░░  0.05 s  (-5.65 s, 114x faster)
```

<details><summary>Benchmark command</summary>

```bash
rpc_port=24000
for commit in 1be0b46297c6b61fefb870db6b3b18c273bcaf97 c7073a40020066568860402f113b593bf2bbbb98; do
  git checkout --detach "$commit" >/dev/null 2>&1 &&
  rm -rfd build &&
  cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=OFF -DBUILD_GUI=OFF -DENABLE_WALLET=OFF >/dev/null 2>&1 &&
  cmake --build build -j --target bitcoind bitcoin-cli >/dev/null 2>&1 || break
  datadir=$(mktemp -d); rpc_port=$((rpc_port + 1)); txids='['
  build/bin/bitcoind -regtest -listen=0 -datadir="$datadir" -rpcport="$rpc_port" -daemonwait -server -rpcuser=bench -rpcpassword=bench
  for i in {1..20}; do txid=$(printf '%064x' "$i"); if [ "$i" -gt 1 ]; then txids+=','; fi; txids+='"'$txid'"'; done; txids+=']'
  echo "$commit: 20-txid gettxoutproof"
  { /usr/bin/time -p build/bin/bitcoin-cli -regtest -datadir="$datadir" -rpcport="$rpc_port" -rpcuser=bench -rpcpassword=bench gettxoutproof "$txids" >/dev/null; } 2>&1 | tail -3
  build/bin/bitcoin-cli -regtest -datadir="$datadir" -rpcport="$rpc_port" -rpcuser=bench -rpcpassword=bench gettxoutproof "$txids" >/dev/null 2>&1 & proof_pid=$!
  sleep 0.2; echo "$commit: concurrent getblockcount"
  { /usr/bin/time -p build/bin/bitcoin-cli -regtest -datadir="$datadir" -rpcport="$rpc_port" -rpcuser=bench -rpcpassword=bench getblockcount >/dev/null; } 2>&1
  wait "$proof_pid" || true
  build/bin/bitcoin-cli -regtest -datadir="$datadir" -rpcport="$rpc_port" -rpcuser=bench -rpcpassword=bench stop >/dev/null
done
```

Repeating the request with `-txindex=1` produced the synced-txindex row above.

</details>

**Related work:** #35531 reduces txindex storage and lookup costs. This PR makes synced txindex nodes use that path before scanning chainstate, and the changes can merge independently.