### PR TITLE
p2p: reject oversized BIP37 vectors before allocation

### DIFF
--- a/src/common/bloom.h
+++ b/src/common/bloom.h
@@ -65,7 +65,10 @@ public:
     CBloomFilter(unsigned int nElements, double nFPRate, unsigned int nTweak, unsigned char nFlagsIn);
     CBloomFilter() : nHashFuncs(0), nTweak(0), nFlags(0) {}
 
-    SERIALIZE_METHODS(CBloomFilter, obj) { READWRITE(obj.vData, obj.nHashFuncs, obj.nTweak, obj.nFlags); }
+    SERIALIZE_METHODS(CBloomFilter, obj)
+    {
+        READWRITE(LIMITED_VECTOR(obj.vData, MAX_BLOOM_FILTER_SIZE), obj.nHashFuncs, obj.nTweak, obj.nFlags);
+    }
 
     void insert(std::span<const unsigned char> vKey);
     void insert(const COutPoint& outpoint);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -5240,7 +5240,12 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
             return;
         }
         CBloomFilter filter;
-        vRecv >> filter;
+        try {
+            vRecv >> filter;
+        } catch (const LimitedVectorExceededError&) {
+            Misbehaving(peer, "too-large bloom filter");
+            return;
+        }
 
         if (!filter.IsWithinSizeConstraints())
         {
@@ -5266,7 +5271,12 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
             return;
         }
         std::vector<unsigned char> vData;
-        vRecv >> vData;
+        try {
+            vRecv >> LIMITED_VECTOR(vData, MAX_SCRIPT_ELEMENT_SIZE);
+        } catch (const LimitedVectorExceededError&) {
+            Misbehaving(peer, "bad filteradd message");
+            return;
+        }
 
         // Nodes must NEVER send a data item > MAX_SCRIPT_ELEMENT_SIZE bytes (the max size for a script data object,
         // and thus, the maximum size any matched object can have) in a filteradd message

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1253,13 +1253,15 @@ static void AddKnownTx(Peer& peer, const uint256& hash)
 /** Read a locator and stop hash, disconnecting if the locator is oversized. */
 bool ReadBlockLocator(DataStream& stream, CBlockLocator& locator, uint256& hash_stop, CNode& node, const std::string& msg_type)
 {
-    stream >> locator >> hash_stop;
-    if (locator.vHave.size() > MAX_LOCATOR_SZ) {
-        LogDebug(BCLog::NET, "%s locator size %lld > %d, %s", msg_type, locator.vHave.size(), MAX_LOCATOR_SZ, node.DisconnectMsg());
+    try {
+        locator.LimitedRead<MAX_LOCATOR_SZ>(stream);
+        stream >> hash_stop;
+        return true;
+    } catch (LimitedVectorExceededError& e) {
+        LogDebug(BCLog::NET, "%s locator size %u > %u, %s", msg_type, e.m_size, MAX_LOCATOR_SZ, node.DisconnectMsg());
         node.fDisconnect = true;
         return false;
     }
-    return true;
 }
 
 /** Whether this peer can serve us blocks. */

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1250,6 +1250,18 @@ static void AddKnownTx(Peer& peer, const uint256& hash)
     tx_relay->m_tx_inventory_known_filter.insert(hash);
 }
 
+/** Read a locator and stop hash, disconnecting if the locator is oversized. */
+bool ReadBlockLocator(DataStream& stream, CBlockLocator& locator, uint256& hash_stop, CNode& node, const std::string& msg_type)
+{
+    stream >> locator >> hash_stop;
+    if (locator.vHave.size() > MAX_LOCATOR_SZ) {
+        LogDebug(BCLog::NET, "%s locator size %lld > %d, %s", msg_type, locator.vHave.size(), MAX_LOCATOR_SZ, node.DisconnectMsg());
+        node.fDisconnect = true;
+        return false;
+    }
+    return true;
+}
+
 /** Whether this peer can serve us blocks. */
 static bool CanServeBlocks(const Peer& peer)
 {
@@ -4481,13 +4493,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
     if (msg_type == NetMsgType::GETBLOCKS) {
         CBlockLocator locator;
         uint256 hashStop;
-        vRecv >> locator >> hashStop;
-
-        if (locator.vHave.size() > MAX_LOCATOR_SZ) {
-            LogDebug(BCLog::NET, "getblocks locator size %lld > %d, %s", locator.vHave.size(), MAX_LOCATOR_SZ, pfrom.DisconnectMsg());
-            pfrom.fDisconnect = true;
-            return;
-        }
+        if (!ReadBlockLocator(vRecv, locator, hashStop, pfrom, msg_type)) return;
 
         // We might have announced the currently-being-connected tip using a
         // compact block, which resulted in the peer sending a getblocks
@@ -4616,13 +4622,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
     if (msg_type == NetMsgType::GETHEADERS) {
         CBlockLocator locator;
         uint256 hashStop;
-        vRecv >> locator >> hashStop;
-
-        if (locator.vHave.size() > MAX_LOCATOR_SZ) {
-            LogDebug(BCLog::NET, "getheaders locator size %lld > %d, %s", locator.vHave.size(), MAX_LOCATOR_SZ, pfrom.DisconnectMsg());
-            pfrom.fDisconnect = true;
-            return;
-        }
+        if (!ReadBlockLocator(vRecv, locator, hashStop, pfrom, msg_type)) return;
 
         if (m_chainman.m_blockman.LoadingBlocks()) {
             LogDebug(BCLog::NET, "Ignoring getheaders from peer=%d while importing/reindexing\n", pfrom.GetId());

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -11,6 +11,7 @@
 #include <uint256.h>
 #include <util/time.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <utility>
@@ -135,6 +136,13 @@ struct CBlockLocator
         int nVersion = DUMMY_VERSION;
         READWRITE(nVersion);
         READWRITE(obj.vHave);
+    }
+
+    template <size_t Limit, typename Stream>
+    void LimitedRead(Stream& s)
+    {
+        s.ignore(sizeof(DUMMY_VERSION));
+        s >> LIMITED_VECTOR(vHave, Limit);
     }
 
     void SetNull()

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -791,10 +791,16 @@ struct DefaultFormatter
     static void Unser(Stream& s, T& t) { Unserialize(s, t); }
 };
 
-/**
- * Limited vector formatter. Throws an error if a vector is oversized.
- */
+class LimitedVectorExceededError : public std::ios_base::failure
+{
+public:
+    explicit LimitedVectorExceededError(size_t size)
+        : std::ios_base::failure{"Vector length limit exceeded"}, m_size{size} {}
 
+    size_t m_size;
+};
+
+/** Limited vector formatter. Throws an error if a vector is oversized. */
 template<size_t Limit, class Formatter = DefaultFormatter>
 struct LimitedVectorFormatter
 {
@@ -805,7 +811,7 @@ struct LimitedVectorFormatter
         v.clear();
         size_t size = ReadCompactSize(s);
         if (size > Limit) {
-            throw std::ios_base::failure("Vector length limit exceeded");
+            throw LimitedVectorExceededError{size};
         }
         v.reserve(size);
         for (size_t i = 0; i < size; ++i) {

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -1686,7 +1686,7 @@ BOOST_AUTO_TEST_CASE(oversized_locator_handling)
         BOOST_REQUIRE(connman.ReceiveMsgFrom(node, std::move(oversized_locator)));
         node.fPauseSend = false;
         BOOST_CHECK(!connman.ProcessMessagesOnce(node));
-        BOOST_CHECK(!node.fDisconnect); // TODO: reject oversized locators before allocating
+        BOOST_CHECK(node.fDisconnect);
 
         m_node.peerman->FinalizeNode(node);
     }

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -1668,4 +1668,28 @@ BOOST_AUTO_TEST_CASE(addlocal_onlynet_externalip)
     fDiscover = discover_orig;
 }
 
+BOOST_AUTO_TEST_CASE(oversized_locator_handling)
+{
+    LOCK(NetEventsInterface::g_msgproc_mutex);
+    auto& connman{static_cast<ConnmanTestMsg&>(*m_node.connman)};
+    const CAddress addr{Lookup("1.2.3.4", 8333, /*fAllowLookup=*/false).value(), NODE_NETWORK};
+
+    for (auto msg_type : {NetMsgType::GETBLOCKS, NetMsgType::GETHEADERS}) {
+        CNode node{/*id=*/0, /*sock=*/nullptr, addr, /*nKeyedNetGroupIn=*/0, /*nLocalHostNonceIn=*/0, /*addrBindIn=*/CService{}, /*addrNameIn=*/"", ConnectionType::INBOUND, /*inbound_onion=*/false, /*network_key=*/0};
+
+        connman.Handshake(node, /*successfully_connected=*/true, /*remote_services=*/ServiceFlags(NODE_NETWORK | NODE_WITNESS), /*local_services=*/NODE_NETWORK, PROTOCOL_VERSION, /*relay_txs=*/true);
+        connman.FlushSendBuffer(node);
+
+        // Advertise MAX_SIZE bytes of hashes but omit them.
+        auto oversized_locator{NetMsg::Make(msg_type, CBlockLocator::DUMMY_VERSION, COMPACTSIZE(MAX_SIZE / sizeof(uint256)))};
+
+        BOOST_REQUIRE(connman.ReceiveMsgFrom(node, std::move(oversized_locator)));
+        node.fPauseSend = false;
+        BOOST_CHECK(!connman.ProcessMessagesOnce(node));
+        BOOST_CHECK(!node.fDisconnect); // TODO: reject oversized locators before allocating
+
+        m_node.peerman->FinalizeNode(node);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/p2p_filter.py
+++ b/test/functional/p2p_filter.py
@@ -20,6 +20,7 @@ from test_framework.messages import (
     msg_getdata,
     msg_mempool,
     msg_version,
+    ser_compact_size,
 )
 from test_framework.p2p import (
     P2PInterface,
@@ -34,6 +35,16 @@ from test_framework.wallet import (
     MiniWallet,
     getnewdestination,
 )
+
+
+class msg_oversized_vector:
+    """Declare a large vector without sending its elements."""
+
+    def __init__(self, msgtype):
+        self.msgtype = msgtype
+
+    def serialize(self):
+        return ser_compact_size(4_000_000)
 
 
 class P2PBloomFilter(P2PInterface):
@@ -105,6 +116,12 @@ class FilterTest(BitcoinTestFramework):
         return self.generatetodescriptor(self.nodes[0], 1, f'raw({scriptpubkey.hex()})')[0]
 
     def test_size_limits(self, filter_peer):
+        self.log.info('Check that oversized filter vectors are rejected before element parsing')
+        with self.nodes[0].assert_debug_log(['Misbehaving']):
+            filter_peer.send_and_ping(msg_oversized_vector(b'filterload'))
+        with self.nodes[0].assert_debug_log(['Misbehaving']):
+            filter_peer.send_and_ping(msg_oversized_vector(b'filteradd'))
+
         self.log.info('Check that too large filter is rejected')
         with self.nodes[0].assert_debug_log(['Misbehaving']):
             filter_peer.send_and_ping(msg_filterload(data=b'\xbb'*(MAX_BLOOM_FILTER_SIZE+1)))


### PR DESCRIPTION
**Problem:** When a node offers `NODE_BLOOM`, a peer can send a five-byte `filterload` or `filteradd` payload declaring a 4,000,000-byte vector. Generic vector deserialization allocates the declared size before the existing 36,000-byte and 520-byte checks. The truncated read then fails while leaving the connection usable, allowing the peer to repeat the allocation work. Bloom filtering is disabled by default.

**Fix:** Apply the BIP37 size limits during vector deserialization and route oversized declarations through the existing misbehavior paths. The functional test covers count-only oversized declarations for both message types.

**Dependency:** This is stacked on #35936, which introduces `LimitedVectorExceededError` so the handlers can distinguish oversized declarations from other deserialization failures. It can be rebased onto master after #35936 is merged.
