### PR TITLE
p2p: enforce inventory limits before allocation

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -206,6 +206,21 @@ static constexpr auto PRIVATE_BROADCAST_MAX_CONNECTION_LIFETIME{3min};
 
 // Internal stuff
 namespace {
+/** Deserialize an inventory vector after bounding its count. */
+bool ReadInvVector(DataStream& stream, std::vector<CInv>& invs, uint64_t& inv_size)
+{
+    invs.clear();
+    inv_size = ReadCompactSize(stream);
+    if (inv_size > MAX_INV_SZ) return false;
+
+    invs.reserve(inv_size);
+    for (uint64_t i{0}; i < inv_size; ++i) {
+        invs.emplace_back();
+        stream >> invs.back();
+    }
+    return true;
+}
+
 /** Blocks that are in flight, and that are in the queue to be downloaded. */
 struct QueuedBlock {
     /** BlockIndex. We must have this since we only request blocks when we've already validated the header. */
@@ -4333,10 +4348,9 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
 
     if (msg_type == NetMsgType::INV) {
         std::vector<CInv> vInv;
-        vRecv >> vInv;
-        if (vInv.size() > MAX_INV_SZ)
-        {
-            Misbehaving(peer, strprintf("inv message size = %u", vInv.size()));
+        uint64_t inv_size;
+        if (!ReadInvVector(vRecv, vInv, inv_size)) {
+            Misbehaving(peer, strprintf("inv message size = %u", inv_size));
             return;
         }
 
@@ -4429,10 +4443,9 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
 
     if (msg_type == NetMsgType::GETDATA) {
         std::vector<CInv> vInv;
-        vRecv >> vInv;
-        if (vInv.size() > MAX_INV_SZ)
-        {
-            Misbehaving(peer, strprintf("getdata message size = %u", vInv.size()));
+        uint64_t inv_size;
+        if (!ReadInvVector(vRecv, vInv, inv_size)) {
+            Misbehaving(peer, strprintf("getdata message size = %u", inv_size));
             return;
         }
 
@@ -5334,7 +5347,8 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
 
     if (msg_type == NetMsgType::NOTFOUND) {
         std::vector<CInv> vInv;
-        vRecv >> vInv;
+        uint64_t inv_size;
+        if (!ReadInvVector(vRecv, vInv, inv_size)) return;
         std::vector<GenTxid> tx_invs;
         if (vInv.size() <= node::MAX_PEER_TX_ANNOUNCEMENTS + MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
             for (CInv &inv : vInv) {

--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -273,9 +273,9 @@ class InvalidMessagesTest(BitcoinTestFramework):
         self.nodes[0].disconnect_p2ps()
 
     def test_count_only_oversized_inv_messages(self):
-        self.check_count_only_oversized_inv_message(b'inv', ['ProcessMessages(inv, 5 bytes): Exception'], [], False)  # TODO: The oversized count reaches entry parsing before rejection.
-        self.check_count_only_oversized_inv_message(b'getdata', ['ProcessMessages(getdata, 5 bytes): Exception'], [], False)  # TODO: The oversized count reaches entry parsing before rejection.
-        self.check_count_only_oversized_inv_message(b'notfound', ['ProcessMessages(notfound, 5 bytes): Exception'], [], False)  # TODO: The oversized count reaches entry parsing before being ignored.
+        self.check_count_only_oversized_inv_message(b'inv', ['inv message size = 1000000'], [], True)
+        self.check_count_only_oversized_inv_message(b'getdata', ['getdata message size = 1000000'], [], True)
+        self.check_count_only_oversized_inv_message(b'notfound', [], ['ProcessMessages(notfound'], False)
 
     def test_oversized_msg(self, msg, size):
         msg_type = msg.msgtype.decode('ascii')

--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -15,11 +15,13 @@ from test_framework.messages import (
     MAX_PROTOCOL_MESSAGE_LENGTH,
     MSG_TX,
     from_hex,
+    msg_generic,
     msg_getdata,
     msg_headers,
     msg_inv,
     msg_ping,
     msg_version,
+    ser_compact_size,
     ser_string,
 )
 from test_framework.p2p import (
@@ -71,6 +73,7 @@ class InvalidMessagesTest(BitcoinTestFramework):
         self.test_addrv2_no_addresses()
         self.test_addrv2_too_long_address()
         self.test_addrv2_unrecognized_network()
+        self.test_count_only_oversized_inv_messages()
         self.test_oversized_inv_msg()
         self.test_oversized_getdata_msg()
         self.test_oversized_headers_msg()
@@ -255,6 +258,24 @@ class InvalidMessagesTest(BitcoinTestFramework):
                 '04' +     # address length (COMPACTSIZE(4))
                 '09' * 4 + # address
                 '208d'))   # port
+
+    def check_count_only_oversized_inv_message(self, msg_type, expected_msgs, unexpected_msgs, disconnect):
+        size = 1_000_000
+        msg_name = msg_type.decode()
+        self.log.info(f"Test count-only oversized {msg_name} message")
+        conn = self.nodes[0].add_p2p_connection(P2PInterface())
+        with self.nodes[0].assert_debug_log(expected_msgs, unexpected_msgs=unexpected_msgs):
+            conn.send_without_ping(msg_generic(msg_type, ser_compact_size(size)))
+            if disconnect:
+                conn.wait_for_disconnect(timeout=1)
+            else:
+                conn.sync_with_ping(timeout=1)
+        self.nodes[0].disconnect_p2ps()
+
+    def test_count_only_oversized_inv_messages(self):
+        self.check_count_only_oversized_inv_message(b'inv', ['ProcessMessages(inv, 5 bytes): Exception'], [], False)  # TODO: The oversized count reaches entry parsing before rejection.
+        self.check_count_only_oversized_inv_message(b'getdata', ['ProcessMessages(getdata, 5 bytes): Exception'], [], False)  # TODO: The oversized count reaches entry parsing before rejection.
+        self.check_count_only_oversized_inv_message(b'notfound', ['ProcessMessages(notfound, 5 bytes): Exception'], [], False)  # TODO: The oversized count reaches entry parsing before being ignored.
 
     def test_oversized_msg(self, msg, size):
         msg_type = msg.msgtype.decode('ascii')


### PR DESCRIPTION
**Problem:** A peer can send a five-byte `INV`, `GETDATA`, or `NOTFOUND` payload declaring one million entries.
Generic vector deserialization reserves about 5 MB before the first missing entry reaches EOF, and the caught exception leaves the connection usable, making the bounded allocation repeatable.

**Fix:** Read and enforce the inventory limit before reserving or parsing entries.
Oversized `INV` and `GETDATA` messages keep their existing misbehavior handling, while oversized `NOTFOUND` messages remain silently ignored.
