### PR TITLE
tx: reject oversized scripts and witness elements

### DIFF
--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -8,6 +8,7 @@
 
 #include <attributes.h>
 #include <consensus/amount.h>
+#include <consensus/consensus.h>
 #include <primitives/transaction_identifier.h> // IWYU pragma: export
 #include <script/script.h>
 #include <serialize.h>
@@ -121,7 +122,7 @@ public:
     explicit CTxIn(COutPoint prevoutIn, CScript scriptSigIn=CScript(), uint32_t nSequenceIn=SEQUENCE_FINAL);
     CTxIn(Txid hashPrevTx, uint32_t nOut, CScript scriptSigIn=CScript(), uint32_t nSequenceIn=SEQUENCE_FINAL);
 
-    SERIALIZE_METHODS(CTxIn, obj) { READWRITE(obj.prevout, obj.scriptSig, obj.nSequence); }
+    SERIALIZE_METHODS(CTxIn, obj) { READWRITE(obj.prevout, LIMITED_BYTE_VECTOR(obj.scriptSig, MAX_BLOCK_WEIGHT / WITNESS_SCALE_FACTOR), obj.nSequence); }
 
     friend bool operator==(const CTxIn& a, const CTxIn& b)
     {
@@ -149,7 +150,7 @@ public:
 
     CTxOut(const CAmount& nValueIn, CScript scriptPubKeyIn);
 
-    SERIALIZE_METHODS(CTxOut, obj) { READWRITE(obj.nValue, obj.scriptPubKey); }
+    SERIALIZE_METHODS(CTxOut, obj) { READWRITE(obj.nValue, LIMITED_BYTE_VECTOR(obj.scriptPubKey, MAX_BLOCK_WEIGHT / WITNESS_SCALE_FACTOR)); }
 
     void SetNull()
     {
@@ -179,6 +180,7 @@ struct TransactionSerParams {
 };
 static constexpr TransactionSerParams TX_WITH_WITNESS{.allow_witness = true};
 static constexpr TransactionSerParams TX_NO_WITNESS{.allow_witness = false};
+using WitnessStackFormatter = VectorFormatter<LimitedByteVectorFormatter<MAX_BLOCK_WEIGHT>>;
 
 /**
  * Basic transaction serialization format:
@@ -223,7 +225,7 @@ void UnserializeTransaction(TxType& tx, Stream& s, const TransactionSerParams& p
         /* The witness flag is present, and we support witnesses. */
         flags ^= 1;
         for (size_t i = 0; i < tx.vin.size(); i++) {
-            s >> tx.vin[i].scriptWitness.stack;
+            s >> Using<WitnessStackFormatter>(tx.vin[i].scriptWitness.stack);
         }
         if (!tx.HasWitness()) {
             /* It's illegal to encode witnesses when all witness stacks are empty. */
@@ -261,7 +263,7 @@ void SerializeTransaction(const TxType& tx, Stream& s, const TransactionSerParam
     s << tx.vout;
     if (flags & 1) {
         for (size_t i = 0; i < tx.vin.size(); i++) {
-            s << tx.vin[i].scriptWitness.stack;
+            s << Using<WitnessStackFormatter>(tx.vin[i].scriptWitness.stack);
         }
     }
     s << tx.nLockTime;

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -649,6 +649,30 @@ struct LimitedStringFormatter
     }
 };
 
+template<typename Stream, unsigned int N, typename T>
+void UnserializeByteVectorElements(Stream& is, prevector<N, T>& v, unsigned int nSize)
+{
+    unsigned int i = 0;
+    while (i < nSize) {
+        unsigned int blk = std::min(nSize - i, (unsigned int)(1 + 4999999 / sizeof(T)));
+        v.resize_uninitialized(i + blk);
+        is.read(std::as_writable_bytes(std::span{&v[i], blk}));
+        i += blk;
+    }
+}
+
+template<typename Stream, typename T, typename A>
+void UnserializeByteVectorElements(Stream& is, std::vector<T, A>& v, unsigned int nSize)
+{
+    unsigned int i = 0;
+    while (i < nSize) {
+        unsigned int blk = std::min(nSize - i, (unsigned int)(1 + 4999999 / sizeof(T)));
+        v.resize(i + blk);
+        is.read(std::as_writable_bytes(std::span{&v[i], blk}));
+        i += blk;
+    }
+}
+
 /** Formatter to serialize/deserialize vector elements using another formatter
  *
  * Example:
@@ -877,14 +901,7 @@ void Unserialize(Stream& is, prevector<N, T>& v)
     if constexpr (BasicByte<T>) { // Use optimized version for unformatted basic bytes
         // Limit size per read so bogus size value won't cause out of memory
         v.clear();
-        unsigned int nSize = ReadCompactSize(is);
-        unsigned int i = 0;
-        while (i < nSize) {
-            unsigned int blk = std::min(nSize - i, (unsigned int)(1 + 4999999 / sizeof(T)));
-            v.resize_uninitialized(i + blk);
-            is.read(std::as_writable_bytes(std::span{&v[i], blk}));
-            i += blk;
-        }
+        UnserializeByteVectorElements(is, v, ReadCompactSize(is));
     } else {
         Unserialize(is, Using<VectorFormatter<DefaultFormatter>>(v));
     }
@@ -920,14 +937,7 @@ void Unserialize(Stream& is, std::vector<T, A>& v)
     if constexpr (BasicByte<T>) { // Use optimized version for unformatted basic bytes
         // Limit size per read so bogus size value won't cause out of memory
         v.clear();
-        unsigned int nSize = ReadCompactSize(is);
-        unsigned int i = 0;
-        while (i < nSize) {
-            unsigned int blk = std::min(nSize - i, (unsigned int)(1 + 4999999 / sizeof(T)));
-            v.resize(i + blk);
-            is.read(std::as_writable_bytes(std::span{&v[i], blk}));
-            i += blk;
-        }
+        UnserializeByteVectorElements(is, v, ReadCompactSize(is));
     } else {
         Unserialize(is, Using<VectorFormatter<DefaultFormatter>>(v));
     }

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -495,6 +495,7 @@ static inline Wrapper<Formatter, T&> Using(T&& t) { return Wrapper<Formatter, T&
 #define COMPACTSIZE(obj) Using<CompactSizeFormatter<true>>(obj)
 #define LIMITED_STRING(obj,n) Using<LimitedStringFormatter<n>>(obj)
 #define LIMITED_VECTOR(obj,n) Using<LimitedVectorFormatter<n>>(obj)
+#define LIMITED_BYTE_VECTOR(obj,n) Using<LimitedByteVectorFormatter<n>>(obj)
 
 /** Serialization wrapper class for integers in VarInt format. */
 template<VarIntMode Mode>
@@ -666,6 +667,24 @@ void UnserializeByteVectorElements(Stream& s, V& v, size_t size)
         allocated = next;
     }
 }
+
+template<size_t Limit>
+struct LimitedByteVectorFormatter
+{
+    template<typename Stream, typename V>
+    void Unser(Stream& s, V& v)
+    {
+        v.clear();
+        if (uint64_t size{ReadCompactSize(s)}; size <= Limit) {
+            UnserializeByteVectorElements(s, v, size);
+        } else {
+            throw std::ios_base::failure("Vector length limit exceeded");
+        }
+    }
+
+    template<typename Stream, typename V>
+    void Ser(Stream& s, const V& v) { s << v; }
+};
 
 /** Formatter to serialize/deserialize vector elements using another formatter
  *

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -649,27 +649,21 @@ struct LimitedStringFormatter
     }
 };
 
-template<typename Stream, unsigned int N, typename T>
-void UnserializeByteVectorElements(Stream& is, prevector<N, T>& v, unsigned int nSize)
+// Limit size per read so bogus size value won't cause out of memory
+template<typename Stream, typename V>
+void UnserializeByteVectorElements(Stream& s, V& v, size_t size)
 {
-    unsigned int i = 0;
-    while (i < nSize) {
-        unsigned int blk = std::min(nSize - i, (unsigned int)(1 + 4999999 / sizeof(T)));
-        v.resize_uninitialized(i + blk);
-        is.read(std::as_writable_bytes(std::span{&v[i], blk}));
-        i += blk;
-    }
-}
-
-template<typename Stream, typename T, typename A>
-void UnserializeByteVectorElements(Stream& is, std::vector<T, A>& v, unsigned int nSize)
-{
-    unsigned int i = 0;
-    while (i < nSize) {
-        unsigned int blk = std::min(nSize - i, (unsigned int)(1 + 4999999 / sizeof(T)));
-        v.resize(i + blk);
-        is.read(std::as_writable_bytes(std::span{&v[i], blk}));
-        i += blk;
+    static_assert(BasicByte<typename V::value_type>);
+    for (size_t allocated{0}; allocated < size;) {
+        const size_t block{std::min(size - allocated, size_t{MAX_VECTOR_ALLOCATE})};
+        const size_t next{allocated + block};
+        if constexpr (requires { v.resize_uninitialized(next); }) {
+            v.resize_uninitialized(next);
+        } else {
+            v.resize(next);
+        }
+        s.read(MakeWritableByteSpan(v).subspan(allocated, block));
+        allocated = next;
     }
 }
 
@@ -899,7 +893,6 @@ template <typename Stream, unsigned int N, typename T>
 void Unserialize(Stream& is, prevector<N, T>& v)
 {
     if constexpr (BasicByte<T>) { // Use optimized version for unformatted basic bytes
-        // Limit size per read so bogus size value won't cause out of memory
         v.clear();
         UnserializeByteVectorElements(is, v, ReadCompactSize(is));
     } else {
@@ -935,7 +928,6 @@ template <typename Stream, typename T, typename A>
 void Unserialize(Stream& is, std::vector<T, A>& v)
 {
     if constexpr (BasicByte<T>) { // Use optimized version for unformatted basic bytes
-        // Limit size per read so bogus size value won't cause out of memory
         v.clear();
         UnserializeByteVectorElements(is, v, ReadCompactSize(is));
     } else {

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -2,10 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <test/data/tx_invalid.json.h>
-#include <test/data/tx_valid.json.h>
-#include <test/util/setup_common.h>
-
 #include <checkqueue.h>
 #include <clientversion.h>
 #include <consensus/amount.h>
@@ -26,22 +22,25 @@
 #include <script/signingprovider.h>
 #include <script/solver.h>
 #include <streams.h>
+#include <test/data/tx_invalid.json.h>
+#include <test/data/tx_valid.json.h>
 #include <test/util/common.h>
 #include <test/util/json.h>
 #include <test/util/random.h>
 #include <test/util/script.h>
+#include <test/util/setup_common.h>
 #include <test/util/transaction_utils.h>
+#include <univalue.h>
 #include <util/strencodings.h>
 #include <util/string.h>
+#include <util/vector.h>
 #include <validation.h>
+
+#include <boost/test/unit_test.hpp>
 
 #include <functional>
 #include <map>
 #include <string>
-
-#include <boost/test/unit_test.hpp>
-
-#include <univalue.h>
 
 using namespace util::hex_literals;
 using util::SplitString;
@@ -371,6 +370,56 @@ BOOST_AUTO_TEST_CASE(tx_oversized)
         TxValidationState state;
         BOOST_CHECK_MESSAGE(!CheckTransaction(createTransaction(maxPayloadSize), state), "Oversized transaction should be invalid");
         BOOST_CHECK(state.GetRejectReason() == "bad-txns-oversize");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(transaction_byte_vector_limits)
+{
+    constexpr size_t MAX_BASE_SIZE{MAX_BLOCK_WEIGHT / WITNESS_SCALE_FACTOR};
+    constexpr std::string_view EXPECTED_ERROR{"end of data"};
+    auto make_stream{[](const auto&... args) {
+        DataStream stream;
+        SerializeMany(stream, args...);
+        return stream;
+    }};
+    auto make_witness_stream{[&](const auto&... args) {
+        return make_stream(CTransaction::CURRENT_VERSION, uint8_t{0}, uint8_t{1}, Vector(CTxIn{}), Vector(CTxOut{}), args...);
+    }};
+
+    // Input script
+    {
+        CTxIn txin;
+        make_stream(COutPoint{}, std::vector<uint8_t>(MAX_BASE_SIZE), CTxIn::SEQUENCE_FINAL) >> txin;
+        BOOST_CHECK_EQUAL(txin.scriptSig.size(), MAX_BASE_SIZE);
+    }
+    {
+        CTxIn txin;
+        BOOST_CHECK_EXCEPTION(make_stream(COutPoint{}, CompactSizeWriter{MAX_BASE_SIZE + 1}) >> txin, std::ios_base::failure, HasReason(EXPECTED_ERROR));
+        BOOST_CHECK_EQUAL(txin.scriptSig.size(), MAX_BASE_SIZE + 1); // TODO: Reject before allocating.
+    }
+
+    // Output script
+    {
+        CTxOut txout;
+        make_stream(CAmount{0}, std::vector<uint8_t>(MAX_BASE_SIZE)) >> txout;
+        BOOST_CHECK_EQUAL(txout.scriptPubKey.size(), MAX_BASE_SIZE);
+    }
+    {
+        CTxOut txout;
+        BOOST_CHECK_EXCEPTION(make_stream(CAmount{0}, CompactSizeWriter{MAX_BASE_SIZE + 1}) >> txout, std::ios_base::failure, HasReason(EXPECTED_ERROR));
+        BOOST_CHECK_EQUAL(txout.scriptPubKey.size(), MAX_BASE_SIZE + 1); // TODO: Reject before allocating.
+    }
+
+    // Witness stack element
+    {
+        CMutableTransaction tx;
+        make_witness_stream(Vector(std::vector<uint8_t>(MAX_BLOCK_WEIGHT)), uint32_t{0}) >> TX_WITH_WITNESS(tx);
+        BOOST_CHECK_EQUAL(tx.vin.at(0).scriptWitness.stack.at(0).size(), MAX_BLOCK_WEIGHT);
+    }
+    {
+        CMutableTransaction tx;
+        BOOST_CHECK_EXCEPTION(make_witness_stream(CompactSizeWriter{1}, CompactSizeWriter{MAX_BLOCK_WEIGHT + 1}) >> TX_WITH_WITNESS(tx), std::ios_base::failure, HasReason(EXPECTED_ERROR));
+        BOOST_CHECK_EQUAL(tx.vin.at(0).scriptWitness.stack.at(0).size(), MAX_BLOCK_WEIGHT + 1); // TODO: Reject before allocating.
     }
 }
 

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -376,7 +376,7 @@ BOOST_AUTO_TEST_CASE(tx_oversized)
 BOOST_AUTO_TEST_CASE(transaction_byte_vector_limits)
 {
     constexpr size_t MAX_BASE_SIZE{MAX_BLOCK_WEIGHT / WITNESS_SCALE_FACTOR};
-    constexpr std::string_view EXPECTED_ERROR{"end of data"};
+    constexpr std::string_view EXPECTED_ERROR{"Vector length limit exceeded"};
     auto make_stream{[](const auto&... args) {
         DataStream stream;
         SerializeMany(stream, args...);
@@ -395,7 +395,7 @@ BOOST_AUTO_TEST_CASE(transaction_byte_vector_limits)
     {
         CTxIn txin;
         BOOST_CHECK_EXCEPTION(make_stream(COutPoint{}, CompactSizeWriter{MAX_BASE_SIZE + 1}) >> txin, std::ios_base::failure, HasReason(EXPECTED_ERROR));
-        BOOST_CHECK_EQUAL(txin.scriptSig.size(), MAX_BASE_SIZE + 1); // TODO: Reject before allocating.
+        BOOST_CHECK_EQUAL(txin.scriptSig.size(), 0);
     }
 
     // Output script
@@ -407,7 +407,7 @@ BOOST_AUTO_TEST_CASE(transaction_byte_vector_limits)
     {
         CTxOut txout;
         BOOST_CHECK_EXCEPTION(make_stream(CAmount{0}, CompactSizeWriter{MAX_BASE_SIZE + 1}) >> txout, std::ios_base::failure, HasReason(EXPECTED_ERROR));
-        BOOST_CHECK_EQUAL(txout.scriptPubKey.size(), MAX_BASE_SIZE + 1); // TODO: Reject before allocating.
+        BOOST_CHECK_EQUAL(txout.scriptPubKey.size(), 0);
     }
 
     // Witness stack element
@@ -419,7 +419,7 @@ BOOST_AUTO_TEST_CASE(transaction_byte_vector_limits)
     {
         CMutableTransaction tx;
         BOOST_CHECK_EXCEPTION(make_witness_stream(CompactSizeWriter{1}, CompactSizeWriter{MAX_BLOCK_WEIGHT + 1}) >> TX_WITH_WITNESS(tx), std::ios_base::failure, HasReason(EXPECTED_ERROR));
-        BOOST_CHECK_EQUAL(tx.vin.at(0).scriptWitness.stack.at(0).size(), MAX_BLOCK_WEIGHT + 1); // TODO: Reject before allocating.
+        BOOST_CHECK_EQUAL(tx.vin.at(0).scriptWitness.stack.at(0).size(), 0);
     }
 }
 


### PR DESCRIPTION
**Problem:** Transaction deserialization uses the generic `MAX_SIZE` byte-vector limit for input scripts, output scripts, and individual witness stack elements.
It can allocate buffers larger than any consensus-valid block could contain before later validation rejects the transaction.

**Fix:** Add a limited byte-vector formatter that rejects input and output scripts above the maximum possible base transaction size and witness stack elements above the block weight limit before growing their buffers.
Serialization bytes remain unchanged, and boundary tests cover the largest accepted and first rejected length in each case.
